### PR TITLE
Fixed offset without limit for mysql and sqlite3

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -75,6 +75,13 @@ QueryCompiler_MySQL.prototype.columnInfo = function() {
   };
 };
 
+QueryCompiler_MySQL.prototype.limit = function() {
+  if (!this.single.limit && !this.single.offset) return '';
+
+  // Workaround for offset only, see http://stackoverflow.com/questions/255517/mysql-offset-infinite-rows
+  return 'limit ' + ((this.single.offset && !this.single.limit) ? '18446744073709551615' : this.formatter.parameter(this.single.limit));
+};
+
 // Set the QueryBuilder & QueryCompiler on the client object,
 // incase anyone wants to modify things to suit their own purposes.
 client.QueryBuilder  = QueryBuilder_MySQL;

--- a/lib/dialects/sqlite3/query.js
+++ b/lib/dialects/sqlite3/query.js
@@ -110,6 +110,13 @@ QueryCompiler_SQLite3.prototype.columnInfo = function() {
   };
 };
 
+QueryCompiler_SQLite3.prototype.limit = function() {
+  if (!this.single.limit && !this.single.offset) return '';
+
+  // Workaround for offset only, see http://stackoverflow.com/questions/10491492/sqllite-with-skip-offset-only-not-limit
+  return 'limit ' + this.formatter.parameter((this.single.offset && !this.single.limit) ? -1 : this.single.limit);
+};
+
 client.QueryBuilder = QueryBuilder_SQLite3;
 client.QueryCompiler = QueryCompiler_SQLite3;
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -729,7 +729,7 @@ module.exports = function(qb, clientName, aliasName) {
       });
     });
 
-    it("Oracle first", function() {
+    it("first", function() {
       testsql(qb().first('*').from('users'), {
         mysql: {
           sql: 'select * from `users` limit ?',
@@ -749,15 +749,15 @@ module.exports = function(qb, clientName, aliasName) {
     it("offsets only", function() {
       testsql(qb().select('*').from('users').offset(5), {
         mysql: {
-          sql: 'select * from `users` offset ?',  // TODO: This is wrong
+          sql: 'select * from `users` limit 18446744073709551615 offset ?',
           bindings: [5]
         },
         sqlite3: {
-          sql: 'select * from "users" offset ?',  // TODO: This is wrong
-          bindings: [5]
+          sql: 'select * from "users" limit ? offset ?',
+          bindings: [-1, 5]
         },
         postgres: {
-          sql: 'select * from "users" offset ?',  // TODO: This is wrong
+          sql: 'select * from "users" offset ?',
           bindings: [5]
         },
         oracle: {


### PR DESCRIPTION
SQLite3 and MySQL do not support offset without limit. So I implemented the recommended workaround (See URLs in the source)

MySQL:

> To retrieve all rows from a certain offset up to the end of the result set, you can use some large number for the second parameter. This statement retrieves all rows from the 96th row to the last:
> 
> SELECT \* FROM tbl LIMIT 95,18446744073709551615;

SQLite3:

> If the LIMIT expression evaluates to a negative value, then there is no upper bound on the number of rows returned. 
