### PR TITLE
properly destroy() connections in pool

### DIFF
--- a/clients/pool.js
+++ b/clients/pool.js
@@ -50,10 +50,10 @@ define(function(require, exports) {
         destroy: function(connection) {
           if (poolInstance.config.beforeDestroy) {
             return poolInstance.config.beforeDestroy(connection, function() {
-              poolInstance.client.getRawConnection(connection);
+              connection.end();
             });
           }
-          poolInstance.client.getRawConnection(connection);
+          connection.end();
         }
       };
     },


### PR DESCRIPTION
The `destroy` function doesn't close the connection. This should fix #70.
