### PR TITLE
added bigint type to postgresql

### DIFF
--- a/clients/server/postgres/schemagrammar.js
+++ b/clients/server/postgres/schemagrammar.js
@@ -113,6 +113,11 @@ exports.schemaGrammar = _.defaults({
     return column.autoIncrement ? 'serial' : 'integer';
   },
 
+  // Create the column definition for a bigint type.
+  typeBigInteger: function(column) {
+    return column.autoIncrement ? 'bigserial' : 'bigint';
+  },
+
   // Create the column definition for a tiny integer type.
   typeTinyInteger: function() {
     return 'smallint';


### PR DESCRIPTION
bigint is treated as an integer, since typeBigInteger isn't defined on `clients/server/postgres/schemagrammar.js`

I was going to write the tests, then I saw that the schemagrammar files are untested... and I don't really think I should write all the tests for the file, especially since I am not familiar with the code base. It would be nice to see it done with mysql or sqlite first.

So your call. I'll make the PR without tests, and you can reject it if you want. I can always help write the tests once I get an example to go off of.

This should help with postgres problems I mentioned in TryGhost/Ghost#1554 and TryGhost/Ghost#1555
