### PR TITLE
Add option to .increments() to disable use as primary key

### DIFF
--- a/src/dialects/mssql/schema/columncompiler.js
+++ b/src/dialects/mssql/schema/columncompiler.js
@@ -18,7 +18,9 @@ inherits(ColumnCompiler_MSSQL, ColumnCompiler);
 
 assign(ColumnCompiler_MSSQL.prototype, {
 
-  increments: 'int identity(1,1) not null primary key',
+  increments(withoutPk){
+    return withoutPk ? 'int identity(1,1) not null' : 'int identity(1,1) not null primary key'
+  },
 
   bigincrements: 'bigint identity(1,1) not null primary key',
 

--- a/src/dialects/mssql/schema/columncompiler.js
+++ b/src/dialects/mssql/schema/columncompiler.js
@@ -18,11 +18,17 @@ inherits(ColumnCompiler_MSSQL, ColumnCompiler);
 
 assign(ColumnCompiler_MSSQL.prototype, {
 
-  increments(withoutPk){
-    return withoutPk ? 'int identity(1,1) not null' : 'int identity(1,1) not null primary key'
+  increments({ primaryKey = true } = {}){
+    return primaryKey ?
+      'int identity(1,1) not null primary key' :
+      'int identity(1,1) not null';
   },
 
-  bigincrements: 'bigint identity(1,1) not null primary key',
+  bigincrements({ primaryKey = true } = {}){
+    return primaryKey ?
+      'bigint identity(1,1) not null primary key' :
+      'bigint identity(1,1) not null';
+  },
 
   bigint: 'bigint',
 

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -19,9 +19,10 @@ inherits(ColumnCompiler_MySQL, ColumnCompiler);
 assign(ColumnCompiler_MySQL.prototype, {
 
   increments(withoutPk){
-    return withoutPk ? 'int unsigned not null auto_increment' : 'int unsigned not null auto_increment primary key'
+    return withoutPk ? 'int unsigned not null auto_increment' :
+    'int unsigned not null auto_increment primary key';
   },
-  
+
   bigincrements: 'bigint unsigned not null auto_increment primary key',
 
   bigint: 'bigint',

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -18,8 +18,10 @@ inherits(ColumnCompiler_MySQL, ColumnCompiler);
 
 assign(ColumnCompiler_MySQL.prototype, {
 
-  increments: 'int unsigned not null auto_increment primary key',
-
+  increments(withoutPk){
+    return withoutPk ? 'int unsigned not null auto_increment' : 'int unsigned not null auto_increment primary key'
+  },
+  
   bigincrements: 'bigint unsigned not null auto_increment primary key',
 
   bigint: 'bigint',

--- a/src/dialects/mysql/schema/columncompiler.js
+++ b/src/dialects/mysql/schema/columncompiler.js
@@ -18,12 +18,17 @@ inherits(ColumnCompiler_MySQL, ColumnCompiler);
 
 assign(ColumnCompiler_MySQL.prototype, {
 
-  increments(withoutPk){
-    return withoutPk ? 'int unsigned not null auto_increment' :
-    'int unsigned not null auto_increment primary key';
+  increments({ primaryKey = true } = {}){
+    return primaryKey ?
+      'int unsigned not null auto_increment primary key' :
+      'int unsigned not null auto_increment';
   },
 
-  bigincrements: 'bigint unsigned not null auto_increment primary key',
+  bigincrements({ primaryKey = true } = {}){
+    return primaryKey ?
+      'bigint unsigned not null auto_increment primary key' :
+      'bigint unsigned not null auto_increment';
+  },
 
   bigint: 'bigint',
 

--- a/src/dialects/oracle/schema/columncompiler.js
+++ b/src/dialects/oracle/schema/columncompiler.js
@@ -26,9 +26,9 @@ assign(ColumnCompiler_Oracle.prototype, {
     });
   },
 
-  increments () {
+  increments (withoutPk) {
     this._createAutoIncrementTriggerAndSequence();
-    return 'integer not null primary key';
+    return withoutPk ? 'integer not null' : 'integer not null primary key';
   },
 
   bigincrements () {

--- a/src/dialects/oracle/schema/columncompiler.js
+++ b/src/dialects/oracle/schema/columncompiler.js
@@ -26,14 +26,14 @@ assign(ColumnCompiler_Oracle.prototype, {
     });
   },
 
-  increments (withoutPk) {
+  increments ({ primaryKey = true } = {}) {
     this._createAutoIncrementTriggerAndSequence();
-    return withoutPk ? 'integer not null' : 'integer not null primary key';
+    return primaryKey ? 'integer not null primary key' : 'integer not null';
   },
 
-  bigincrements () {
+  bigincrements ({ primaryKey = true } = {}) {
     this._createAutoIncrementTriggerAndSequence();
-    return 'number(20, 0) not null primary key';
+    return primaryKey ? 'number(20, 0) not null primary key' : 'number(20, 0) not null';
   },
 
   floating(precision) {

--- a/src/dialects/postgres/schema/columncompiler.js
+++ b/src/dialects/postgres/schema/columncompiler.js
@@ -36,7 +36,9 @@ assign(ColumnCompiler_PG.prototype, {
 
   double: 'double precision',
   floating: 'real',
-  increments: 'serial primary key',
+  increments(withoutPk) {
+    return withoutPk ? 'serial' : 'serial primary key'
+  },
   json(jsonb) {
     if (jsonb) helpers.deprecate('json(true)', 'jsonb()')
     return jsonColumn(this.client, jsonb);

--- a/src/dialects/postgres/schema/columncompiler.js
+++ b/src/dialects/postgres/schema/columncompiler.js
@@ -18,7 +18,9 @@ assign(ColumnCompiler_PG.prototype, {
 
   // Types
   // ------
-  bigincrements: 'bigserial primary key',
+  bigincrements({ primaryKey = true } = {}){
+    return primaryKey ? 'bigserial primary key' : 'bigserial';
+  },
   bigint: 'bigint',
   binary: 'bytea',
 
@@ -36,8 +38,8 @@ assign(ColumnCompiler_PG.prototype, {
 
   double: 'double precision',
   floating: 'real',
-  increments(withoutPk) {
-    return withoutPk ? 'serial' : 'serial primary key'
+  increments({ primaryKey = true } = {}) {
+    return primaryKey ? 'serial primary key' : 'serial';
   },
   json(jsonb) {
     if (jsonb) helpers.deprecate('json(true)', 'jsonb()')

--- a/src/schema/columncompiler.js
+++ b/src/schema/columncompiler.js
@@ -74,7 +74,8 @@ ColumnCompiler.prototype.getModifiers = function() {
 // Types
 // ------
 
-ColumnCompiler.prototype.increments = 'integer not null primary key autoincrement';
+ColumnCompiler.prototype.increments = withoutPk =>
+  withoutPk ? 'integer not null autoincrement' : 'integer not null primary key autoincrement';
 ColumnCompiler.prototype.bigincrements = 'integer not null primary key autoincrement';
 ColumnCompiler.prototype.integer       =
 ColumnCompiler.prototype.smallint      =

--- a/src/schema/columncompiler.js
+++ b/src/schema/columncompiler.js
@@ -74,9 +74,12 @@ ColumnCompiler.prototype.getModifiers = function() {
 // Types
 // ------
 
-ColumnCompiler.prototype.increments = withoutPk =>
-  withoutPk ? 'integer not null autoincrement' : 'integer not null primary key autoincrement';
-ColumnCompiler.prototype.bigincrements = 'integer not null primary key autoincrement';
+ColumnCompiler.prototype.increments     =
+ColumnCompiler.prototype.bigincrements  = function({ primaryKey = true } = {}){
+  return primaryKey ?
+    'integer not null primary key autoincrement' :
+    'integer not null autoincrement';
+};
 ColumnCompiler.prototype.integer       =
 ColumnCompiler.prototype.smallint      =
 ColumnCompiler.prototype.mediumint = 'integer';

--- a/test/unit/schema/mssql.js
+++ b/test/unit/schema/mssql.js
@@ -25,7 +25,7 @@ describe("MSSQL SchemaBuilder", function() {
 
   it('test basic create table with incrementing without primary key', function(){
     tableSql = client.schemaBuilder().createTable('users', function(table) {
-      table.increments('id', true);
+      table.increments('id', { primaryKey: false });
     });
 
     equal(1, tableSql.toSQL().length);
@@ -262,6 +262,15 @@ describe("MSSQL SchemaBuilder", function() {
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [id] bigint identity(1,1) not null primary key');
+  });
+
+  it('test adding big incrementing id without primary key', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.bigIncrements('id', { primaryKey: false });
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [id] bigint identity(1,1) not null');
   });
 
   it('test adding column after another column', function() {

--- a/test/unit/schema/mssql.js
+++ b/test/unit/schema/mssql.js
@@ -23,6 +23,16 @@ describe("MSSQL SchemaBuilder", function() {
     expect(tableSql.toQuery()).to.equal('CREATE TABLE [users] ([id] int identity(1,1) not null primary key, [email] nvarchar(255))');
   });
 
+  it('test basic create table with incrementing without primary key', function(){
+    tableSql = client.schemaBuilder().createTable('users', function(table) {
+      table.increments('id', true);
+    });
+
+    equal(1, tableSql.toSQL().length);
+    expect(tableSql.toSQL()[0].sql).to.equal('CREATE TABLE [users] ([id] int identity(1,1) not null)');
+    expect(tableSql.toQuery()).to.equal('CREATE TABLE [users] ([id] int identity(1,1) not null)');
+  });
+
   it('basic create table without charset or collate', function() {
     tableSql = client.schemaBuilder().table('users', function() {
       this.increments('id');

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -30,6 +30,16 @@ describe(dialect + " SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) collate \'utf8_unicode_ci\')');
   });
 
+  it('test basic create table with incrementing without primary key', function(){
+    tableSql = client.schemaBuilder().createTable('users', function(table) {
+      table.increments('id');
+      table.increments('other_id', true)
+    });
+
+    equal(1, tableSql.toSQL().length);
+    expect(tableSql.toSQL()[0].sql).to.equal('create table `users` (`id` int unsigned not null auto_increment primary key, `other_id` int unsigned not null auto_increment)');
+  });
+
   it('test basic create table with charset and collate', function() {
     tableSql = client.schemaBuilder().createTable('users', function(table) {
       table.increments('id');

--- a/test/unit/schema/mysql.js
+++ b/test/unit/schema/mysql.js
@@ -33,7 +33,7 @@ describe(dialect + " SchemaBuilder", function() {
   it('test basic create table with incrementing without primary key', function(){
     tableSql = client.schemaBuilder().createTable('users', function(table) {
       table.increments('id');
-      table.increments('other_id', true)
+      table.increments('other_id', { primaryKey: false });
     });
 
     equal(1, tableSql.toSQL().length);
@@ -270,6 +270,15 @@ describe(dialect + " SchemaBuilder", function() {
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table `users` add `id` bigint unsigned not null auto_increment primary key');
+  });
+
+  it('test adding big incrementing id without primary key', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.bigIncrements('id', { primaryKey: false });
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table `users` add `id` bigint unsigned not null auto_increment');
   });
 
   it('test adding column after another column', function() {

--- a/test/unit/schema/oracle.js
+++ b/test/unit/schema/oracle.js
@@ -31,6 +31,15 @@ describe("Oracle SchemaBuilder", function() {
     expect(tableSql.toSQL()[1].sql).to.equal("DECLARE PK_NAME VARCHAR(200); BEGIN  EXECUTE IMMEDIATE (\'CREATE SEQUENCE \"users_seq\"\');  SELECT cols.column_name INTO PK_NAME  FROM all_constraints cons, all_cons_columns cols  WHERE cons.constraint_type = \'P\'  AND cons.constraint_name = cols.constraint_name  AND cons.owner = cols.owner  AND cols.table_name = \'users\';  execute immediate (\'create or replace trigger \"users_autoinc_trg\"  BEFORE INSERT on \"users\"  for each row  declare  checking number := 1;  begin    if (:new.\"\' || PK_NAME || \'\" is null) then      while checking >= 1 loop        select \"users_seq\".nextval into :new.\"\' || PK_NAME || \'\" from dual;        select count(\"\' || PK_NAME || \'\") into checking from \"users\"        where \"\' || PK_NAME || \'\" = :new.\"\' || PK_NAME || \'\";      end loop;    end if;  end;\'); END;");
   });
 
+  it('test basic create table with incrementing without primary key', function(){
+    tableSql = client.schemaBuilder().createTableIfNotExists('users', function(table) {
+      table.increments('id', true);
+    });
+
+    equal(2, tableSql.toSQL().length);
+    expect(tableSql.toSQL()[0].sql).to.equal("begin execute immediate 'create table \"users\" (\"id\" integer not null)'; exception when others then if sqlcode != -955 then raise; end if; end;");
+  });
+
   it('test drop table', function() {
     tableSql = client.schemaBuilder().dropTable('users').toSQL();
 

--- a/test/unit/schema/oracle.js
+++ b/test/unit/schema/oracle.js
@@ -33,7 +33,7 @@ describe("Oracle SchemaBuilder", function() {
 
   it('test basic create table with incrementing without primary key', function(){
     tableSql = client.schemaBuilder().createTableIfNotExists('users', function(table) {
-      table.increments('id', true);
+      table.increments('id', { primaryKey: false });
     });
 
     equal(2, tableSql.toSQL().length);
@@ -261,6 +261,15 @@ describe("Oracle SchemaBuilder", function() {
     equal(2, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table "users" add "id" number(20, 0) not null primary key');
     expect(tableSql[1].sql).to.equal('DECLARE PK_NAME VARCHAR(200); BEGIN  EXECUTE IMMEDIATE (\'CREATE SEQUENCE \"users_seq\"\');  SELECT cols.column_name INTO PK_NAME  FROM all_constraints cons, all_cons_columns cols  WHERE cons.constraint_type = \'P\'  AND cons.constraint_name = cols.constraint_name  AND cons.owner = cols.owner  AND cols.table_name = \'users\';  execute immediate (\'create or replace trigger \"users_autoinc_trg\"  BEFORE INSERT on \"users\"  for each row  declare  checking number := 1;  begin    if (:new.\"\' || PK_NAME || \'\" is null) then      while checking >= 1 loop        select \"users_seq\".nextval into :new.\"\' || PK_NAME || \'\" from dual;        select count(\"\' || PK_NAME || \'\") into checking from \"users\"        where \"\' || PK_NAME || \'\" = :new.\"\' || PK_NAME || \'\";      end loop;    end if;  end;\'); END;');
+  });
+
+  it('test adding big incrementing id without primary key', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.bigIncrements('id', { primaryKey: false });
+    }).toSQL();
+
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "id" number(20, 0) not null');
   });
 
   it('test rename column', function() {

--- a/test/unit/schema/oracledb.js
+++ b/test/unit/schema/oracledb.js
@@ -34,7 +34,7 @@ describe("OracleDb SchemaBuilder", function() {
 
   it('test basic create table with incrementing without primary key', function(){
     tableSql = client.schemaBuilder().createTableIfNotExists('users', function(table) {
-      table.increments('id', true);
+      table.increments('id', { primaryKey: false });
     });
 
     equal(2, tableSql.toSQL().length);
@@ -251,6 +251,15 @@ describe("OracleDb SchemaBuilder", function() {
     equal(2, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table "users" add "id" number(20, 0) not null primary key');
     expect(tableSql[1].sql).to.equal('DECLARE PK_NAME VARCHAR(200); BEGIN  EXECUTE IMMEDIATE (\'CREATE SEQUENCE \"users_seq\"\');  SELECT cols.column_name INTO PK_NAME  FROM all_constraints cons, all_cons_columns cols  WHERE cons.constraint_type = \'P\'  AND cons.constraint_name = cols.constraint_name  AND cons.owner = cols.owner  AND cols.table_name = \'users\';  execute immediate (\'create or replace trigger \"users_autoinc_trg\"  BEFORE INSERT on \"users\"  for each row  declare  checking number := 1;  begin    if (:new.\"\' || PK_NAME || \'\" is null) then      while checking >= 1 loop        select \"users_seq\".nextval into :new.\"\' || PK_NAME || \'\" from dual;        select count(\"\' || PK_NAME || \'\") into checking from \"users\"        where \"\' || PK_NAME || \'\" = :new.\"\' || PK_NAME || \'\";      end loop;    end if;  end;\'); END;');
+  });
+
+  it('test adding big incrementing id without primary key', function() {
+    tableSql = client.schemaBuilder().table('users', function() {
+      this.bigIncrements('id', { primaryKey: false });
+    }).toSQL();
+
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add "id" number(20, 0) not null');
   });
 
   it('test rename column', function() {

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -382,7 +382,7 @@ describe("PostgreSQL SchemaBuilder", function() {
 
   it("adding incrementing id without primary key", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
-      table.increments('id', true);
+      table.increments('id', { primaryKey: false });
     }).toSQL();
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table "users" add column "id" serial');
@@ -394,6 +394,14 @@ describe("PostgreSQL SchemaBuilder", function() {
     }).toSQL();
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal('alter table "users" add column "id" bigserial primary key');
+  });
+
+  it("adding big incrementing id without primary key", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.bigIncrements('id', { primaryKey: false });
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "id" bigserial');
   });
 
   it("adding string", function() {

--- a/test/unit/schema/postgres.js
+++ b/test/unit/schema/postgres.js
@@ -380,6 +380,14 @@ describe("PostgreSQL SchemaBuilder", function() {
     expect(tableSql[0].sql).to.equal('alter table "users" add column "id" serial primary key');
   });
 
+  it("adding incrementing id without primary key", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.increments('id', true);
+    }).toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('alter table "users" add column "id" serial');
+  });
+
   it("adding big incrementing id", function() {
     tableSql = client.schemaBuilder().table('users', function(table) {
       table.bigIncrements('id');

--- a/test/unit/schema/sqlite3.js
+++ b/test/unit/schema/sqlite3.js
@@ -24,6 +24,16 @@ describe("SQLite SchemaBuilder", function() {
     equal(tableSql[0].sql, 'create table "users" ("id" integer not null primary key autoincrement, "email" varchar(255))');
   });
 
+  it("basic create table without primary key", function() {
+    tableSql = client.schemaBuilder().createTable('users', function(table) {
+      table.increments('id');
+      table.increments('other_id', true)
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    equal(tableSql[0].sql, 'create table "users" ("id" integer not null primary key autoincrement, "other_id" integer not null autoincrement)');
+  });
+
   it("basic alter table", function() {
     tableSql = client.schemaBuilder().alterTable('users', function(table) {
       table.increments('id');

--- a/test/unit/schema/sqlite3.js
+++ b/test/unit/schema/sqlite3.js
@@ -27,7 +27,7 @@ describe("SQLite SchemaBuilder", function() {
   it("basic create table without primary key", function() {
     tableSql = client.schemaBuilder().createTable('users', function(table) {
       table.increments('id');
-      table.increments('other_id', true)
+      table.increments('other_id', { primaryKey: false })
     }).toSQL();
 
     equal(1, tableSql.length);
@@ -221,6 +221,15 @@ describe("SQLite SchemaBuilder", function() {
 
     equal(1, tableSql.length);
     equal(tableSql[0].sql, 'alter table "users" add column "id" integer not null primary key autoincrement');
+  });
+
+  it("adding big incrementing id without primary key", function() {
+    tableSql = client.schemaBuilder().table('users', function(table) {
+      table.bigIncrements('id', { primaryKey: false });
+    }).toSQL();
+
+    equal(1, tableSql.length);
+    equal(tableSql[0].sql, 'alter table "users" add column "id" integer not null autoincrement');
   });
 
   it("adding string", function() {


### PR DESCRIPTION
Usage: 

`t.increments('id', { primaryKey: false })` => Not primary key
`t.increments('id')` => Primary key as currently

I had some trouble running the `maria` tests

Fixes #385 