### PR TITLE
enable migrations to run within an external transaction

### DIFF
--- a/docs/src/guide/migrations.md
+++ b/docs/src/guide/migrations.md
@@ -308,6 +308,26 @@ exports.config = { transaction: false };
 
 The same config property can be used for enabling transaction per-migration in case the common configuration has `disableTransactions: false`.
 
+#### Running migrations within an external transaction
+
+The migration methods `latest`, `up`, `down` and `rollback` can be called on a transaction object. When invoked this way, they reuse the surrounding transaction instead of opening a new (nested) one, so the migrations become part of the outer transaction and are committed or rolled back together with it.
+
+This is especially useful for transaction-based testing: run your migrations, exercise your code, then roll back the transaction to leave the database untouched.
+
+```js
+await knex.transaction(async (trx) => {
+  // Migrations run inside `trx`, not in a new nested transaction
+  await trx.migrate.latest();
+
+  // ... run your tests against `trx` ...
+
+  // Rolling back the transaction undoes the migrations as well
+  await trx.rollback();
+});
+```
+
+Note that this is not supported on sqlite3, which does not allow schema changes inside a transaction that is later rolled back without side effects.
+
 #### Sqlite3-specific concerns
 
 Disabling / enabling foreign key checking [has no effect within a transaction](https://sqlite.org/pragma.html#pragma_foreign_keys) on sqlite3, so features such as `.dropColumn()` cannot be emulated correctly inside of a migration-level transaction (and [can even cause data loss](https://github.com/knex/knex/pull/6315)). Knex now throws an error in these cases.

--- a/docs/src/guide/migrations.md
+++ b/docs/src/guide/migrations.md
@@ -315,18 +315,25 @@ The migration methods `latest`, `up`, `down` and `rollback` can be called on a t
 This is especially useful for transaction-based testing: run your migrations, exercise your code, then roll back the transaction to leave the database untouched.
 
 ```js
-await knex.transaction(async (trx) => {
-  // Migrations run inside `trx`, not in a new nested transaction
-  await trx.migrate.latest();
+const Rollback = new Error('rollback');
+try {
+  await knex.transaction(async (trx) => {
+    // Migrations run inside `trx`, not in a new nested transaction
+    await trx.migrate.latest();
 
-  // ... run your tests against `trx` ...
+    // ... run your tests against `trx` ...
 
-  // Rolling back the transaction undoes the migrations as well
-  await trx.rollback();
-});
+    // Throw to roll the whole transaction (migrations included) back
+    throw Rollback;
+  });
+} catch (err) {
+  if (err !== Rollback) throw err;
+}
 ```
 
-Note that this is not supported on sqlite3, which does not allow schema changes inside a transaction that is later rolled back without side effects.
+Use a thrown error to trigger the rollback rather than calling `trx.rollback()` and letting the callback resolve normally — the latter leaves Knex trying to both roll back and commit the same transaction, which hangs on some drivers (e.g. MSSQL).
+
+Rolling back schema migrations this way relies on the database supporting **transactional DDL**. PostgreSQL, CockroachDB and MSSQL do, so a migration that creates or drops tables can be fully undone by rolling back the surrounding transaction. MySQL/MariaDB and Oracle implicitly commit on DDL statements (e.g. `CREATE TABLE`), so those changes cannot be rolled back, and SQLite has its own limitations here. On those engines you can still run migrations within a transaction that you intend to commit, but you cannot rely on rolling DDL back.
 
 #### Sqlite3-specific concerns
 

--- a/lib/migrations/migrate/Migrator.js
+++ b/lib/migrations/migrate/Migrator.js
@@ -89,13 +89,7 @@ class Migrator {
         )
       ).some((isTransactionUsed) => isTransactionUsed);
 
-    if (transactionForAll) {
-      return this.knex.transaction((trx) => {
-        return this._runBatch(migrations, 'up', trx);
-      });
-    } else {
-      return this._runBatch(migrations, 'up');
-    }
+    return this._runMigrations(migrations, 'up', transactionForAll);
   }
 
   // Runs the next migration that has not yet been run
@@ -150,13 +144,7 @@ class Migrator {
     const transactionForAll =
       !this.config.disableTransactions && (!migrationToRun || useTransaction);
 
-    if (transactionForAll) {
-      return await this.knex.transaction((trx) => {
-        return this._runBatch(migrationsToRun, 'up', trx);
-      });
-    } else {
-      return await this._runBatch(migrationsToRun, 'up');
-    }
+    return await this._runMigrations(migrationsToRun, 'up', transactionForAll);
   }
 
   // Rollback the last "batch", or all, of migrations that were run.
@@ -196,7 +184,7 @@ class Migrator {
             : this._getLastBatch(val);
         })
         .then((migrations) => {
-          return this._runBatch(migrations, 'down');
+          return this._runMigrations(migrations, 'down', false);
         })
         .then(resolve, reject);
     });
@@ -241,7 +229,7 @@ class Migrator {
           migrationsToRun.push(migrationToRun);
         }
 
-        return this._runBatch(migrationsToRun, 'down');
+        return this._runMigrations(migrationsToRun, 'down', false);
       });
   }
 
@@ -444,6 +432,19 @@ class Migrator {
   // Creates a new migration, with a given name.
   make(name, config) {
     return this.generator.make(name, config, this.knex.client.logger);
+  }
+
+  // Decides how to run a batch: reuse external transaction, create a new one, or run without.
+  _runMigrations(migrations, direction, useTransaction) {
+    if (this.knex.isTransaction) {
+      return this._runBatch(migrations, direction, this.knex);
+    } else if (useTransaction) {
+      return this.knex.transaction((trx) => {
+        return this._runBatch(migrations, direction, trx);
+      });
+    } else {
+      return this._runBatch(migrations, direction);
+    }
   }
 
   _disableProcessing() {

--- a/lib/migrations/migrate/Migrator.js
+++ b/lib/migrations/migrate/Migrator.js
@@ -489,14 +489,18 @@ class Migrator {
     try {
       await this._getLock(canGetLockInTransaction ? trx : undefined);
       // When there is a wrapping transaction, some migrations
-      // could have been done while waiting for the lock:
-      const completed = trx
-        ? await migrationListResolver.listCompleted(
-            this.config.tableName,
-            this.config.schemaName,
-            trx
-          )
-        : [];
+      // could have been done while waiting for the lock. This only
+      // applies when migrating up: when migrating down the supplied
+      // migrations are the already-completed ones we intend to undo,
+      // so filtering them out would leave nothing to run.
+      const completed =
+        trx && direction === 'up'
+          ? await migrationListResolver.listCompleted(
+              this.config.tableName,
+              this.config.schemaName,
+              trx
+            )
+          : [];
 
       migrations = getNewMigrations(
         this.config.migrationSource,

--- a/test/integration2/migrate/migration-integration.spec.js
+++ b/test/integration2/migrate/migration-integration.spec.js
@@ -1056,6 +1056,11 @@ describe('Migrations', function () {
         });
 
         describe('knex.migrate within external transaction', () => {
+          // Rolling DDL back needs transactional DDL. MySQL/MariaDB and
+          // Oracle implicitly commit on DDL; SQLite can't roll it back here.
+          const canRollbackDDL = (knex) =>
+            !isSQLite(knex) && !isMysql(knex) && !isOracle(knex);
+
           afterEach(async () => {
             await knex.migrate.rollback(
               { directory: 'test/integration2/migrate/test' },
@@ -1064,20 +1069,25 @@ describe('Migrations', function () {
           });
 
           it('should run latest() inside an external transaction and roll back cleanly', async function () {
-            if (isSQLite(knex)) {
+            if (!canRollbackDDL(knex)) {
               return this.skip();
             }
-            await knex.transaction(async (trx) => {
-              await trx.migrate.latest({
-                directory: 'test/integration2/migrate/test',
+            const rollback = new Error('rollback');
+            await knex
+              .transaction(async (trx) => {
+                await trx.migrate.latest({
+                  directory: 'test/integration2/migrate/test',
+                });
+
+                const data = await trx('knex_migrations').select('*');
+                expect(data).to.have.length(2);
+
+                // Throw to roll the whole transaction back
+                throw rollback;
+              })
+              .catch((error) => {
+                if (error !== rollback) throw error;
               });
-
-              const data = await trx('knex_migrations').select('*');
-              expect(data).to.have.length(2);
-
-              // Roll back the transaction — everything should be undone
-              await trx.rollback();
-            });
 
             // After rollback, no migrations should be recorded
             const hasTable = await knex.schema.hasTable('knex_migrations');
@@ -1109,7 +1119,7 @@ describe('Migrations', function () {
           });
 
           it('should run rollback() inside an external transaction and undo on trx rollback', async function () {
-            if (isSQLite(knex)) {
+            if (!canRollbackDDL(knex)) {
               return this.skip();
             }
             // First, run migrations normally
@@ -1117,17 +1127,22 @@ describe('Migrations', function () {
               directory: 'test/integration2/migrate/test',
             });
 
-            await knex.transaction(async (trx) => {
-              await trx.migrate.rollback({
-                directory: 'test/integration2/migrate/test',
+            const rollback = new Error('rollback');
+            await knex
+              .transaction(async (trx) => {
+                await trx.migrate.rollback({
+                  directory: 'test/integration2/migrate/test',
+                });
+
+                const data = await trx('knex_migrations').select('*');
+                expect(data).to.have.length(0);
+
+                // Throw to undo the rollback we just performed
+                throw rollback;
+              })
+              .catch((error) => {
+                if (error !== rollback) throw error;
               });
-
-              const data = await trx('knex_migrations').select('*');
-              expect(data).to.have.length(0);
-
-              // Roll back the transaction — rollback should be undone
-              await trx.rollback();
-            });
 
             // Migrations should still be there
             const data = await knex('knex_migrations').select('*');

--- a/test/integration2/migrate/migration-integration.spec.js
+++ b/test/integration2/migrate/migration-integration.spec.js
@@ -1055,6 +1055,108 @@ describe('Migrations', function () {
           });
         });
 
+        describe('knex.migrate within external transaction', () => {
+          afterEach(async () => {
+            await knex.migrate.rollback(
+              { directory: 'test/integration2/migrate/test' },
+              true
+            );
+          });
+
+          it('should run latest() inside an external transaction and roll back cleanly', async function () {
+            if (isSQLite(knex)) {
+              return this.skip();
+            }
+            await knex.transaction(async (trx) => {
+              await trx.migrate.latest({
+                directory: 'test/integration2/migrate/test',
+              });
+
+              const data = await trx('knex_migrations').select('*');
+              expect(data).to.have.length(2);
+
+              // Roll back the transaction — everything should be undone
+              await trx.rollback();
+            });
+
+            // After rollback, no migrations should be recorded
+            const hasTable = await knex.schema.hasTable('knex_migrations');
+            if (hasTable) {
+              const data = await knex('knex_migrations').select('*');
+              expect(data).to.have.length(0);
+            }
+          });
+
+          it('should run up() inside an external transaction', async function () {
+            if (isSQLite(knex)) {
+              return this.skip();
+            }
+            await knex.transaction(async (trx) => {
+              await trx.migrate.up({
+                directory: 'test/integration2/migrate/test',
+              });
+
+              const data = await trx('knex_migrations').select('*');
+              expect(data).to.have.length(1);
+              expect(path.basename(data[0].name)).to.equal(
+                '20131019235242_migration_1.js'
+              );
+            });
+
+            // Transaction committed — migration should persist
+            const data = await knex('knex_migrations').select('*');
+            expect(data).to.have.length(1);
+          });
+
+          it('should run rollback() inside an external transaction and undo on trx rollback', async function () {
+            if (isSQLite(knex)) {
+              return this.skip();
+            }
+            // First, run migrations normally
+            await knex.migrate.latest({
+              directory: 'test/integration2/migrate/test',
+            });
+
+            await knex.transaction(async (trx) => {
+              await trx.migrate.rollback({
+                directory: 'test/integration2/migrate/test',
+              });
+
+              const data = await trx('knex_migrations').select('*');
+              expect(data).to.have.length(0);
+
+              // Roll back the transaction — rollback should be undone
+              await trx.rollback();
+            });
+
+            // Migrations should still be there
+            const data = await knex('knex_migrations').select('*');
+            expect(data).to.have.length(2);
+          });
+
+          it('should run down() inside an external transaction', async function () {
+            if (isSQLite(knex)) {
+              return this.skip();
+            }
+            await knex.migrate.latest({
+              directory: 'test/integration2/migrate/test',
+            });
+
+            await knex.transaction(async (trx) => {
+              await trx.migrate.down({
+                directory: 'test/integration2/migrate/test',
+              });
+
+              const data = await trx('knex_migrations').select('*');
+              expect(data).to.have.length(1);
+            });
+
+            // Transaction committed — should have undone last migration
+            const data = await knex('knex_migrations').select('*');
+            expect(data).to.have.length(1);
+          });
+        });
+
         describe('knex.migrate.list', () => {
           const availableMigrations = [
             '20131019235242_migration_1.js',


### PR DESCRIPTION
After reading #2076 I'm not sure why we can't pass a transaction to `Migrator`?