### PR TITLE
Added a NOW() helper

### DIFF
--- a/knex.js
+++ b/knex.js
@@ -141,6 +141,14 @@ Knex.initialize = function(config) {
         if (!client.Migrator) client.initMigrator();
         return new client.Migrator(knex);
       }
+    },
+
+    // Lazy-load / return a `FunctionHelper` object.
+    fn: {
+      get: function() {
+        if (!client.FunctionHelper) client.initFunctionHelper();
+        return client.FunctionHelper;
+      }
     }
   });
 

--- a/lib/dialects/mysql/functionhelper.js
+++ b/lib/dialects/mysql/functionhelper.js
@@ -1,0 +1,11 @@
+module.exports = function(client) {
+
+var FunctionHelper = require('../../functionhelper');
+
+var FunctionHelper_MySQL = Object.create(FunctionHelper);
+FunctionHelper_MySQL.client = client;
+
+// Assign the newly extended `FunctionHelper` constructor to the client object.
+client.FunctionHelper = FunctionHelper_MySQL;
+
+};

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -43,6 +43,11 @@ Client_MySQL.prototype.initRaw = function() {
   require('./raw')(this);
 };
 
+// Attaches the `FunctionHelper` constructor to the client object.
+Client_MySQL.prototype.initFunctionHelper = function() {
+  require('./functionhelper')(this);
+};
+
 // Attaches the `Transaction` constructor to the client object.
 Client_MySQL.prototype.initTransaction = function() {
   require('./transaction')(this);

--- a/lib/dialects/postgres/functionhelper.js
+++ b/lib/dialects/postgres/functionhelper.js
@@ -1,0 +1,11 @@
+module.exports = function(client) {
+
+var FunctionHelper = require('../../functionhelper');
+
+var FunctionHelper_PG = Object.create(FunctionHelper);
+FunctionHelper_PG.client = client;
+
+// Assign the newly extended `FunctionHelper` constructor to the client object.
+client.FunctionHelper = FunctionHelper_PG;
+
+};

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -48,6 +48,11 @@ Client_PG.prototype.initRaw = function() {
   require('./raw')(this);
 };
 
+// Attaches the `FunctionHelper` constructor to the client object.
+Client_PG.prototype.initFunctionHelper = function() {
+  require('./functionhelper')(this);
+};
+
 // Attaches the `Transaction` constructor to the client object.
 Client_PG.prototype.initTransaction = function() {
   require('./transaction')(this);

--- a/lib/dialects/sqlite3/functionhelper.js
+++ b/lib/dialects/sqlite3/functionhelper.js
@@ -1,0 +1,11 @@
+module.exports = function(client) {
+
+var FunctionHelper = require('../../functionhelper');
+
+var FunctionHelper_SQLite3 = Object.create(FunctionHelper);
+FunctionHelper_SQLite3.client = client;
+
+// Assign the newly extended `FunctionHelper` constructor to the client object.
+client.FunctionHelper = FunctionHelper_SQLite3;
+
+};

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -44,6 +44,11 @@ Client_SQLite3.prototype.initRaw = function() {
   require('./raw')(this);
 };
 
+// Attaches the `FunctionHelper` constructor to the client object.
+Client_SQLite3.prototype.initFunctionHelper = function() {
+  require('./functionhelper')(this);
+};
+
 // Always initialize with the "Query" and "QueryCompiler"
 // objects, each of which is unique to this client (and thus)
 // can be altered without messing up anything for anyone else.

--- a/lib/functionhelper.js
+++ b/lib/functionhelper.js
@@ -1,0 +1,10 @@
+// FunctionHelper
+// -------
+
+module.exports = {
+
+  now : function() {
+    return new this.client.Raw('CURRENT_TIMESTAMP');
+  }
+
+};

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -42,6 +42,11 @@ module.exports = function(knex) {
       expect(knex(knex.raw("raw_table_name")).toQuery()).to.equal('select * from raw_table_name');
     });
 
+    it('should allow using .fn-methods to create raw statements', function() {
+      expect(knex.fn.now().prototype === knex.raw().prototype);
+      expect(knex.fn.now().toQuery()).to.equal('CURRENT_TIMESTAMP');
+    });
+
     it('gets the columnInfo', function() {
       return knex('datatype_test').columnInfo().testSql(function(tester) {
         tester('mysql',


### PR DESCRIPTION
After some IRC-discussion with @tgriesser, here's a pull request for solving #310.

It adds a `now()` method to the database client so one can do `knex.client.now()` as a shortcut for `knex.raw('NOW()')` and then get the database specific representation of `NOW()` returned – which means better interoperability.

Includes one DB-specific override, that was brought up as an example in #310, for SQLite3 that replaces `NOW()` with `date('now')` instead.
