### PR TITLE
Match CoffeeScript stub to JS

### DIFF
--- a/lib/stub/coffee.stub
+++ b/lib/stub/coffee.stub
@@ -2,7 +2,12 @@
 exports.up = (knex, Promise) ->
   <% if (d.tableName) { %>
   knex.schema.createTable "<%= d.tableName %>", (t) ->
+    t.increments()
+    t.timestamp()
+  <% } %>
 
 
 exports.down = (knex, Promise) ->
+  <% if (d.tableName) { %>
   knex.schema.dropTable "<%= d.tableName %>"
+  <% } %>


### PR DESCRIPTION
The CoffeeScript migration template was incomplete/invalid — this updates it to be identical to the JS one
