### PR TITLE
make sure CLI works for namespaced knex packages as well

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -353,6 +353,7 @@ const cli = new Liftoff({
   name: 'knex',
   extensions: interpret.jsVariants,
   v8flags: require('v8flags'),
+  moduleName: require('../package.json').name,
 });
 
 cli.on('require', function(name) {


### PR DESCRIPTION
by passing and extra property to liftoff. Without this change when using a namespaced knex like `@capaj/knex` CLI won't run