### PR TITLE
fix off-by-one error in sqlite insertChunked

### DIFF
--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -82,6 +82,7 @@ SQLite3_DDL.prototype.insertChunked = function(amount, target, iterator) {
     var ddl = this;
     return Promise.reduce(result, function(memo, row) {
       memo++;
+      batch.push(row);
       if (memo % 20 === 0 || memo === result.length) {
         return new client.QueryBuilder()
           .connection(ddl.runner.connection)
@@ -90,7 +91,6 @@ SQLite3_DDL.prototype.insertChunked = function(amount, target, iterator) {
           .then(function() { batch = []; })
           .thenReturn(memo);
       }
-      batch.push(row);
       return memo;
     }, 0);
   };


### PR DESCRIPTION
I was looking into an issue with sqlite renaming columns and as part of that debugging I noticed that insertChunked for a table with a single row was inserting a batch with 0 entries in it.

It looks like this is due to a simple off-by-one logic error in the computation of when the reduce loop should end, since memo is incremented before the row is added to the batch, so when memo === result.length, there's still one row left to add to the batch.

I don't know this codebase well enough to craft a test for this, but by inspection it seems to me like the previous version would have dropped the last row every time, which seems like an egregious error that I'm surprised wasn't noticed previously.
