### PR TITLE
Fix .dropColumn in sqlite3

### DIFF
--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -30,7 +30,7 @@ SQLite3_DDL.prototype.getColumn = Promise.method(function(column) {
 
 SQLite3_DDL.prototype.ensureTransaction = Promise.method(function() {
   if (!this.runner.transaction) {
-    return this.runner.query({sql: 'begin transaction;'});
+    return this.runner.beginTransaction();
   }
 });
 


### PR DESCRIPTION
Presumably sqlite3 doesn't have an 'alter table drop column', since the code appears to be making a copy of the table, with the intent of making the table without the column being dropped, and copying the data over. However, the code was appending a comma to the table definition and using replace to remove it; this didn't work on the last column in the list, since it wasn't followed with a column. Instead, I removed the appended comma before the sanity check, then "fixed up" the query by removing redundant commas. Note: the regex should probably be //g, but since the function in question only drops one column, I felt it better to leave it this way.
