### PR TITLE
chained where and join

### DIFF
--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -19,6 +19,8 @@ function QueryBuilder() {
   // Internal flags used in the builder.
   this._joinFlag  = 'inner';
   this._boolFlag  = 'and';
+
+  this.and = this;
 }
 inherits(QueryBuilder, EventEmitter);
 
@@ -257,6 +259,7 @@ QueryBuilder.prototype.whereWrapped = function(callback) {
 
 // Adds a `where exists` clause to the query.
 QueryBuilder.prototype.whereExists = function(callback, not) {
+  not = this._not() || not;
   this._statements.push({
     grouping: 'where',
     type: 'whereExists',
@@ -284,6 +287,7 @@ QueryBuilder.prototype.orWhereNotExists = function(callback) {
 
 // Adds a `where in` clause to the query.
 QueryBuilder.prototype.whereIn = function(column, values, not) {
+  not = this._not() || not;
   this._statements.push({
     grouping: 'where',
     type: 'whereIn',
@@ -312,6 +316,7 @@ QueryBuilder.prototype.orWhereNotIn = function(column, values) {
 
 // Adds a `where null` clause to the query.
 QueryBuilder.prototype.whereNull = function(column, not) {
+  not = this._not() || not;
   this._statements.push({
     grouping: 'where',
     type: 'whereNull',
@@ -345,6 +350,7 @@ QueryBuilder.prototype.whereBetween = function(column, values, not) {
   if (values.length !== 2) {
     return this._errors.push(new Error('You must specify 2 values for the whereBetween clause'));
   }
+  not = this._not() || not;
   this._statements.push({
     grouping: 'where',
     type: 'whereBetween',
@@ -659,6 +665,17 @@ QueryBuilder.prototype._bool = function(val) {
   return ret;
 };
 
+// Helper to get or set the "notFlag" value.
+QueryBuilder.prototype._not = function(val) {
+  if (arguments.length === 1) {
+    this._notFlag = val;
+    return this;
+  }
+  var ret = this._notFlag;
+  this._notFlag = false;
+  return ret;
+};
+
 // Helper to get or set the "joinFlag" value.
 QueryBuilder.prototype._joinType = function (val) {
   if (arguments.length === 1) {
@@ -680,6 +697,19 @@ QueryBuilder.prototype._aggregate = function(method, column) {
   });
   return this;
 };
+
+Object.defineProperty(QueryBuilder.prototype, 'or', {
+  get: function () {
+    return this._bool('or');
+  }
+});
+
+
+Object.defineProperty(QueryBuilder.prototype, 'not', {
+  get: function () {
+    return this._not(true);
+  }
+});
 
 // Attach all of the top level promise methods that should be chainable.
 require('../interface')(QueryBuilder);

--- a/lib/query/joinclause.js
+++ b/lib/query/joinclause.js
@@ -7,6 +7,7 @@ function JoinClause(table, type) {
   this.table    = table;
   this.joinType = type;
   this.clauses  = [];
+  this.and = this;
 }
 
 JoinClause.prototype.grouping = 'join';
@@ -47,5 +48,11 @@ JoinClause.prototype._bool = function(bool) {
   this._boolFlag = 'and';
   return ret;
 };
+
+Object.defineProperty(JoinClause.prototype, 'or', {
+  get: function () {
+    return this._bool('or');
+  }
+});
 
 module.exports = JoinClause;


### PR DESCRIPTION
adds some magic to make where, on, and join clauses easier.
- you can add or. in front of a when or on to do the same thing that whenOr and onOr did, e.g.
  
  ```
  qb.on('users.id', '=', 'contacts.id').or.on('users.name', '=', 'contacts.name');
  sql().select('*').from('users').where('id', '=', 1).or.where('email', '=', 'foo')
  ```
  
  instead of
  
  ```
  qb.on('users.id', '=', 'contacts.id').orOn('users.name', '=', 'contacts.name');
  sql().select('*').from('users').where('id', '=', 1).orWhere('email', '=', 'foo')
  ```
- you can chain exists, in, between, raw, null, and wrapped after where, e.g.
  
  ```
  sql().select('*').from('users').where.in('id', [1, 2, 3]).toSQL();
  chain = sql().select('*').from('users').where.between('id', [1, 2]).toSQL();
  ```
  
  instead of  
  
  ```
  sql().select('*').from('users').whereIn('id', [1, 2, 3]).toSQL();
  chain = sql().select('*').from('users').whereBetween('id', [1, 2]).toSQL();
  ```
- you can negate one of those by putting a not after the where
  
  ```
  sql().select('*').from('users').where.not.in('id', [1, 2, 3]).toSQL();
  ```
  
  instead of
  
  ```
  sql().select('*').from('users').whereNotIn('id', [1, 2, 3]).toSQL();
  ```
- you can also just put the not infront of where
  
  ```
  sql().select('*').from('users').not.whereIn('id', [1, 2, 3]).toSQL();
  ```
- similarly to or you can also chain with 'and' but this doesn't do anything special
      sql().select('*').from('users').and.where('id', '=', 1)
  
  vs
  
  ```
  sql().select('*').from('users').where('id', '=', 1)
  ```
- lastly you can do
  - query.inner.join()
  - query.left.join()
  - query.right.join()
  - query.cross.join()
  - query.outer.join()
  - query.left.outer.join()
  - query.right.outer.join()
  - query.full.outer.join()

the only weirdness I've found is that this line

```
chain = sql()
    .select('*')
    .from('orders')
    .where
    .exists(
        sql()
        .select('*')
        .from('products')
        .where
        .raw('products.id = orders.id')
    ).toSQL();
```

causes a stack overflow but doesn't if I switch from where.exists to whereExists
