### PR TITLE
fix for using a pgConnectionString

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -97,6 +97,14 @@ Client_PG.prototype.prepBindings = function(bindings, tz) {
 Client_PG.prototype.acquireRawConnection = Promise.method(function(callback) {
   var connection = new pg.Client(this.connectionSettings);
   var client = this;
+  
+  this.connectionSettings = { 
+    user : connection.connectionParameters.user,
+    database : connection.connectionParameters.database,
+    port : connection.connectionParameters.port,
+    host : connection.connectionParameters.host,
+  };
+
   return new Promise(function(resolver, rejecter) {
     connection.connect(function(err, connection) {
       if (err) return rejecter(err);


### PR DESCRIPTION
When you connect to postgresql using a connection string, the connectionSettings object of knex is inaccurate and calls like columnInfo() that rely on that information fail.

In the following example you can see the database name binding is undefined:

var knex = require('knex')({
  client: 'pg',
  connection: "pg://user@localhost/mydb"
});

knex('user').debug().columnInfo().then(function(info) {});

{ __cid: '__cid1',
  method: 'columnInfo',
  options: undefined,
  bindings: [ 'user', undefined ],
  sql: 'select \* from information_schema.columns where table_name = $1 and table_catalog = $2',
  output: [Function] }

The pg module has a connection string parser and it writes through the parsed string to the pg client object connectionParameters.   Unfortunately it seems the pg module does not expose this parser, so we have to delay updating the knex.connectionSettings until the the actual database connection is made.   I'm going to ask the pg dev if it's possible to get access to the parser.  If so, a better place to do this would probably be in the Client_PG function.
