### PR TITLE
changed init to use this.config in case one isn't passed in

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -31,8 +31,8 @@ Migrate.prototype = {
         this.config.directory = path.resolve(process.cwd(), this.config.directory);
       }
       this._init = Promise.all([
-        this.ensureFolder(config),
-        this.ensureTable(config)
+        this.ensureFolder(this.config),
+        this.ensureTable(this.config)
       ]).bind(this);
     }
     return this._init;


### PR DESCRIPTION
Doing a call such as `knex.migrate.currentVersion()` in my code would produce errors related to config (since one was never passed in), this fixes it.
