### PR TITLE
Fix #440, orderBy with raw argument should use direction

### DIFF
--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -267,20 +267,12 @@ QueryCompiler.prototype.counter = function() {
 QueryCompiler.prototype._groupsOrders = function(type) {
   var items = this.grouped[type];
   if (!items) return '';
-  var sql = [];
-  for (var i = 0, l = items.length; i < l; i++) {
-    var str, item = items[i];
-    if (item.value instanceof Raw) {
-      str = this.formatter.checkRaw(item.value);
-    } else {
-      str = this.formatter.columnize(item.value);
-      if (type === 'order') {
-        str += ' ' + this.formatter.direction(item.direction);
-      }
-    }
-    sql.push(str);
-  }
-  return sql.length > 0 ? type + ' by ' + sql.join(', ') : '';
+  var formatter = this.formatter;
+  var sql = items.map(function (item) {
+    return (item.value instanceof Raw ? formatter.checkRaw(item.value) : formatter.columnize(item.value)) +
+      ((type === 'order' && item.type !== 'orderByRaw') ? ' ' + formatter.direction(item.direction) : '');
+  });
+  return sql.length ? type + ' by ' + sql.join(', ') : '';
 };
 
 // Where Clause

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -614,8 +614,34 @@ module.exports = function(qb, clientName, aliasName) {
       });
     });
 
-    it("raw order bys", function() {
-      testsql(qb().select('*').from('users').orderBy(raw('col NULLS LAST DESC')), {
+    it("raw order bys with default direction", function() {
+      testsql(qb().select('*').from('users').orderBy(raw('col NULLS LAST')), {
+        mysql: {
+          sql: 'select * from `users` order by col NULLS LAST asc',
+          bindings: []
+        },
+        default: {
+          sql: 'select * from "users" order by col NULLS LAST asc',
+          bindings: []
+        }
+      });
+    });
+
+    it("raw order bys with specified direction", function() {
+      testsql(qb().select('*').from('users').orderBy(raw('col NULLS LAST'), 'desc'), {
+        mysql: {
+          sql: 'select * from `users` order by col NULLS LAST desc',
+          bindings: []
+        },
+        default: {
+          sql: 'select * from "users" order by col NULLS LAST desc',
+          bindings: []
+        }
+      });
+    });
+
+    it("orderByRaw", function() {
+      testsql(qb().select('*').from('users').orderByRaw('col NULLS LAST DESC'), {
         mysql: {
           sql: 'select * from `users` order by col NULLS LAST DESC',
           bindings: []
@@ -625,15 +651,17 @@ module.exports = function(qb, clientName, aliasName) {
           bindings: []
         }
       });
+    });
 
-      testsql(qb().select('*').from('users').orderByRaw('col NULLS LAST DESC'), {
+    it("orderByRaw second argument is the binding", function() {
+      testsql(qb().select('*').from('users').orderByRaw('col NULLS LAST ?', 'dEsc'), {
         mysql: {
-          sql: 'select * from `users` order by col NULLS LAST DESC',
-          bindings: []
+          sql: 'select * from `users` order by col NULLS LAST ?',
+          bindings: ['dEsc']
         },
         default: {
-          sql: 'select * from "users" order by col NULLS LAST DESC',
-          bindings: []
+          sql: 'select * from "users" order by col NULLS LAST ?',
+          bindings: ['dEsc']
         }
       });
     });


### PR DESCRIPTION
If the first argument for orderBy() is a raw value it will now add the 'asc' (default), or the 2nd argument for direction.
