### PR TITLE
Fix migrations bug for multiple operations

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -213,7 +213,7 @@ Migrate.prototype = {
 
         // We're going to run each of the migrations in the current "up"
         current = current.then(function() {
-          return migration[direction](knex, Promise.fulfilled());
+          return migration[direction](knex, Promise);
         }).then(function() {
           log.push(name);
           if (direction === 'up') {

--- a/test/integration/migrate/test/20131019235306_migration_2.js
+++ b/test/integration/migrate/test/20131019235306_migration_2.js
@@ -13,5 +13,5 @@ exports.up = function(knex, promise) {
 };
 
 exports.down = function(knex, promise) {
-  return promise.all([knex.schema.dropTable('migration_test_2'), knex.schema.dropTable('migration_test_2.1')]);
+  return promise.all([knex.schema.dropTable('migration_test_2'), knex.schema.dropTable('migration_test_2_1')]);
 };


### PR DESCRIPTION
`promise.fulfilled()` was being passed to each migration's `up` function. Based on the integration tests, I figured passing `promise` through is meant to be a convenience so that `promise.all[promises*]` can be called.

At the moment the integration tests just verify that a migration took place and that it the promise wasn't rejected. When I have a second I'll write a case to actually confirm that the right tables are being created and deleted. 
