### PR TITLE
Require Promise module for use in knex.destroy()

### DIFF
--- a/knex.js
+++ b/knex.js
@@ -47,6 +47,7 @@ var Clients = Knex.Clients = {
 
 // Require lodash.
 var _ = require('lodash');
+var Promise = require('./lib/promise');
 
 // Each of the methods which may be statically chained from knex.
 var QueryInterface   = require('./lib/query/methods');


### PR DESCRIPTION
Currently calling `knex.destroy()` results in an error:

```
[ReferenceError: Promise is not defined]
```

@tgriesser I don't see a good place to put a test for `knex.destroy` any thoughts on where that should go?
