### PR TITLE
Support for .join(table, raw) and join using

### DIFF
--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -141,26 +141,20 @@ QueryCompiler.prototype.aggregate = function(stmt) {
 QueryCompiler.prototype.join = function() {
   var joins = this.grouped.join;
   if (!joins) return '';
-  var sql = [];
-  for (var i = 0, l = joins.length; i < l; i++) {
-    var str, stmt = joins[i];
-    if (stmt.joinType === 'raw') {
-      str = this.formatter.checkRaw(stmt.table);
+  var sql = _.reduce(joins, function(acc, join) {
+    if (join.joinType === 'raw') {
+      acc.push(this.formatter.checkRaw(join.table));
     } else {
-      str = stmt.joinType + ' join ' + this.formatter.wrap(stmt.table);
-      for (var i2 = 0, l2 = stmt.clauses.length; i2 < l2; i2++) {
-        var clause = stmt.clauses[i2];
-        if (i2 > 0) {
-          str += ' ' + clause[1] + ' ';
-        } else {
-          str += ' on ';
-        }
-        str += this.formatter.wrap(clause[2]) + ' ' + this.formatter.operator(clause[3]) +
-          ' ' + this.formatter.wrap(clause[4]);
-      }
+      acc.push(join.joinType + ' join ' + this.formatter.wrap(join.table));
+      _.each(join.clauses, function(clause, i) {
+        acc.push(i > 0 ? clause[1] : clause[0]);
+        acc.push(this.formatter.wrap(clause[2]));
+        if (clause[3]) acc.push(this.formatter.operator(clause[3]));
+        if (clause[4]) acc.push(this.formatter.wrap(clause[4]));
+      }, this);
     }
-    sql.push(str);
-  }
+    return acc;
+  }, [], this);
   return sql.length > 0 ? sql.join(' ') : '';
 };
 

--- a/lib/query/joinclause.js
+++ b/lib/query/joinclause.js
@@ -17,13 +17,18 @@ JoinClause.prototype.grouping = 'join';
 // Adds an "on" clause to the current join object.
 JoinClause.prototype.on = function(first, operator, second) {
   var data;
-  if (arguments.length === 2) {
-    data = ['on', this._bool(), first, '=', operator];
-  } else {
-    data = ['on', this._bool(), first, operator, second];
+  switch (arguments.length) {
+    case 1:  data = ['on', this._bool(), first]; break;
+    case 2:  data = ['on', this._bool(), first, '=', operator]; break;
+    default: data = ['on', this._bool(), first, operator, second];
   }
   this.clauses.push(data);
   return this;
+};
+
+// Adds a "using" clause to the current join.
+JoinClause.prototype.using = function(table) {
+  return this.clauses.push(['using', this._bool(), table]);
 };
 
 // Adds an "and on" clause to the current join object.

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -1994,6 +1994,32 @@ module.exports = function(qb, clientName, aliasName) {
       });
     });
 
+    it('allows a raw query in the second param', function() {
+      testsql(qb().select('*').from('accounts').innerJoin(
+        'table1', raw('ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))')
+      ), {
+        mysql: {
+          sql: 'select * from `accounts` inner join `table1` on ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))'
+        },
+        default: {
+          sql: 'select * from "accounts" inner join "table1" on ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))'
+        }
+      });
+    });
+
+    it('allows join "using"', function() {
+      testsql(qb().select('*').from('accounts').innerJoin('table1', function() {
+        this.using('id');
+      }), {
+        mysql: {
+          sql: 'select * from `accounts` inner join `table1` using `id`'
+        },
+        default: {
+          sql: 'select * from "accounts" inner join "table1" using "id"'
+        }
+      });
+    });
+
     it('allows sub-query function on insert, #427', function() {
       testsql(qb().into('votes').insert(function() {
         this.select('*').from('votes').where('id', 99);


### PR DESCRIPTION
Adds support for `.join(tableName, rawQuery)` as well as 

``` js
.join(tableName, function() { 
   this.using(table); 
})
```

The case that brought it up was that

``` sql
.innerJoin('buildings_building', knex.raw('ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))'))
```

would output:

``` sql
inner join buildings_building
on ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))
```

On the second, I forget, I think someone brought up using as a potential join feature somewhere.

Tests added & pass but figured another set of eyes on it might be good, @vschoettke or @bendrucker?
