### PR TITLE
Started to implement schema.columns

### DIFF
--- a/knex.js
+++ b/knex.js
@@ -91,7 +91,7 @@ Knex.initialize = function(config) {
   // `knex.schema.table('tableName', function() {...`
   // `knex.schema.createTable('tableName', function() {...`
   // `knex.schema.dropTableIfExists('tableName');`
-  _.each(['table', 'createTable', 'editTable', 'dropTable',
+  _.each(['table', 'createTable', 'editTable', 'dropTable', 'columns',
     'dropTableIfExists',  'renameTable', 'hasTable', 'hasColumn'], function(key) {
     schema[key] = function(tableName) {
       if (!client.SchemaBuilder) client.initSchema();

--- a/lib/clients/mysql/schema/builder.js
+++ b/lib/clients/mysql/schema/builder.js
@@ -33,6 +33,25 @@ module.exports = function(client) {
         }
       });
       return this;
+    },
+
+    // Retrieve columns for the specified table
+    columns: function(tableName) {
+      this.sequence.push({
+        sql: 'select column_name, data_type, character_maximum_length from information_schema.columns where table_name = ? and table_schema = ?',
+        bindings: [tableName, client.database()],
+        output: function(resp) {
+          return _.reduce(resp, function (columns, val) {
+            columns[val.column_name] = {
+              type: val.data_type,
+              charMaxLength: val.character_maximum_length
+            };
+            return columns;
+          }, {});
+        }
+      });
+
+      return this;
     }
 
   });

--- a/lib/clients/postgres/schema/builder.js
+++ b/lib/clients/postgres/schema/builder.js
@@ -35,6 +35,26 @@ module.exports = function(client) {
         sql: 'alter table ' + this._wrap(from) + ' rename to ' + this._wrap(to)
       });
       return this;
+    },
+
+    // Retrieve columns for the specified table
+    columns: function(tableName) {
+      this.sequence.push({
+        sql: 'select column_name, data_type, character_maximum_length from information_schema.columns where table_name = ? and table_catalog = ?',
+        bindings: [tableName, client.connectionSettings.database],
+        output: function(resp) {
+          console.log(resp);
+          return _.reduce(resp.rows, function (columns, val) {
+            columns[val.column_name] = {
+              type: val.data_type,
+              charMaxLength: val.character_maximum_length
+            };
+            return columns;
+          }, {});
+        }
+      });
+
+      return this;
     }
 
   });

--- a/lib/clients/sqlite3/schema/builder.js
+++ b/lib/clients/sqlite3/schema/builder.js
@@ -36,6 +36,28 @@ module.exports = function(client) {
         sql: 'alter table ' + this._wrap(from) + ' rename to ' + this._wrap(to)
       });
       return this;
+    },
+
+    // Retrieve columns for the specified table
+    columns: function(tableName) {
+      this.sequence.push({
+        sql: 'PRAGMA table_info(' + this._wrap(tableName) + ')',
+        output: function(resp) {
+          var maxLengthRegex = /.*\((\d+)\)/;
+          return _.reduce(resp, function (columns, val) {
+            var type = val.type;
+            var maxLength = (maxLength = type.match(maxLengthRegex)) && maxLength[1];
+            type = maxLength ? type.split('(')[0] : type;
+            columns[val.name] = {
+              type: type.toLowerCase(),
+              charMaxLength: maxLength
+            };
+            return columns;
+          }, {});
+        }
+      });
+
+      return this;
     }
 
   });


### PR DESCRIPTION
No tests at the moment, but seems to work fine so far. Added it to schema, because from my point of view that's where it actually belongs. @tgriesser, do you agree? It's up for discussion whether to include the numeric precision for numbers or not.

Also, as I already noted in my plugin pull-req over at bookshelf, when doing this in mysql, when you are creating tables on the fly, a `FLUSH TABLES` must be sent prior to fetching columns. Questions is, whether we should have the statement in there always or not.
