### PR TITLE
add pluck to builder interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,7 @@
       <li><b><a href="#Builder-Interface">Interface:</a></b></li>
       <li>– <a href="#Builder-tap">tap</a></li>
       <li>– <a href="#Builder-then">then</a></li>
+      <li>– <a href="#Builder-pluck">pluck</a></li>
       <li>– <a href="#Builder-exec">exec</a></li>
       <li>– <a href="#Builder-toString">toString</a></li>
     </ul>
@@ -954,6 +955,13 @@ knex.transaction(function(t) {
       with the same value, in the order they were called; the query will not be executed multiple times.
     </p>
 
+    <p id="Builder-pluck">
+      <b class="header">tap</b><code>.pluck(id)</code>
+      <br />
+      This will pluck the specified column from each row in your results, yielding a promise which resolves
+      to the array of values selected.
+    </p>
+
     <p id="Builder-exec">
       <b class="header">exec</b><code>.exec(callback)</code>
       <br />
@@ -970,6 +978,7 @@ knex.transaction(function(t) {
       this will execute side effects on the resolved response, ultimately returning a promise that fulfills with the original
       value. A thrown error or rejected promise will cause the promise to transition into a rejected state.
     </p>
+
 <pre>
 // Using only .then()
 query.then(function(x) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -510,7 +510,17 @@ _.extend(Builder.prototype, Common, {
     callback.call(query, query);
     this.unions.push({query: query, all: bool});
     push.apply(this.bindings, query.bindings);
-  }
+  },
+
+  // Helper to pull a single column from each result and return array
+  pluck: function (column) {
+    if (!column) {
+      throw new Error('You must specify a column to pluck.');
+    }
+    return this.column(column).then(function (results) {
+      return _.pluck(results, column);
+    });
+  },
 
 });
 

--- a/test/unit/builder.js
+++ b/test/unit/builder.js
@@ -432,4 +432,10 @@ describe('Builder', function () {
 
   });
 
+  describe('pluck', function() {
+
+    it('should pluck a defined key from the result set');
+
+  });
+
 });


### PR DESCRIPTION
allows you to grab a single element from each row in your results, returning a promise which yields an array of those values.
