### PR TITLE
andWhereRaw method for clarity

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -215,6 +215,11 @@ _.extend(Builder.prototype, Common, {
     return this.whereRaw(sql, bindings, 'or');
   },
 
+  // Adds a raw `and where` clause to the query
+  andWhereRaw: function(sql, bindings) {
+    return this.whereRaw(sql, bindings, 'and');
+  },
+
   // Adds a `where exists` clause to the query.
   whereExists: function(callback, bool, type) {
     var query = new Builder(this.knex);


### PR DESCRIPTION
I noticed that there is a `orWhereRaw` method as well as an `andWhere` method (which has identical usage as a simple `where`) so I thought that for clarity's sake, it would make sense to add an `andWhereRaw` method.

Otherwise, it seems the naming conventions seem a little inconsistent.
