### PR TITLE
Remove sqlite3 specific modifyNullable

### DIFF
--- a/clients/base/sqlite3.js
+++ b/clients/base/sqlite3.js
@@ -236,13 +236,6 @@ define(function(require, exports) {
       return 'datetime';
     },
 
-    // Get the SQL for a nullable column modifier.
-    modifyNullable: function(column) {
-      if (column.isNullable === false) {
-        return ' not null';
-      }
-    },
-
     // Get the SQL for an auto-increment column modifier.
     modifyIncrement: function(blueprint, column) {
       if ((column.type == 'integer' || column.type == 'bigInteger') && column.autoIncrement) {


### PR DESCRIPTION
A quick PR which resolves my latest issue. Have not run the tests or added any to detect this issue as yet as I'm still getting setup with mysql and postgres. Hopefully will update PR with tests later

closes #67

sqlite3 can use the base modifyNullable, the specific one was missing
blueprint and therefore meant nothing was ever set to not null
