### PR TITLE
Added knex.migrate.to and knex.migrate.before

### DIFF
--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -67,6 +67,46 @@ Migrator.prototype.rollback = Promise.method(function(config) {
     });
 });
 
+// Migrate either up or to the specified version.
+// The database will be in the state after this migration has been applied.
+Migrator.prototype.to = Promise.method(function(version, config) {
+  this.config = this.setConfig(config);
+    return this._migrationData()
+      .tap(validateMigrationList)
+      .bind(this)
+      .spread(function(all, completed) {
+        if (version === null || version === 'none') {
+          return this._runBatch(completed.reverse(), 'down');
+        } else {
+          var allIndex = all.indexOf(version),
+            completedIndex = completed.indexOf(version);
+          if (allIndex === -1) {
+            throw new Error('A migration file named `'+version+'` does not exist.');
+          }
+          if (completedIndex !== -1) {
+            return this._runBatch(completed.slice(completedIndex + 1).reverse(), 'down');
+          } else {
+            return this._runBatch(_.difference(all.slice(0, allIndex + 1), completed), 'up');
+          }
+        }
+      });
+});
+
+// Migrate either up or to the predecessor of the specified version.
+// The database will be in the state right before this migration would have been applied.
+Migrator.prototype.before = Promise.method(function(beforeVersion, config) {
+  this.config = this.setConfig(config);
+  return this._listAll()
+    .bind(this)
+    .then(function(all) {
+      var idx = all.indexOf(beforeVersion);
+      if (idx === -1) {
+        throw new Error('A migration file named `'+beforeVersion+'` does not exist.');
+      }
+      return this.to(all[idx - 1] || null, config);
+    });
+});
+
 // Retrieves and returns the current migration version
 // we're on, as a promise. If there aren't any migrations run yet,
 // return "none" as the value for the `currentVersion`.

--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -36,6 +36,25 @@ var yyyymmddhhmmss = function() {
       padDate(d.getSeconds());
 };
 
+//Attempts to find the index of `needle` in `haystack` by exact match.
+//If not found, it falls back to finding the index of an item in `haystack`
+//which integer part equals `needle`.
+var indexOfVersion = function(haystack, needle) {
+  needle = String(needle);
+  var i = haystack.indexOf(needle);
+  if (i !== -1) {
+    return i;
+  }
+  var intPart;
+  for (i = 0; i < haystack.length; i++) {
+    intPart = haystack[i].split('_', 2)[0];
+    if (needle === intPart) {
+      return i;
+    }
+  }
+  return -1;
+};
+
 // The new migration we're performing, typically called from the `knex.migrate`
 // interface on the main `knex` object. Passes the `knex` instance performing
 // the migration.
@@ -78,8 +97,8 @@ Migrator.prototype.to = Promise.method(function(version, config) {
         if (version === null || version === 'none') {
           return this._runBatch(completed.reverse(), 'down');
         } else {
-          var allIndex = all.indexOf(version),
-            completedIndex = completed.indexOf(version);
+          var allIndex = indexOfVersion(all, version),
+            completedIndex = indexOfVersion(completed, version);
           if (allIndex === -1) {
             throw new Error('A migration file named `'+version+'` does not exist.');
           }
@@ -99,7 +118,7 @@ Migrator.prototype.before = Promise.method(function(beforeVersion, config) {
   return this._listAll()
     .bind(this)
     .then(function(all) {
-      var idx = all.indexOf(beforeVersion);
+      var idx = indexOfVersion(all, beforeVersion);
       if (idx === -1) {
         throw new Error('A migration file named `'+beforeVersion+'` does not exist.');
       }

--- a/lib/migrate/migrate-stub.js
+++ b/lib/migrate/migrate-stub.js
@@ -16,5 +16,7 @@ StubMigrate.prototype = {
   make: noSuchMethod,
   latest: noSuchMethod,
   rollback: noSuchMethod,
+  to: noSuchMethod,
+  before: noSuchMethod,
   currentVersion: noSuchMethod
 };

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -218,6 +218,27 @@ module.exports = function(knex) {
 
       });
 
+      describe('using only integer part of migration name', function() {
+
+        before(function() {
+          return knex.migrate.to(20131019235306, config);
+        });
+
+        after(function() {
+          return resetTables();
+        });
+
+        it('runs up-migrations up to and including the target', function() {
+          return getCompletedMigrations().then(function(names) {
+            expect(names).to.deep.equal([
+              '20131019235242_migration_1.js',
+              '20131019235306_migration_2.js'
+            ]);
+          });
+        });
+
+      });
+
       describe('from empty to empty', function() {
         before(function() {
           return knex.migrate.to(null, config);
@@ -301,6 +322,26 @@ module.exports = function(knex) {
         });
 
         it('does nothing', function() {
+          return getCompletedMigrations().then(function(names) {
+            expect(names).to.deep.equal([
+              '20131019235242_migration_1.js'
+            ]);
+          });
+        });
+
+      });
+
+      describe('using only integer part of migration name', function() {
+
+        before(function() {
+          return knex.migrate.before(20131019235306, config);
+        });
+
+        after(function() {
+          return resetTables();
+        });
+
+        it('runs up-migrations up to excluding the target', function() {
           return getCompletedMigrations().then(function(names) {
             expect(names).to.deep.equal([
               '20131019235242_migration_1.js'

--- a/test/integration/migrate/index.js
+++ b/test/integration/migrate/index.js
@@ -7,51 +7,68 @@ var rimraf   = require('rimraf');
 var Promise  = require('../../../lib/promise');
 
 module.exports = function(knex) {
-
-  require('rimraf').sync(path.join(__dirname, './migration'));
-
   describe('knex.migrate', function () {
 
-    it('should create a new migration file with the create method', function() {
-      return knex.migrate.make('test').then(function(name) {
-        name = path.basename(name);
-        expect(name.split('_')[0]).to.have.length(14);
-        expect(name.split('_')[1].split('.')[0]).to.equal('test');
-      });
-    });
+    var tables = ['migration_test_1', 'migration_test_2', 'migration_test_2_1', 'migration_test_3'];
 
-    it('should list the current migration state with the currentVersion method', function() {
-      return knex.migrate.currentVersion().then(function(version) {
-        equal(version, 'none');
-      });
-    });
+    var config = {directory: 'test/integration/migrate/test'};
 
-    var tables = ['migration_test_1', 'migration_test_2', 'migration_test_2_1'];
+    function resetTables() {
+      return Promise.all(['knex_migrations'].concat(tables).map(function(table) {
+        return knex.schema.dropTableIfExists(table);
+      }));
+    }
+
+    function getCompletedMigrations() {
+      var orderBy = knex.client.dialect === 'oracle' ? 'migration_time' : 'id';
+      return knex('knex_migrations').orderBy(orderBy, 'asc').select('*')
+        .then(function(rows) {
+          return rows.map(function(row) {
+            return row.name;
+          });
+        });
+    }
+
+    describe('knex.migrate.make', function() {
+
+      after(function() {
+        rimraf.sync(path.join(__dirname, './migration'));
+      });
+
+      it('should create a new migration file with the create method', function() {
+        return knex.migrate.make('test').then(function(name) {
+          name = path.basename(name);
+          expect(name.split('_')[0]).to.have.length(14);
+          expect(name.split('_')[1].split('.')[0]).to.equal('test');
+        });
+      });
+
+    });
 
     describe('knex.migrate.latest', function() {
 
       before(function() {
-        return knex.migrate.latest({directory: 'test/integration/migrate/test'});
+        return knex.migrate.latest(config);
+      });
+
+      after(function() {
+        return resetTables();
       });
 
       it('should run all migration files in the specified directory', function() {
         return knex('knex_migrations').select('*').then(function(data) {
-          expect(data.length).to.equal(2);
+          expect(data.length).to.equal(3);
         });
       });
 
       it('should run the migrations from oldest to newest', function() {
-        if (knex.client.dialect === 'oracle') {
-          return knex('knex_migrations').orderBy('migration_time', 'asc').select('*').then(function(data) {
-            expect(path.basename(data[0].name)).to.equal('20131019235242_migration_1.js');
-            expect(path.basename(data[1].name)).to.equal('20131019235306_migration_2.js');
-          });
-        } else {
-          return knex('knex_migrations').orderBy('id', 'asc').select('*').then(function(data) {
-            expect(path.basename(data[0].name)).to.equal('20131019235242_migration_1.js');
-            expect(path.basename(data[1].name)).to.equal('20131019235306_migration_2.js');
-          });
-        }
+        return getCompletedMigrations().then(function(names) {
+          expect(names).to.deep.equal([
+            '20131019235242_migration_1.js',
+            '20131019235306_migration_2.js',
+            '20141001120000_migration_3.js'
+          ]);
+        });
       });
 
       it('should create all specified tables and columns', function() {
@@ -78,11 +95,17 @@ module.exports = function(knex) {
     });
 
     describe('knex.migrate.rollback', function() {
-      it('should delete the most recent batch from the migration log', function() {
-        return knex.migrate.rollback({directory: 'test/integration/migrate/test'}).then(function() {
-          return knex('knex_migrations').select('*').then(function(data) {
-            expect(data.length).to.equal(0);
+
+      before(function() {
+        return knex.migrate.latest(config)
+          .then(function() {
+            return knex.migrate.rollback(config);
           });
+      });
+
+      it('should delete the most recent batch from the migration log', function() {
+        return knex('knex_migrations').select('*').then(function(data) {
+          expect(data.length).to.equal(0);
         });
       });
 
@@ -93,12 +116,264 @@ module.exports = function(knex) {
           });
         });
       });
+
     });
 
-    after(function() {
-      rimraf.sync(path.join(__dirname, './migration'));
+    describe('knex.migrate.to', function() {
+
+      it('unknown version fails', function() {
+        return knex.migrate.to('i_am_not_here', config)
+          .then(function() {
+            throw new Error('Incorrect version name should fail.');
+          }, function(e) {
+            expect(e.message).to.equal('A migration file named `i_am_not_here` does not exist.');
+          });
+      });
+
+      describe('migrating up', function() {
+
+        before(function() {
+          return knex.migrate.to('20131019235306_migration_2.js', config);
+        });
+
+        after(function() {
+          return resetTables();
+        });
+
+        it('runs up-migrations up to and including the target', function() {
+          return getCompletedMigrations().then(function(names) {
+            expect(names).to.deep.equal([
+              '20131019235242_migration_1.js',
+              '20131019235306_migration_2.js'
+            ]);
+          });
+        });
+
+      });
+
+      describe('migrating down', function() {
+
+        before(function() {
+          return knex.migrate.latest(config)
+            .then(function() {
+              return knex.migrate.to('20131019235242_migration_1.js', config);
+            });
+        });
+
+        after(function() {
+          return resetTables();
+        });
+
+        it('runs down-migrations down to excluding the target', function() {
+          return getCompletedMigrations().then(function(names) {
+            expect(names).to.deep.equal([
+              '20131019235242_migration_1.js'
+            ]);
+          });
+        });
+
+      });
+
+      describe('migrating down to nothing', function() {
+
+        before(function() {
+          return knex.migrate.latest(config)
+            .then(function() {
+              return knex.migrate.to(null, config);
+            });
+        });
+
+        after(function() {
+          return resetTables();
+        });
+
+        it('runs all down-migrations', function() {
+          return getCompletedMigrations().then(function(names) {
+            expect(names).to.deep.equal([]);
+          });
+        });
+
+      });
+
+      describe('to current version', function() {
+
+        before(function() {
+          return knex.migrate.to('20131019235242_migration_1.js', config)
+            .then(function() {
+              return knex.migrate.to('20131019235242_migration_1.js', config);
+            });
+        });
+
+        after(function() {
+          return resetTables();
+        });
+
+        it('does nothing', function() {
+          return getCompletedMigrations().then(function(names) {
+            expect(names).to.deep.equal([
+              '20131019235242_migration_1.js'
+            ]);
+          });
+        });
+
+      });
+
+      describe('from empty to empty', function() {
+        before(function() {
+          return knex.migrate.to(null, config);
+        });
+
+        it('does nothing', function() {
+          return getCompletedMigrations().then(function(names) {
+            expect(names).to.deep.equal([]);
+          });
+        });
+
+      });
+
+    });
+
+    describe('knex.migrate.before', function() {
+
+      it('unknown version fails', function() {
+        return knex.migrate.before('i_am_not_here', config)
+          .then(function() {
+            throw new Error('Incorrect version name should fail.');
+          }, function(e) {
+            expect(e.message).to.equal('A migration file named `i_am_not_here` does not exist.');
+          });
+      });
+
+      describe('migrating up', function() {
+
+        before(function() {
+          return knex.migrate.before('20131019235306_migration_2.js', config);
+        });
+
+        after(function() {
+          return resetTables();
+        });
+
+        it('runs up-migrations up to excluding the target', function() {
+          return getCompletedMigrations().then(function(names) {
+            expect(names).to.deep.equal([
+              '20131019235242_migration_1.js'
+            ]);
+          });
+        });
+
+      });
+
+      describe('migrating down', function() {
+
+        before(function() {
+          return knex.migrate.latest(config)
+            .then(function() {
+              return knex.migrate.before('20131019235306_migration_2.js', config);
+            });
+        });
+
+        after(function() {
+          return resetTables();
+        });
+
+        it('runs down-migrations down to and including the target', function() {
+          return getCompletedMigrations().then(function(names) {
+            expect(names).to.deep.equal([
+              '20131019235242_migration_1.js'
+            ]);
+          });
+        });
+
+      });
+
+      describe('to current version', function() {
+
+        before(function() {
+          return knex.migrate.before('20131019235306_migration_2.js', config)
+            .then(function() {
+              return knex.migrate.before('20131019235306_migration_2.js', config);
+            });
+        });
+
+        after(function() {
+          return resetTables();
+        });
+
+        it('does nothing', function() {
+          return getCompletedMigrations().then(function(names) {
+            expect(names).to.deep.equal([
+              '20131019235242_migration_1.js'
+            ]);
+          });
+        });
+
+      });
+
+      describe('from empty to empty', function() {
+        before(function() {
+          return knex.migrate.before('20131019235242_migration_1.js', config);
+        });
+
+        it('does nothing', function() {
+          return getCompletedMigrations().then(function(names) {
+            expect(names).to.deep.equal([]);
+          });
+        });
+
+      });
+
+    });
+
+    describe('knex.migrate.currentVersion', function() {
+
+      describe('when empty', function() {
+
+        it('should return none', function() {
+          return knex.migrate.currentVersion().then(function(version) {
+            equal(version, 'none');
+          });
+        });
+
+      });
+
+      describe('when up-to-date', function() {
+
+        before(function() {
+          return knex.migrate.latest(config);
+        });
+
+        after(function() {
+          return resetTables();
+        });
+
+        it('should return timestamp of latest migration', function() {
+          return knex.migrate.currentVersion().then(function(version) {
+            equal(version, '20141001120000');
+          });
+        });
+
+      });
+
+      describe('when at specific version', function() {
+
+        before(function() {
+          return knex.migrate.to('20131019235242_migration_1.js', config);
+        });
+
+        after(function() {
+          return resetTables();
+        });
+
+        it('should return timestamp of the target migration', function() {
+          return knex.migrate.currentVersion().then(function(version) {
+            equal(version, '20131019235242');
+          });
+        });
+
+      });
+
     });
 
   });
-
 };

--- a/test/integration/migrate/test/20141001120000_migration_3.js
+++ b/test/integration/migrate/test/20141001120000_migration_3.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('migration_test_3', function(t) {
+      t.increments();
+      t.string('name');
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('migration_test_3');
+};


### PR DESCRIPTION
Like described in https://github.com/tgriesser/knex/issues/506

Example usage in test:

``` js
describe('1234_my_change migration', function() {
  //First set the db in the state before the migration we're testing
  before(function() {
    return db.migrate.before('1234_my_change.js')
  })

  describe('up', function() {
    //Trigger `up` to be run
    before(function() {
      return db.migrate.to('1234_my_change.js')
    })

    it('created my_table', function() {
      return knex.schema.hasTable('my_table')
        .then(function(exists) {
          assert(exists)
        })
    })
  })

  describe('down', function() {
    //Trigger `down` to be run
    before(function() {
      return db.migrate.before('1234_my_change.js')
    })

    it('dropped my_table', function() {
      return knex.schema.hasTable('my_table')
        .then(function(exists) {
          assert(!exists)
        })
    })
  })
})
```

I also cleaned up the migration integration tests a bit. Isolated the tests for each method more and made sure that they each clean up after themselves.

Questions:
1. Should the name of the version be the complete filename? E.g. do you say `knex.migrate.to('12345678_my_thing.js')` or `knex.migrate.to('12345678')`? I prefer the first one, as there is no checks AFAICS whether the integer part is unique.

Let me know if there is anything you want me to look at.
