### PR TITLE
Do not attempt to release undefined connections from pool, #414

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -233,7 +233,7 @@ Runner.prototype.rollbackTransaction = function() {
 // explicitly set on the query we don't need to do anything here,
 // otherwise we
 Runner.prototype.cleanupConnection = Promise.method(function() {
-  if (!this.builder._connection) {
+  if (!this.builder._connection && typeof this.connection !== "undefined") {
     return this.client.releaseConnection(this.connection);
   }
 });


### PR DESCRIPTION
If a connection is not able to be initially established, there is no need to release it from the pool.  This is currently resulting in pushing an undefined connection to release into the generic-pool-redux.

I propose checking to make sure the connection is not "undefined" before attempting to release it.  This will avoid crashing an app with the undefined method .end() error.

This is aimed to fix issue #414.
