### PR TITLE
Do not push undefined connections back into the pool

### DIFF
--- a/clients/server/base.js
+++ b/clients/server/base.js
@@ -56,6 +56,11 @@ var ServerBase = ClientBase.extend({
     // ensure the connection gets dumped back into the client pool.
     if (!builder.usingConnection) {
       chain = chain.ensure(function() {
+        if (!conn) {
+          // The connection must have failed to initialize. Avoid pushing undefined
+          // into the connection pool.
+          return;
+        }
         client.pool.release(conn);
       });
     }


### PR DESCRIPTION
If the connection fails because of a server error, the code pushes an undefined connection back into the pool.
