### PR TITLE
MSSQL: Support query string options.

### DIFF
--- a/.babelconfig.js
+++ b/.babelconfig.js
@@ -10,6 +10,7 @@ module.exports = {
   "plugins": [
     "lodash",
     "transform-runtime",
-    "add-module-exports"
+    "add-module-exports",
+    ["transform-object-rest-spread", { "useBuiltIns": true }]
   ]
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-eslint": "^8.2.1",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-lodash": "3.3.2",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "chai": "^4.1.2",
@@ -82,7 +83,7 @@
     "oracledb:test": "docker rmi -f --no-prune knex-test-oracledb && docker build -f scripts/oracle-tests-Dockerfile --tag knex-test-oracledb . && docker run -i -t knex-test-oracledb",
     "mssql:init": "docker-compose -f scripts/mssql-docker-compose.yml up --no-start && docker-compose -f scripts/mssql-docker-compose.yml start",
     "mssql:test": "DB=mssql npm test",
-    "mssql:destroy": "docker-compose -f scripts/mssql-docker-compose.yml stop",    
+    "mssql:destroy": "docker-compose -f scripts/mssql-docker-compose.yml stop",
     "stress:init": "docker-compose -f scripts/stress-test/docker-compose.yml up --no-start && docker-compose -f scripts/stress-test/docker-compose.yml start",
     "stress:test": "node scripts/stress-test/knex-stress-test.js |  grep -A 3 -- '- STATS '",
     "stress:destroy": "docker-compose -f scripts/stress-test/docker-compose.yml stop"

--- a/src/util/parse-connection.js
+++ b/src/util/parse-connection.js
@@ -3,7 +3,7 @@ import url from 'url'
 import { parse as parsePG } from 'pg-connection-string'
 
 export default function parseConnectionString(str) {
-  const parsed = url.parse(str)
+  const parsed = url.parse(str, true)
   let { protocol } = parsed
   if (protocol && protocol.indexOf('maria') === 0) {
     protocol = 'maria'
@@ -56,6 +56,9 @@ function connectionObject(parsed) {
     } else {
       connection.user = parsed.auth;
     }
+  }
+  if (parsed.query && parsed.protocol.indexOf('mssql') === 0) {
+    connection.options = { ...parsed.query }
   }
   return connection
 }


### PR DESCRIPTION
This is a PR to add support to the `mssql` dialect to parse query string parameters when a connection string is provided to knex. It's needed for Azure SQL, where encryption is turned on and the mssql library knex uses requires `encrypt: true`.

The implementation just uses the existing `url.parse` function's [second parameter](https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost) to parse query strings into an object. Then it assigns a clone of this object to the options property accepted by the library.

Example connection string: `mssql://user:password@example.com/ExampleDB?encrypt=true`

I also added the Babel plugin to implement a transform for object rest spread. It is supported in the latest Node 8 LTS so I think it should be supported here.

There are some issues with this PR I'd like opinion on:
1. Boolean arguments. The mssql library checks for `encrypt: true` through type coercion. So if `encrypt=false` is passed, then it's still coerced to a boolean `true`. Without parsing the boolean string `'false'` or changing the `mssql` library this is potentially confusing for some users.
2. Not sure if any additional tests are needed. I think this is already covered fairly well by the existing integration tests, which support dynamic configuration of the connection parameters/string.
3. I'm aware there has been discussion around this in the past and #1528 suggests a bigger overhaul may be necessary. If this is not suitable please let me know.

Thanks!

EDIT: I do not know why the Travis CI builds have failed. I cannot view the logs.