### PR TITLE
sqlite3 - fixed raw order bys

### DIFF
--- a/lib/dialects/sqlite3/query.js
+++ b/lib/dialects/sqlite3/query.js
@@ -54,16 +54,6 @@ QueryCompiler_SQLite3.prototype.insert = function() {
   return sql + ' select ' + blocks.join(' union all select ');
 };
 
-// Adds a `order by` clause to the query.
-QueryCompiler_SQLite3.prototype.order = function() {
-  var orders = this.grouped.order;
-  if (!orders) return '';
-  return 'order by ' + _.map(orders, function(order) {
-    var cols = _.isArray(order.value) ? order.value : [order.value];
-    return this.formatter.columnize(cols) + ' ' + this.formatter.direction(order.direction);
-  }, this).join(', ');
-};
-
 // Compiles an `update` query.
 QueryCompiler_SQLite3.prototype.update = function() {
   var updateData = this._prepUpdate(this.single.update);

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -620,10 +620,6 @@ module.exports = function(qb, clientName, aliasName) {
           sql: 'select * from `users` order by col NULLS LAST DESC',
           bindings: []
         },
-        sqlite3: {
-          sql: 'select * from "users" order by col NULLS LAST DESC asc',  // TODO: THIS IS WRONG
-          bindings: []
-        },
         default: {
           sql: 'select * from "users" order by col NULLS LAST DESC',
           bindings: []
@@ -633,10 +629,6 @@ module.exports = function(qb, clientName, aliasName) {
       testsql(qb().select('*').from('users').orderByRaw('col NULLS LAST DESC'), {
         mysql: {
           sql: 'select * from `users` order by col NULLS LAST DESC',
-          bindings: []
-        },
-        sqlite3: {
-          sql: 'select * from "users" order by col NULLS LAST DESC asc',  // TODO: THIS IS WRONG
           bindings: []
         },
         default: {


### PR DESCRIPTION
Fixed orderByRaw  and orderBy(raw(..)) for SQLite3 dialect by removing the outdated order implementation.
