### PR TITLE
Fix direct inclusion of Knex instance in migrations

### DIFF
--- a/lib/cli/migrate.js
+++ b/lib/cli/migrate.js
@@ -88,7 +88,7 @@ var checkConfig = function(argv) {
   return fs.statAsync(configFile).then(function() {
     return require(path.resolve(configFile));
   }).tap(function(config) {
-    if (config.database instanceof Knex) {
+    if (config.database.client && (config.database.client instanceof Knex.ClientBase)) {
       knex = config.database;
     } else {
       knex = Knex(config.database);


### PR DESCRIPTION
Knex doesn't create actual instances so checking whether a valid Knex client is an `instanceof require('knex')` fails. I'm borrowing the detection logic [from Bookshelf](https://github.com/tgriesser/bookshelf/blob/master/bookshelf.js#L37). Definitely planning to write tests for all this soon, but I can confirm that it works (migrations run) on a real project. 
