### PR TITLE
Add support for pure JS driver for PostgreSQL

### DIFF
--- a/clients/server/postgres.js
+++ b/clients/server/postgres.js
@@ -1,11 +1,17 @@
 // PostgreSQL
 // -------
 
-// Other dependencies, including the `pg` library,
+// Other dependencies, including the `pg` or `pg.js` libraries,
 // which needs to be added as a dependency to the project
 // using this database.
 var _    = require('lodash');
-var pg   = require('pg');
+var pg   = null;
+
+try {
+  pg = require('pg');
+} catch (e) {
+  pg = require('pg.js');
+}
 
 // All other local project modules needed in this scope.
 var ServerBase        = require('./base').ServerBase;


### PR DESCRIPTION
As there is no way to tell `npm` to not compile native driver, we should use https://github.com/brianc/node-postgres-pure instead which is exactly the same library without native driver, but as `knex` has no idea about it, i cannot use it. Please take a look at project's homepage.
