### PR TITLE
support --cwd with commander

### DIFF
--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -56,7 +56,9 @@ function invoke(env) {
     )
     .option('--debug', 'Run with debugging.')
     .option('--knexfile [path]', 'Specify the knexfile path.')
+    .option('--cwd [path]', 'Specify the working directory.')
     .option('--env [name]', 'environment, default: process.NODE_ENV || development');
+
 
   commander
     .command('init')


### PR DESCRIPTION
fixes #326. 

I can submit a PR later this week that removes the dependency on minimist (that way the only options parser you are using is commander).
