### PR TITLE
schemabuilder bigInteger documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1168,7 +1168,7 @@ knex.schema.table('users', function (table) {
     </p>
 
     <p id="Schema-bigInteger">
-      <b class="header">integer</b><code>table.integer(name)</code>
+      <b class="header">bigInteger</b><code>table.bigInteger(name)</code>
       <br />
       In MySQL or PostgreSQL, adds a <tt>bigint</tt> column,
       otherwise adds a normal integer.


### PR DESCRIPTION
Documentation was showing `integer` instead of `bigInteger` for the function name
