### PR TITLE
Option for ignoring changes in migrations

### DIFF
--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -17,13 +17,13 @@ function Migrator(knex) {
 }
 
 // Migrators to the latest configuration.
-Migrator.prototype.latest = Promise.method(function(config) {
+Migrator.prototype.latest = Promise.method(function(config, ignoreChanges) {
   this.config = this.setConfig(config);
   return this._migrationData()
     .tap(validateMigrationList)
     .bind(this)
     .spread(function(all, completed) {
-      return this._runBatch(_.difference(all, completed), 'up');
+      return this._runBatch(_.difference(all, completed), 'up', ignoreChanges);
     });
 });
 
@@ -107,7 +107,7 @@ Migrator.prototype._createMigrationTable = function(tableName) {
 };
 
 // Run a batch of current migrations, in sequence.
-Migrator.prototype._runBatch = function(migrations, direction) {
+Migrator.prototype._runBatch = function(migrations, direction, ignoreChanges) {
   return Promise.all(_.map(migrations, this._validateMigrationStructure, this))
     .bind(this)
     .then(function(migrations) {
@@ -118,7 +118,7 @@ Migrator.prototype._runBatch = function(migrations, direction) {
           return batchNo;
         })
         .then(function(batchNo) {
-          return this._waterfallBatch(batchNo, migrations, direction);
+          return this._waterfallBatch(batchNo, migrations, direction, ignoreChanges);
         });
     });
 };
@@ -199,7 +199,7 @@ Migrator.prototype._latestBatchNumber = function() {
 
 // Runs a batch of `migrations` in a specified `direction`,
 // saving the appropriate database information as the migrations are run.
-Migrator.prototype._waterfallBatch = function(batchNo, migrations, direction) {
+Migrator.prototype._waterfallBatch = function(batchNo, migrations, direction, ignoreChanges) {
   var knex      = this.knex;
   var tableName = this.config.tableName;
   var directory = this.config.directory;
@@ -211,7 +211,7 @@ Migrator.prototype._waterfallBatch = function(batchNo, migrations, direction) {
 
     // We're going to run each of the migrations in the current "up"
     current = current.then(function() {
-      return migration[direction](knex, Promise);
+      return ignoreChanges ? Promise.resolve() : migration[direction](knex, Promise);
     }).then(function() {
       log.push(name);
       if (direction === 'up') {


### PR DESCRIPTION
This is to enable the migrations to be marked as complete without the migrations actually being run – which eg. is something you likely want to do if you install an instance of a website from scratch and already have an up to date schema from the installation.

This new option enables the installation script to mark all migrations as already complete by doing `knex.migrate.latest({}, true)` to run through all migrations without actually applying any of the changes.

This same pattern could probably be used in other cases as well where a change has already happened outside the migration scripts for one reason or another.

I myself am only interested in pairing it with an installation scripts that sets up a fresh already up to date schema from scratch.
