### PR TITLE
Check for transaction before committing or rolling back

### DIFF
--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -30,7 +30,7 @@ SQLite3_DDL.prototype.getColumn = Promise.method(function(column) {
 
 SQLite3_DDL.prototype.ensureTransaction = Promise.method(function() {
   if (!this.runner.transaction) {
-    return this.runner.query({sql: 'begin transaction;'});
+    return this.runner.beginTransaction();
   }
 });
 
@@ -146,7 +146,7 @@ SQLite3_DDL.prototype.dropColumn = Promise.method(function(column) {
     .then(this.getTableSql)
     .then(function(sql) {
       var createTable = sql[0];
-      var a = this.formatter.wrap(column) + ' ' + currentCol.type + ', ';
+      var a = this.formatter.wrap(column) + ' ' + currentCol.type;
       if (createTable.sql.indexOf(a) === -1) {
         throw new Error('Unable to find the column to change');
       }
@@ -155,7 +155,7 @@ SQLite3_DDL.prototype.dropColumn = Promise.method(function(column) {
         .then(this.copyData)
         .then(this.dropOriginal)
         .then(function() {
-          return this.runner.query({sql: createTable.sql.replace(a, '')});
+          return this.runner.query({sql: createTable.sql.replace(a, '').replace(/,\s*([,)])/, '$1')});
         })
         .then(this.reinsertData(function(row) {
           return _.omit(row, column);


### PR DESCRIPTION
In `.renameColumn` (and probably elsewhere), some commands are run in the promise chain before `.ensureTransaction`; in certain cases, these may fail, in which case the `.catch` handler attempts to roll back the transaction when it doesn't exist. This causes a useless error to be thrown about a transaction as opposed to the error that actually caused the problem (for example, column name doesn't exist in table)
