### PR TITLE
Fixes #319. Inserting multiple rows with default values

### DIFF
--- a/lib/dialects/oracle/query.js
+++ b/lib/dialects/oracle/query.js
@@ -65,11 +65,18 @@ QueryCompiler_Oracle.prototype.insert = function() {
     returning = [returning];
   }
 
+  if (_.isArray(self.single.insert) && (self.single.insert.length === 1) && _.isEmpty(self.single.insert[0])) {
+    self.single.insert = [];
+  }
+
   if (_.isEmpty(self.single.insert) && !_.isFunction(this.single.insert)) {
     return self._addReturningToSqlAndConvert('insert into ' + self.tableName + ' (' + self.formatter.wrap(self.single.returning) + ') values (default)', returning, self.tableName);
   }
 
   var insertData = self._prepInsert(self.single.insert);
+
+  var sql = {};
+
   if (_.isString(insertData)) {
     return self._addReturningToSqlAndConvert('insert into ' + self.tableName + ' ' + insertData, returning);
   }
@@ -78,23 +85,36 @@ QueryCompiler_Oracle.prototype.insert = function() {
     return self._addReturningToSqlAndConvert('insert into ' + self.tableName + ' (' + self.formatter.columnize(insertData.columns) + ') values (' + self.formatter.parameterize(insertData.values[0]) + ')', returning, self.tableName);
   }
 
-  var sql = {};
+  var insertDefaultsOnly = (insertData.columns.length === 0);
+
   sql.sql = 'begin ' +
     _.map(insertData.values, function (value) {
         var returningHelper;
-        var parameterizedValues = self.formatter.parameterize(value);
+        var parameterizedValues = !insertDefaultsOnly ? self.formatter.parameterize(value) : '';
         var returningValues = _.isArray(returning) ? returning : [returning];
+        var subSql = 'insert into ' + self.tableName + ' ';
 
         if (returning) {
           returningHelper = new ReturningHelper(returningValues.join(':'));
           sql.outParams = (sql.outParams || []).concat(returningHelper);
         }
 
-        var subSql = 'insert into ' + self.tableName + ' (' + self.formatter.columnize(insertData.columns) + ') values (' + parameterizedValues + ')' + (returning ? ' returning ROWID into ' + self.formatter.parameter(returningHelper) : '');
+        if (insertDefaultsOnly) {
+          // no columns given so only the default value
+          subSql += '(' + self.formatter.wrap(self.single.returning) + ') values (default)';
+        } else {
+          subSql += '(' + self.formatter.columnize(insertData.columns) + ') values (' + parameterizedValues + ')';
+        }
+        subSql += (returning ? ' returning ROWID into ' + self.formatter.parameter(returningHelper) : '');
+
         // pre bind position because subSql is an execute immediate parameter
         // later position binding will only convert the ? params
         subSql = self.formatter.client.positionBindings(subSql);
-        return 'execute immediate \'' + subSql.replace(/'/g, "''") + '\' using ' + parameterizedValues + (returning ? ', out ?' : '') + ';';
+        return 'execute immediate \'' + subSql.replace(/'/g, "''") +
+          ((parameterizedValues || returning) ? '\' using ' : '') +
+          parameterizedValues +
+          ((parameterizedValues && returning) ? ', ' : '') +
+          (returning ? 'out ?' : '') + ';';
       }
     ).join(' ') +
     'end;';

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -39,10 +39,39 @@ QueryCompiler_PG.prototype.truncate = function() {
 // Used when the insert call is empty.
 QueryCompiler_PG.prototype._emptyInsertValue = 'default values';
 
+// is used if the an array with multiple empty values supplied
+QueryCompiler_PG.prototype._defaultInsertValue = 'default';
+
 // Compiles an `insert` query, allowing for multiple
 // inserts using a single query statement.
 QueryCompiler_PG.prototype.insert = function() {
-  var sql = QueryCompiler.prototype.insert.call(this);
+  var self = this;
+  var insertValues = this.single.insert;
+
+  var sql = 'insert into ' + this.tableName + ' ';
+
+  if (_.isArray(insertValues) && (insertValues.length === 1) && _.isEmpty(insertValues[0])) {
+    insertValues = [];
+  }
+
+  if (_.isEmpty(insertValues) && !_.isFunction(insertValues)) {
+    sql += this._emptyInsertValue;
+  } else {
+    var insertData = this._prepInsert(insertValues);
+
+    if (_.isString(insertData)) {
+      sql += insertData;
+    } else  {
+      if (insertData.columns.length) {
+        sql += '(' + this.formatter.columnize(insertData.columns) + ') values (' +
+          _.map(insertData.values, this.formatter.parameterize, this.formatter).join('), (') + ')';
+      } else {
+        // if there is no target column only insert default values
+        sql += '(' + self.formatter.wrap(self.single.returning) + ') values ' + _.map(insertData.values, function () { return '(' + (self._defaultInsertValue || '') + ')'; }).join(', ');
+      }
+    }
+  }
+
   var returning  = this.single.returning;
   return {
     sql: sql + this._returning(returning),

--- a/lib/dialects/sqlite3/query.js
+++ b/lib/dialects/sqlite3/query.js
@@ -38,7 +38,12 @@ QueryCompiler_SQLite3.prototype.forUpdate = function() {
 QueryCompiler_SQLite3.prototype.insert = function() {
   var insert = this.single.insert;
   var sql = 'insert into ' + this.tableName + ' ';
-  if (_.isEmpty(this.single.insert) && !_.isFunction(this.single.insert)) {
+
+  if (_.isArray(insert) && (insert.length === 1) && _.isEmpty(insert[0])) {
+    insert = [];
+  }
+
+  if (_.isEmpty(insert) && !_.isFunction(insert)) {
     return sql + 'default values';
   }
   var insertData = this._prepInsert(insert);

--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -64,16 +64,30 @@ QueryCompiler.prototype.pluck = function() {
 // Compiles an "insert" query, allowing for multiple
 // inserts using a single query statement.
 QueryCompiler.prototype.insert = function() {
+  var self = this;
+  var insertValues = this.single.insert;
+
   var sql = 'insert into ' + this.tableName + ' ';
-  if (_.isEmpty(this.single.insert) && !_.isFunction(this.single.insert)) {
+
+  if (_.isArray(insertValues) && (insertValues.length === 1) && _.isEmpty(insertValues[0])) {
+    insertValues = [];
+  }
+
+  if (_.isEmpty(insertValues) && !_.isFunction(insertValues)) {
     sql += this._emptyInsertValue;
   } else {
-    var insertData = this._prepInsert(this.single.insert);
+    var insertData = this._prepInsert(insertValues);
+
     if (_.isString(insertData)) {
       sql += insertData;
     } else  {
-      sql += '(' + this.formatter.columnize(insertData.columns) + ') values (' +
-        _.map(insertData.values, this.formatter.parameterize, this.formatter).join('), (') + ')';
+      if (insertData.columns.length) {
+        sql += '(' + this.formatter.columnize(insertData.columns) + ') values (' +
+          _.map(insertData.values, this.formatter.parameterize, this.formatter).join('), (') + ')';
+      } else {
+        // if there is no target column only insert default values
+        sql += '() values ' + _.map(insertData.values, function () { return '(' + (self._defaultInsertValue || '') + ')'; }).join(', ');
+      }
     }
   }
   return sql;

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -32,6 +32,8 @@ module.exports = function(knex) {
             .dropTableIfExists('migration_test_2')
             .dropTableIfExists('migration_test_2_1')
             .dropTableIfExists('test_default_table')
+            .dropTableIfExists('test_default_table2')
+            .dropTableIfExists('test_default_table3')
             .dropTableIfExists('knex_migrations')
             .dropTableIfExists('bool_test')
         ]);


### PR DESCRIPTION
If an array with one empty object or null etc. is specified knex will now insert the default value correctly for all dialects.

If an array with multiple empty object or null etc.is specified knex will now:
- insert multiple rows with default values for MySQL and derivatives
- insert multiple rows with default values for Oracle and PostgreSQL if a returning column is specified, otherwise **fail**
- **fail** with SQLite.
