### PR TITLE
oracle - fix returning for non-integer types

### DIFF
--- a/lib/dialects/oracle/index.js
+++ b/lib/dialects/oracle/index.js
@@ -128,7 +128,8 @@ Client_Oracle.prototype.preprocessBindings = function (bindings) {
 
   return bindings.map(function (binding) {
     if (binding instanceof ReturningHelper && oracle) {
-      return new oracle.OutParam();
+      // returning helper uses always ROWID as string
+      return new oracle.OutParam(oracle.OCCISTRING);
     }
 
     if (typeof binding === 'boolean') {

--- a/lib/dialects/oracle/query.js
+++ b/lib/dialects/oracle/query.js
@@ -34,38 +34,22 @@ function QueryCompiler_Oracle() {
 }
 inherits(QueryCompiler_Oracle, QueryCompiler);
 
-
-QueryCompiler_Oracle.prototype._returningParams = function (value) {
-  if (!value || value === '*') {
-    return;
-  }
-
-  var self = this;
-  var returningValues = _.isArray(value) ? value : [value];
-  var returning = [];
-  var outParams = _.map(returningValues, function (v) {
-      var returningHelper = new ReturningHelper(v);
-      returning.push(returningHelper);
-      return self.formatter.parameter(returningHelper);
-    }).join (', ');
-
-  return {
-    columns: this.formatter.columnize(value),
-    outParams: outParams,
-    returning: returning
-  };
-};
-
-QueryCompiler_Oracle.prototype._addReturningToSqlAndConvert = function (sql, returning) {
+// for single commands only
+QueryCompiler_Oracle.prototype._addReturningToSqlAndConvert = function (sql, returning, tableName) {
   var res = {
     sql: sql
   };
-  var returningInfo = this._returningParams(returning);
-  if (returningInfo) {
-    res.sql = sql + ' returning ' + returningInfo.columns + ' into ' + returningInfo.outParams;
-    res.returning = returningInfo.returning;
+
+  if (!returning) {
+    return res;
   }
 
+  var returningValues = _.isArray(returning) ? returning : [returning];
+  var returningHelper = new ReturningHelper(returningValues.join(':'));
+  res.sql = sql + ' returning ROWID into ' + this.formatter.parameter(returningHelper);
+  res.returningSql = 'select ' + this.formatter.columnize(returning) + ' from ' + tableName + ' where ROWID = :1';
+  res.outParams = [returningHelper];
+  res.returning = returning;
   return res;
 };
 
@@ -74,8 +58,14 @@ QueryCompiler_Oracle.prototype._addReturningToSqlAndConvert = function (sql, ret
 QueryCompiler_Oracle.prototype.insert = function() {
   var self = this;
   var returning  = self.single.returning;
+
+  // always wrap returning argument in array
+  if (returning && !_.isArray(returning)) {
+    returning = [returning];
+  }
+
   if (_.isEmpty(self.single.insert)) {
-    return self._addReturningToSqlAndConvert('insert into ' + self.tableName + ' (' + self.formatter.wrap(self.single.returning) + ') values (default)', returning);
+    return self._addReturningToSqlAndConvert('insert into ' + self.tableName + ' (' + self.formatter.wrap(self.single.returning) + ') values (default)', returning, self.tableName);
   }
 
   var insertData = self._prepInsert(self.single.insert);
@@ -84,26 +74,38 @@ QueryCompiler_Oracle.prototype.insert = function() {
   }
 
   if (insertData.values.length === 1) {
-    return self._addReturningToSqlAndConvert('insert into ' + self.tableName + ' (' + self.formatter.columnize(insertData.columns) + ') values (' + self.formatter.parameterize(insertData.values[0]) + ')', returning);
+    return self._addReturningToSqlAndConvert('insert into ' + self.tableName + ' (' + self.formatter.columnize(insertData.columns) + ') values (' + self.formatter.parameterize(insertData.values[0]) + ')', returning, self.tableName);
   }
 
   var sql = {};
   sql.sql = 'begin ' +
     _.map(insertData.values, function (value) {
+        var returningHelper;
         var parameterizedValues = self.formatter.parameterize(value);
-        var returningInfo = self._returningParams(returning);
-        var subSql = 'insert into ' + self.tableName + ' (' + self.formatter.columnize(insertData.columns) + ') values (' + parameterizedValues + ')' + (returningInfo ? ' returning ' + returningInfo.columns + ' into ' + returningInfo.outParams : '');
+        var returningValues = _.isArray(returning) ? returning : [returning];
+
+        if (returning) {
+          returningHelper = new ReturningHelper(returningValues.join(':'));
+          sql.outParams = (sql.outParams || []).concat(returningHelper);
+        }
+
+        var subSql = 'insert into ' + self.tableName + ' (' + self.formatter.columnize(insertData.columns) + ') values (' + parameterizedValues + ')' + (returning ? ' returning ROWID into ' + self.formatter.parameter(returningHelper) : '');
         // pre bind position because subSql is an execute immediate parameter
         // later position binding will only convert the ? params
         subSql = self.formatter.client.positionBindings(subSql);
-
-        if (returningInfo) {
-          sql.returning = (sql.returning || []).concat(returningInfo.returning.length > 1 ? [returningInfo.returning]: returningInfo.returning);
-        }
-        return 'execute immediate \'' + subSql.replace(/'/g, "''") + '\' using ' + parameterizedValues + (returningInfo ? ', ' + returningInfo.outParams.replace(/\?/g, 'out ?') : '') + ';';
+        return 'execute immediate \'' + subSql.replace(/'/g, "''") + '\' using ' + parameterizedValues + (returning ? ', out ?' : '') + ';';
       }
     ).join(' ') +
     'end;';
+
+  if (returning) {
+    sql.returning = returning;
+    // generate select statement with special order by to keep the order because 'in (..)' may change the order
+    sql.returningSql = 'select ' + this.formatter.columnize(returning) +
+      ' from ' + self.tableName +
+      ' where ROWID in (' + sql.outParams.map(function (v, i) {return ':' + (i + 1);}).join(', ') + ')' +
+      ' order by case ROWID ' + sql.outParams.map(function (v, i) {return 'when CHARTOROWID(:' + (i + 1) + ') then ' + i;}).join(' ') + ' end';
+  }
 
   return sql;
 };

--- a/lib/dialects/oracle/runner.js
+++ b/lib/dialects/oracle/runner.js
@@ -51,30 +51,24 @@ Runner_Oracle.prototype._query = Promise.method(function(obj) {
   return new Promise(function(resolver, rejecter) {
     connection.execute(obj.sql, obj.bindings, function(err, response) {
       if (err) return rejecter(err);
-      obj.response = response;
-      resolver(obj);
+
+      if (obj.returning) {
+        var rowIds = obj.outParams.map(function (v, i) {
+          return response['returnParam' + (i ? i : '')];
+        });
+
+        return connection.execute(obj.returningSql, rowIds, function (err, subres) {
+          if (err) return rejecter(err);
+          obj.response = subres;
+          resolver(obj);
+        });
+      } else {
+        obj.response = response;
+        resolver(obj);
+      }
     });
   });
 });
-
-function convertReturningValuesToResult(response, array) {
-  var counter = 0;
-  function getNextReturnParameter() {
-    var res = response['returnParam' + (counter ? counter : '')];
-    counter += 1;
-    return res;
-  }
-
-  return array.map(function (elem) {
-    if (_.isArray(elem)) {
-      return array.reduce(function (res, helper) {
-        res[helper.columnName] = getNextReturnParameter();
-        return res;
-      }, {});
-    }
-    return getNextReturnParameter();
-  });
-}
 
 // Process the response as returned from the query.
 Runner_Oracle.prototype.processResponse = function(obj) {
@@ -94,8 +88,11 @@ Runner_Oracle.prototype.processResponse = function(obj) {
     case 'update':
     case 'counter':
       if (obj.returning) {
-        var res = convertReturningValuesToResult(response, obj.returning);
-        return res;
+        if (obj.returning.length > 1 || obj.returning[0] === '*') {
+          return response;
+        }
+        // return an array with values if only one returning value was specified
+        return _.flatten(_.map(response, _.values));
       }
       return response.updateCount;
     default:

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -516,7 +516,7 @@ module.exports = function(pgclient, mysqlclient, sqlite3client, oracleclient) {
     it("Oracle multiple inserts with returning", function() {
       chain = oracle().from('users').insert([{email: 'foo', name: 'taylor'}, {email: 'bar', name: 'dayle'}], 'id').toSQL();
 
-      expect(chain.sql).to.equal("begin execute immediate 'insert into \"users\" (\"email\", \"name\") values (:1, :2) returning \"id\" into :3' using ?, ?, out ?; execute immediate 'insert into \"users\" (\"email\", \"name\") values (:1, :2) returning \"id\" into :3' using ?, ?, out ?;end;");
+      expect(chain.sql).to.equal("begin execute immediate 'insert into \"users\" (\"email\", \"name\") values (:1, :2) returning ROWID into :3' using ?, ?, out ?; execute immediate 'insert into \"users\" (\"email\", \"name\") values (:1, :2) returning ROWID into :3' using ?, ?, out ?;end;");
       expect(chain.bindings.length).to.equal(6);
       expect(chain.bindings[0]).to.equal('foo');
       expect(chain.bindings[1]).to.equal('taylor');
@@ -528,16 +528,14 @@ module.exports = function(pgclient, mysqlclient, sqlite3client, oracleclient) {
 
     it("Oracle multiple inserts with multiple returning", function() {
       chain = oracle().from('users').insert([{email: 'foo', name: 'taylor'}, {email: 'bar', name: 'dayle'}], ['id', 'name']).toSQL();
-      expect(chain.sql).to.equal("begin execute immediate 'insert into \"users\" (\"email\", \"name\") values (:1, :2) returning \"id\", \"name\" into :3, :4' using ?, ?, out ?, out ?; execute immediate 'insert into \"users\" (\"email\", \"name\") values (:1, :2) returning \"id\", \"name\" into :3, :4' using ?, ?, out ?, out ?;end;");
-      expect(chain.bindings.length).to.equal(8);
+      expect(chain.sql).to.equal("begin execute immediate 'insert into \"users\" (\"email\", \"name\") values (:1, :2) returning ROWID into :3' using ?, ?, out ?; execute immediate 'insert into \"users\" (\"email\", \"name\") values (:1, :2) returning ROWID into :3' using ?, ?, out ?;end;");
+      expect(chain.bindings.length).to.equal(6);
       expect(chain.bindings[0]).to.equal('foo');
       expect(chain.bindings[1]).to.equal('taylor');
-      expect(chain.bindings[2].toString()).to.equal('[object ReturningHelper:id]');
-      expect(chain.bindings[3].toString()).to.equal('[object ReturningHelper:name]');
-      expect(chain.bindings[4]).to.equal('bar');
-      expect(chain.bindings[5]).to.equal('dayle');
-      expect(chain.bindings[6].toString()).to.equal('[object ReturningHelper:id]');
-      expect(chain.bindings[7].toString()).to.equal('[object ReturningHelper:name]');
+      expect(chain.bindings[2].toString()).to.equal('[object ReturningHelper:id:name]');
+      expect(chain.bindings[3]).to.equal('bar');
+      expect(chain.bindings[4]).to.equal('dayle');
+      expect(chain.bindings[5].toString()).to.equal('[object ReturningHelper:id:name]');
     });
 
     it("insert method respects raw bindings", function() {
@@ -621,7 +619,7 @@ module.exports = function(pgclient, mysqlclient, sqlite3client, oracleclient) {
 
     it("Oracle insert get id", function() {
       chain = oracle().from('users').insert({email: 'foo'}, 'id').toSQL();
-      expect(chain.sql).to.equal('insert into "users" ("email") values (?) returning "id" into ?', ['foo', '']);
+      expect(chain.sql).to.equal("insert into \"users\" (\"email\") values (?) returning ROWID into ?", ['foo', '']);
     });
 
     it("postgres insert get id", function() {


### PR DESCRIPTION
Now returning for inserts works just like postgres. I had to split the query into two separate SQL commands (insert and select) because directly returning the values requires to know the type beforehand. Before this it worked fine for integer types (which is the usual auto_increment replacement) but not for other types (e.g. char).

The problem came up while using bookshelf with a uuid as key and a forced insert which uses `insert(<values>, <idAttribute>)` by default. I think bookshelf should omit the returning <idAttribute> if the idAttribute is already specified in the <values>.
