### PR TITLE
Prevent executing a query when no connection exists

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -116,6 +116,9 @@ Runner.prototype.pipe = function(writable) {
 // to run in sequence, and on the same connection, especially helpful when schema building
 // and dealing with foreign key constraints, etc.
 Runner.prototype.query = Promise.method(function(obj) {
+  if (!this.connection) {
+    throw new Error('There is an error with the database connection. Please check your config.');
+  }
   obj.__cid = this.connection.__cid;
   this.builder.emit('query', obj);
   this.client.emit('query', obj);


### PR DESCRIPTION
I am not sure whether this is the best course of action, but it prevents errors like `cannot read property _cid of undefined.` from appearing and provides a clean error message. 

This is related to issues at Ghost (https://ghost.org/forum/installation/10207-error-cannot-read-property-__cid-of-undefined-at-runner_sqlite3-anonymous/) where either the file name for SQLite3 is missing or there are connection troubles with other databases.

A different solution would be to provide a `knex.checkConnection()` method that returns whether knex can interact with the database before sending off queries. Suggestions very welcome! 
