### PR TITLE
Allow debug flag to be a function.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -28,11 +28,16 @@ Runner.prototype.run = Promise.method(function() {
     .then(this.ensureConnection)
     .then(function(connection) {
       this.connection = connection;
+      this.client.emit('start', this.builder);
+      this.builder.emit('start');
       var sql = this.builder.toSQL();
       if (_.isArray(sql)) {
         return this.queryArray(sql);
       }
       return this.query(sql);
+    })
+    .tap(function() {
+      this.builder.emit('end');
     })
     .finally(this.cleanupConnection);
 });


### PR DESCRIPTION
I was thinking about making some Express middleware that will allow showing the queries that are being executed and how long they take.

At this point, the best that I can come up with is making the `debug` config a callable. I don't really like this, though, and I think it'd be better to listen for some events. The following events should suffice to build this:
- `query`
- `queryComplete`

The current `query` event doesn't seem to make it's way back to the `knex` instance all the time, though. I've created another pull request, #336, to resolve issues with the events making their way back.

Would you guys be open to adding another event for when the query completes?
