### PR TITLE
documentation fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1029,12 +1029,12 @@ knex('accounts')
 
 knex.transaction(function(trx) {
 
-  knex('books').transacting(t).insert({name: 'Old Books'})
+  knex('books').transacting(trx).insert({name: 'Old Books'})
     .then(function(id) {
-      return someExternalMethod(t);
+      return someExternalMethod(trx);
     })
-    .then(t.commit)
-    .then(t.rollback);
+    .then(trx.commit)
+    .then(trx.rollback);
 
 }).then(function(resp) {
   console.log('Transaction complete.');


### PR DESCRIPTION
I think I found a bug in the documentation. "t" should say "trx", right?
