### PR TITLE
Continuously release docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,6 @@ matrix:
   allow_failures:
     - node_js: '0.11'
   fast_finish: true
+
+after_script:
+  - npm run-script docs

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,10 +116,16 @@ gulp.task('release', function() {
         'npm publish',
         'git push',
         'git push --tags',
-        'git checkout gh-pages',
-        'git merge master',
-        'git push',
-        'git checkout master'
+        'gulp docs'
       ])();
     });
+});
+
+gulp.task('docs', function() {
+  return shell.task([
+    'git checkout gh-pages',
+    'git merge master',
+    'git push',
+    'git checkout master'
+  ])();
 });

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test": "npm run jshint && istanbul --config=test/.istanbul.yml cover _mocha -- --check-leaks -t 5000 -b -R spec test/index.js",
     "coveralls": "cat ./test/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "jshint": "gulp jshint",
+    "docs": "gulp docs",
     "release:patch": "gulp jshint && npm test && gulp build && gulp bump --type patch && gulp release",
     "release:minor": "gulp jshint && npm test && gulp build && gulp bump --type minor && gulp release"
   },


### PR DESCRIPTION
Instead of having docs only updated on releases, I've updated things to release from Travis. Technically this'll run a bunch of times unnecessarily (like on branches other than master) but the merge will be a noop so I didn't bother to handle those cases.
