### PR TITLE
Fix broken references in documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2195,7 +2195,7 @@ $ knex migrate:latest
     <p>
       <tt>knex.migrate</tt> is the class utilized by the knex migrations cli. Each method
       takes an optional <tt>config</tt> object, which may specify specifies the <tt>database</tt>,
-      <tt>directory</tt>, and <tt>tableName</tt> for the migrations. Check <a href="https://github.com/tgriesser/knex/blob/master/bin/readme.md">here</a> for more information about the migration CLI tool.
+      <tt>directory</tt>, and <tt>tableName</tt> for the migrations.
     </p>
 
     <p id="Migrations-make">


### PR DESCRIPTION
The `bin/readme.md` file was removed in f7ad182
