### PR TITLE
don't throw away the postgres client's password

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -108,6 +108,7 @@ Client_PG.prototype.acquireRawConnection = Promise.method(function(callback) {
     database : connection.connectionParameters.database,
     port : connection.connectionParameters.port,
     host : connection.connectionParameters.host,
+    password : connection.connectionParameters.password
   };
 
   return new Promise(function(resolver, rejecter) {


### PR DESCRIPTION
I'm getting lots of `error: password authentication failed for user` since tgriesser/knex#390
