### PR TITLE
Only use files with the correct extension for migrations

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -129,7 +129,10 @@ Migrate.prototype = {
         return Promise.promisify(fs.readdir, fs)(this.config.directory);
       })
       .then(function(migrations) {
-        return migrations.sort();
+        var ext = this.config.extension;
+        return _.filter(migrations, function (value) {
+          return value.indexOf(ext, value.length - ext.length) !== -1;
+        }).sort();
       });
   },
 

--- a/test/integration/migrate/test/random_bad_file.txt
+++ b/test/integration/migrate/test/random_bad_file.txt
@@ -1,0 +1,1 @@
+This is definitely not a migration.


### PR DESCRIPTION
When editing migrations in VIM, I noticed that Knex was picking up the `.swp` files and throwing an error. This commit filters by extension for just the expected files.

I didn't code up a full-blown test, but the addition of a random crap file in the migration fixtures will trigger the error that this commit fixes.
