### PR TITLE
Change seed generation to have same directory behaviour as migration

### DIFF
--- a/lib/seed/index.js
+++ b/lib/seed/index.js
@@ -133,7 +133,7 @@ Seeder.prototype._waterfallBatch = function(seeds) {
 };
 
 Seeder.prototype._absoluteConfigDir = function() {
-  return path.join(process.cwd(), this.config.directory);
+  return path.resolve(process.cwd(), this.config.directory);
 };
 
 Seeder.prototype.setConfig = function(config) {


### PR DESCRIPTION
Change to seed behaviour to use the same path resolution as migration - essentially, replicating change SHA: b7672df53623dc9112c13120fc46eca5a48e5dd4 by @demmer

Primarily for consistency.
