### PR TITLE
Fixed integration tests not closing connections

### DIFF
--- a/test/knexfile.js
+++ b/test/knexfile.js
@@ -10,8 +10,9 @@ var pool = {
     expect(connection).to.have.property('__cid');
     callback(null, connection);
   },
-  beforeDestroy: function(connection) {
+  beforeDestroy: function(connection, continueFunc) {
     expect(connection).to.have.property('__cid');
+    continueFunc();
   }
 };
 


### PR DESCRIPTION
The integration tests now correctly close the connection. 
