### PR TITLE
migration config support both absolute and relative paths

### DIFF
--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -260,7 +260,7 @@ Migrator.prototype._waterfallBatch = function(batchNo, migrations, direction) {
 };
 
 Migrator.prototype._absoluteConfigDir = function() {
-  return path.join(process.cwd(), this.config.directory);
+  return path.resolve(process.cwd(), this.config.directory);
 };
 
 Migrator.prototype.setConfig = function(config) {


### PR DESCRIPTION
The change in #391 to add support for relative paths in the migration config ended up breaking support for specifying absolute paths.

Changing path.join to path.resolve should work for both cases.
