### PR TITLE
add ability to specify a migration environment key

### DIFF
--- a/lib/cli/migrate.js
+++ b/lib/cli/migrate.js
@@ -78,10 +78,15 @@ module.exports = function(commands) {
 
 var checkConfig = function(argv) {
   var configFile = argv.c || argv.config;
+  var environment = argv.e || argv.environment;
+
   if (!configFile) {
     configFile = path.join(process.cwd(), 'config.js');
   }
   return fs.statAsync(configFile).then(function() {
+    if (environment !== void(0)) {
+      return require(path.resolve(configFile))[environment];
+    }
     return require(path.resolve(configFile));
   }).tap(function(config) {
     config.projectRoot = config.projectRoot || process.cwd();


### PR DESCRIPTION
This PR allows you to do this

```
./node_modules/knex/bin/knex migrate:latest --environment=development
```

or

```
./node_modules/knex/bin/knex migrate:latest -e=development
```

Thus allowing for this syntax in your config file

``` js
module.exports = {
  "test": {
    ...
  }
  "dev": {
    ...
  },
  "production": {
    ...
  }
}
```

this allows you to keep your config centralized
and dynamic based on your environment.
