### PR TITLE
Resolve configuration file path on migration

### DIFF
--- a/lib/cli/migrate.js
+++ b/lib/cli/migrate.js
@@ -81,11 +81,12 @@ module.exports = function(commands) {
 };
 
 var checkConfig = function(argv) {
-  if (!(configFile = (argv.c || argv.config))) {
+  var configFile = argv.c || argv.config;
+  if (!configFile) {
     configFile = path.join(process.cwd(), 'config.js');
   }
   return fs.statAsync(configFile).then(function() {
-    return require(configFile);
+    return require(path.resolve(configFile));
   }).tap(function(config) {
     if (config.database instanceof Knex) {
       knex = config.database;


### PR DESCRIPTION
It changes so that the path of the migration config file is resolved before it is required.
This avoids `Cannot find module` error when the configuration file path is specified as relative path:

``` bash
$ cd some-project/
$ cat db/config.js
// Sample Config File
module.exports = {

  directory: './migrations-folder',

  database: {
    client: 'sqlite3',
    connection: {
      filename: './db.sqlite3'
    }
  }

};
$ ./node_modules/.bin/knex migrate:make create_posts -c ./db/config.js
```
