### PR TITLE
Drain connection pool on SIGINT as well as exit

### DIFF
--- a/clients/server/base.js
+++ b/clients/server/base.js
@@ -49,11 +49,13 @@ exports.setup = function(Client, name, options) {
 
   // Default to draining on exit.
   if (poolInstance.drainOnExit !== false && typeof process === 'object') {
-    process.on('exit', function() {
+    function drainPool() {
       poolInstance.drain(function() {
-          poolInstance.destroyAllNow();
+        poolInstance.destroyAllNow();
       });
-    });
+    }
+    process.on('exit', drainPool);
+    process.on('SIGINT', drainPool);
   }
 };
 


### PR DESCRIPTION
Noticed that I'm getting a connection leak when I restart node a few times... seems to be because the connection pool is only drained on exit, and not on SIGINT. Made a change to base.js to listen for SIGINT as well as exit.
