### PR TITLE
Support strong-oracle driver.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ var jshint     = require('gulp-jshint');
 
 var excluded = {
   oracle:   ['oracle'],
+  "strong-oracle":   ['strong-oracle'],
   mariasql: ['mariasql'],
   sqlite3:  ['sqlite3'],
   mysql:    ['mysql'],
@@ -21,6 +22,7 @@ var excluded = {
 
 var bases = {
   oracle:   './lib/dialects/oracle',
+  "strong-oracle":   './lib/dialects/strong-oracle',
   mariasql: './lib/dialects/maria',
   mysql:    './lib/dialects/mysql',
   mysql2:   './lib/dialects/mysql2',

--- a/knex.js
+++ b/knex.js
@@ -31,6 +31,7 @@ var maria = function() { return require('./lib/dialects/maria'); };
 var oracle = function() { return require('./lib/dialects/oracle'); };
 var pg = function() { return require('./lib/dialects/postgres'); };
 var sqlite3 = function() { return require('./lib/dialects/sqlite3'); };
+var strong_oracle = function() { return require('./lib/dialects/strong-oracle'); };
 var websql = function() { return require('./lib/dialects/websql'); };
 
 // The client names we'll allow in the `{name: lib}` pairing.
@@ -46,6 +47,7 @@ var Clients = Knex.Clients = {
   'postgresql' : pg,
   'sqlite'     : sqlite3,
   'sqlite3'    : sqlite3,
+  'strong-oracle': strong_oracle,
   'websql'     : websql
 };
 

--- a/lib/dialects/oracle/index.js
+++ b/lib/dialects/oracle/index.js
@@ -3,9 +3,9 @@
 // Oracle Client
 // -------
 var inherits = require('inherits');
-var _        = require('lodash');
-var Client   = require('../../client');
-var Promise  = require('../../promise');
+var _ = require('lodash');
+var Client = require('../../client');
+var Promise = require('../../promise');
 
 var oracle;
 
@@ -31,7 +31,8 @@ Client_Oracle.prototype.dialect = 'oracle';
 // Lazy-load the oracle dependency, since we might just be
 // using the client to generate SQL strings.
 Client_Oracle.prototype.initDriver = function() {
-  oracle = oracle || require('oracle');
+  Client_Oracle.prototype.driver = Client_Oracle.prototype.driver || require(
+    'oracle');
 };
 
 // Attach a `Formatter` constructor to the client object.
@@ -90,10 +91,15 @@ Client_Oracle.prototype.initSeeder = function() {
 Client_Oracle.prototype.acquireRawConnection = function() {
   var self = this;
   return new Promise(function(resolver, rejecter) {
-    oracle.connect(self.connectionSettings, function(err, connection) {
-      if (err) return rejecter(err);
-      resolver(connection);
-    });
+    self.driver.connect(self.connectionSettings,
+      function(err,
+        connection) {
+        if (err) return rejecter(err);
+        if (self.connectionSettings.prefetchRowCount) {
+          connection.setPrefetchRowCount(self.connectionSettings.prefetchRowCount);
+        }
+        resolver(connection);
+      });
   });
 };
 
@@ -120,13 +126,13 @@ Client_Oracle.prototype.positionBindings = function(sql) {
 
 var ReturningHelper = require('./utils').ReturningHelper;
 
-Client_Oracle.prototype.preprocessBindings = function (bindings) {
+Client_Oracle.prototype.preprocessBindings = function(bindings) {
 
   if (!bindings) {
     return bindings;
   }
 
-  return bindings.map(function (binding) {
+  return bindings.map(function(binding) {
     if (binding instanceof ReturningHelper && oracle) {
       // returning helper uses always ROWID as string
       return new oracle.OutParam(oracle.OCCISTRING);

--- a/lib/dialects/oracle/oracle-query-stream.js
+++ b/lib/dialects/oracle/oracle-query-stream.js
@@ -7,36 +7,58 @@ var Readable = require('stream').Readable;
 var _ = require('lodash');
 
 function OracleQueryStream(connection, sql, bindings, options) {
-    try {
-        Readable.call(this, _.merge({}, {
-            objectMode: true,
-            highWaterMark: 1000
-        }, options));
+  try {
+    Readable.call(this, _.merge({}, {
+      objectMode: true,
+      highWaterMark: 1000
+    }, options));
 
-        this.oracleReader = connection.reader(sql, bindings || []);
-    } catch (err) {
-        throw err;
-    }
+    this.oracleReader = connection.reader(sql, bindings || []);
+  } catch (err) {
+    throw err;
+  }
 }
 
 inherits(OracleQueryStream, Readable);
 
-OracleQueryStream.prototype._read = function () {
-    var self = this;
+OracleQueryStream.prototype._read = function() {
+  var self = this;
 
-    this.oracleReader.nextRow(function (err, row) {
-        if (err) {
-            return self.emit('error', err);
-        }
-
-        if (!row) {
-            process.nextTick(function () {
-                self.push(null);
-            });
-        }
-
-        self.push(row);
+  function pushNull() {
+    process.nextTick(function() {
+      self.push(null);
     });
+  }
+
+  try {
+    this.oracleReader.nextRows(function(err, rows) {
+      if (err) {
+        return self.emit('error', err);
+      }
+
+      if (rows.length === 0) {
+        pushNull();
+      } else {
+        for (var i = 0; i < rows.length; i++) {
+          if (rows[i]) {
+            self.push(rows[i]);
+          } else {
+            pushNull();
+          }
+        }
+      }
+    });
+  } catch (e) {
+    // Catch Error: invalid state: reader is busy with another nextRows call
+    // and return false to rate limit stream.
+    if (e.message ===
+      'invalid state: reader is busy with another nextRows call') {
+      return false;
+    } else {
+      this.emit('error', e);
+    }
+  }
 };
+
 
 module.exports = OracleQueryStream;

--- a/lib/dialects/strong-oracle/index.js
+++ b/lib/dialects/strong-oracle/index.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// Oracle Client
+// -------
+var inherits = require('inherits');
+var Oracle = require('../oracle');
+
+// Always initialize with the "QueryBuilder" and "QueryCompiler"
+// objects, which extend the base 'lib/query/builder' and
+// 'lib/query/compiler', respectively.
+function Client_StrongOracle() {
+  Oracle.apply(this, arguments);
+}
+inherits(Client_StrongOracle, Oracle);
+
+// Lazy-load the strong-oracle dependency, since we might just be
+// using the client to generate SQL strings.
+Client_StrongOracle.prototype.initDriver = function() {
+  Client_StrongOracle.prototype.driver = Client_StrongOracle.prototype.driver ||
+    require('strong-oracle')();
+};
+
+module.exports = Client_StrongOracle;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "browser": {
     "./lib/dialects/oracle": false,
+    "./lib/dialects/strong-oracle": false,
     "./lib/dialects/maria": false,
     "./lib/dialects/mysql": false,
     "./lib/dialects/mysql2": false,


### PR DESCRIPTION
This supports the strong-oracle driver. The main difference is the strong-oracle driver compiles on node 0.10, 0.11 and 0.12 while node-oracle compiles on 0.10 only.

strong-oracle also provides access to a native connection pool, though currently that functionality segfaults. (I have an issue opened for that.) I also don't know if there is any advantages with a native connection pool.

Also, in both drivers you can do something like connection.setPrefetchRowCount(100) to configure the prefetch row count for the connection. Prefetching can have a dramatic impact on performance but uses more memory.. This results in much faster streaming in particular.

My strong-oracle-query-stream.js takes advantage of that with the getRows. The same could be done in the node-oracle impl, I believe.
