### PR TITLE
Quote Node versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 # .travis.yml
 language: node_js
 node_js:
-  - 0.10
-  - 0.8
+  - "0.10"
+  - "0.8"
 
 before_script:
   - psql -c 'create database knex_test;' -U postgres


### PR DESCRIPTION
Node versions in the Travis configuration should be quoted, otherwise yaml sees this as `0.1` rather than `0.10`. This currently works because Travis treats the unknown `0.1` as `latest`, which is `0.10`, but it'll stop doing what you expect once `0.12` is out.
