### PR TITLE
Minor change to the CLI help text

### DIFF
--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -57,7 +57,7 @@ function invoke(env) {
     .option('--debug', 'Run with debugging.')
     .option('--knexfile [path]', 'Specify the knexfile path.')
     .option('--cwd [path]', 'Specify the working directory.')
-    .option('--env [name]', 'environment, default: process.NODE_ENV || development');
+    .option('--env [name]', 'environment, default: process.env.NODE_ENV || development');
 
 
   commander


### PR DESCRIPTION
Change the help text for the --env command to say 'process.env.NODE_ENV' instead of 'process.NODE_ENV'
