### PR TITLE
upgrade bluebird to v2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,19 +15,19 @@
     "sqlite3": false
   },
   "dependencies": {
-    "minimist": "~0.0.9",
-    "bluebird": "1.2.x",
+    "bluebird": ">=1.2.0",
     "chalk": "^0.4.0",
     "commander": "^2.2.0",
-    "interpret": "^0.3.2",
-    "liftoff": "^0.11.0",
-    "semver": "^2.3.0",
-    "tildify": "^0.2.0",
     "generic-pool-redux": "~0.1.0",
     "inherits": "~2.0.1",
+    "interpret": "^0.3.2",
+    "liftoff": "^0.11.0",
     "lodash": "~2.4.0",
+    "minimist": "~0.0.9",
     "mkdirp": "^0.5.0",
-    "readable-stream": "^1.1.12"
+    "readable-stream": "^1.1.12",
+    "semver": "^2.3.0",
+    "tildify": "^0.2.0"
   },
   "devDependencies": {
     "through": "^2.3.4",


### PR DESCRIPTION
Bluebird is now at version 2.2.2 but knex is still using the 1.2.0 release. I'd like to use some of the new 2.X features in our projects but would rather not mix bluebird versions if I can avoid it. Would you consider upgrading the knex dependency to start tracking the 2.X version?

I ran the tests and they pass for me with bluebird version 2.2.2.

Closes #400
