### PR TITLE
Help text error for migrate:latest

### DIFF
--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -94,7 +94,7 @@ function invoke(env) {
 
   commander
     .command('migrate:latest')
-    .description('        Rollback the last set of migrations performed.')
+    .description('        Run all migrations that have not yet been run.')
     .action(function(options) {
       pending = initKnex(env).migrate.latest().spread(function(batchNo, log) {
         if (log.length === 0) {


### PR DESCRIPTION
Changed the help text for migrate:latest as described in the documentation.
