### PR TITLE
Warn if local knex module is missing

### DIFF
--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -72,6 +72,7 @@ function invoke(env) {
       if (env.configPath) {
         exit('Error: ' + env.configPath + ' already exists');
       }
+      checkLocalModule(env);
       var stubPath = './knexfile.' + type;
       pending = fs.readFileAsync(path.dirname(env.modulePath) + '/lib/migrate/stub/knexfile-' + type + '.stub')
         .then(function(code) {
@@ -132,21 +133,25 @@ function invoke(env) {
   });
 }
 
-function initKnex(env) {
-
+function checkLocalModule(env) {
   if (!env.modulePath) {
     console.log(chalk.red('No local knex install found in:'), chalk.magenta(tildify(env.cwd)));
     exit('Try running: npm install knex.');
-  }
-
-  if (!env.configPath) {
-    exit('No knexfile found in this directory. Specify a path with --knexfile');
   }
 
   // check for semver difference between cli and local installation
   if (semver.gt(cliPkg.version, env.modulePackage.version)) {
     console.log(chalk.blue('Running knex is: ', chalk.green(cliPkg.version)));
     console.log(chalk.blue('Local knex (installed in knexfile dir) is', chalk.green(env.modulePackage.version)));
+  }
+}
+
+function initKnex(env) {
+
+  checkModule(env);
+
+  if (!env.configPath) {
+    exit('No knexfile found in this directory. Specify a path with --knexfile');
   }
 
   if (process.cwd() !== env.cwd) {


### PR DESCRIPTION
If one tries to do a "knex init" prior to having added the knex module locally to ones project, then one previously didn't get a warning – just a confusing error about a file not being found. Now an error is shown instead.
