### PR TITLE
Continue to propigate event for cloned objects.

### DIFF
--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -47,6 +47,12 @@ QueryBuilder.prototype.clone = function() {
     cloned._debug       = this._debug;
     cloned._transacting = this._transacting;
     cloned._connection  = this._connection;
+
+  var self = this;
+  cloned.on('query', function(data) {
+    self.emit('query', data);
+  });
+
   return cloned;
 };
 


### PR DESCRIPTION
Cloned query builders don't allow events to propagate back to the main `knex` object. This causes problems if you want to build something that listens for all queries that are running via Knex.

A concern with the solute here is that each clone is retaining a reference to the query that cloned it. This could cause memory problems, so it's possible that another solution would be preferable. I believe, however, that within the confines of this architecture, that this could be okay. Based on my experience with other ORM tools, it's generally true that queries that are extensions (or cloned) from other queries are siblings of the query from which they're cloned. As long as the cloned query doesn't refer back to the query from which it was cloned, I don't think any sort of memory growth would occur here.

I'd love to see something like this happen, though, so that I can come up with a more elegant solution to debugging queries during development than #335.
