### PR TITLE
adding more array operators to builder for postgres array functionality

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -27,7 +27,7 @@ var Builder = function(knex) {
 
 // All operators used in the `where` clause generation.
 var operators = ['=', '<', '>', '<=', '>=', '<>', '!=', 'like', 'not like',
-  'between', 'ilike', '&', '&&', '|', '^', '#', '<<', '>>'];
+  'between', 'ilike', '&', '&&', '|', '^', '#', '<<', '>>', '@>', '<@', '||'];
 
 var nullOperators = ['is', 'is not'];
 


### PR DESCRIPTION
Turns out, I was using the wrong array operators anyway - I needed @> instead of &&. But these three operators are valid array operators in postgres per http://www.postgresql.org/docs/9.3/static/functions-array.html
