### PR TITLE
Tweak the wrapValue function to allow for array column operations

### DIFF
--- a/clients/server/postgres/grammar.js
+++ b/clients/server/postgres/grammar.js
@@ -10,9 +10,9 @@ exports.grammar = _.defaults({
   // The keyword identifier wrapper format.
   wrapValue: function(value) {
     if (value === '*') {
-      return '"*"';
+      return '*';
     } else if (value.indexOf('[') >= 0) {
-      return Helpers.format('"%s"%s', value.substr(0,value.indexOf('[')), value.substr(value.indexOf('[')))
+      return Helpers.format('"%s"%s', value.substr(0,value.indexOf('[')), value.substr(value.indexOf('[')));
     } else {
       return Helpers.format('"%s"', value);
     }


### PR DESCRIPTION
This is probably _not_ the general-purpose solution to the problem I'm encountering, but it solves my issues. I need to do a join on table.array_column[1] = value, but the existing wrapValue process turns that into "table"."array_column[1]" instead of "table"."array_column"[1]. This seemed like the best place to find that case and fix it.

In where clauses, I could do a whereRaw to brute-force the double-quotes, but there doesn't seem to be a similar functionality in join clauses. That would be another way to solve this problem, though - allow for a join(this.raw("stuff")) (which currently throws a toLowerCase error when compileJoins tries to lowercasify the Raw.
