### PR TITLE
added toLowerCase() call so we can use "LIKE".

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -124,7 +124,7 @@ define(function(require, exports) {
         }
         return this;
       }
-      if (!_.contains(operators, operator)) {
+      if (!_.contains(operators, operator.toLowerCase())) {
         value = operator;
         operator = '=';
       }


### PR DESCRIPTION
Tried using Knex today with my operator as "LIKE", which promptly failed because it's uppercase. 
