### PR TITLE
Fix global variable 'data' in JoinClause.on method

### DIFF
--- a/browser/knex.js
+++ b/browser/knex.js
@@ -4555,6 +4555,7 @@ JoinClause.prototype.grouping = 'join';
 
 // Adds an "on" clause to the current join object.
 JoinClause.prototype.on = function(first, operator, second) {
+  var data;
   if (arguments.length === 2) {
     data = ['on', this._bool(), first, '=', operator];
   } else {

--- a/browser/websql.js
+++ b/browser/websql.js
@@ -2828,6 +2828,7 @@ JoinClause.prototype.grouping = 'join';
 
 // Adds an "on" clause to the current join object.
 JoinClause.prototype.on = function(first, operator, second) {
+  var data;
   if (arguments.length === 2) {
     data = ['on', this._bool(), first, '=', operator];
   } else {

--- a/lib/query/joinclause.js
+++ b/lib/query/joinclause.js
@@ -14,6 +14,7 @@ JoinClause.prototype.grouping = 'join';
 
 // Adds an "on" clause to the current join object.
 JoinClause.prototype.on = function(first, operator, second) {
+  var data;
   if (arguments.length === 2) {
     data = ['on', this._bool(), first, '=', operator];
   } else {


### PR DESCRIPTION
Found this global in the node-debug interface:

`data = ["on", "and", "users.id", "=", "user_package.user_id"]`

Tracked it down in 3 files and added var data; at top of the function to avoid this.

Tested again and no more global "data" found.
