### PR TITLE
Implement listTables (#360)

### DIFF
--- a/src/dialects/mssql/query/compiler.js
+++ b/src/dialects/mssql/query/compiler.js
@@ -4,7 +4,7 @@
 import inherits from 'inherits';
 import QueryCompiler from '../../../query/compiler';
 
-import { assign, isEmpty, compact, identity } from 'lodash'
+import { assign, isEmpty, compact, identity, map } from 'lodash'
 
 function QueryCompiler_MSSQL(client, builder) {
   QueryCompiler.call(this, client, builder)
@@ -170,6 +170,20 @@ assign(QueryCompiler_MSSQL.prototype, {
 
   forShare() {
     return 'with (NOLOCK)';
+  },
+
+  // Compiles a `listTables` query
+  listTables() {
+    return {
+      sql: 'select table_name from information_schema.tables' +
+           'where table_schema = \'public\' and table_catalog = ?',
+      bindings: [this.client.database()],
+      output(resp) {
+        return map(resp.rows, function (table) {
+          return table.table_name
+        })
+      }
+    }
   },
 
   // Compiles a `columnInfo` query.

--- a/src/dialects/mysql/query/compiler.js
+++ b/src/dialects/mysql/query/compiler.js
@@ -4,7 +4,7 @@
 import inherits from 'inherits';
 import QueryCompiler from '../../../query/compiler';
 
-import { assign, identity } from 'lodash'
+import { assign, identity, map } from 'lodash'
 
 function QueryCompiler_MySQL(client, builder) {
   QueryCompiler.call(this, client, builder)
@@ -36,6 +36,19 @@ assign(QueryCompiler_MySQL.prototype, {
 
   forShare() {
     return 'lock in share mode';
+  },
+
+  // Compiles a `listTables` query
+  listTables() {
+    return {
+      sql: 'select table_name from information_schema.tables where table_schema = ?',
+      bindings: [this.client.database()],
+      output(resp) {
+        return map(resp, function (table) {
+          return table.table_name
+        })
+      }
+    }
   },
 
   // Compiles a `columnInfo` query.

--- a/src/dialects/oracle/query/compiler.js
+++ b/src/dialects/oracle/query/compiler.js
@@ -143,6 +143,18 @@ assign(QueryCompiler_Oracle.prototype, {
     return '';
   },
 
+  // Compiles a `listTables` query
+  listTables() {
+    return {
+      sql: `select table_name from user_tables`,
+      output(resp) {
+        return map(resp, function (table) {
+          return table.TABLE_NAME
+        })
+      }
+    }
+  },
+
   // Compiles a `columnInfo` query.
   columnInfo() {
     const column = this.single.columnInfo;

--- a/src/dialects/postgres/query/compiler.js
+++ b/src/dialects/postgres/query/compiler.js
@@ -5,7 +5,7 @@ import inherits from 'inherits';
 
 import QueryCompiler from '../../../query/compiler';
 
-import { assign, reduce, identity } from 'lodash'
+import { assign, reduce, identity, map } from 'lodash'
 
 function QueryCompiler_PG(client, builder) {
   QueryCompiler.call(this, client, builder);
@@ -73,6 +73,20 @@ assign(QueryCompiler_PG.prototype, {
 
   forShare() {
     return 'for share';
+  },
+
+  // Compiles a `listTables` query
+  listTables() {
+    return {
+      sql: 'select table_name from information_schema.tables' +
+           'where table_schema = \'public\' and table_catalog = ?',
+      bindings: [this.client.database()],
+      output(resp) {
+        return map(resp.rows, function (table) {
+          return table.table_name
+        })
+      }
+    }
   },
 
   // Compiles a columnInfo query

--- a/src/dialects/sqlite3/query/compiler.js
+++ b/src/dialects/sqlite3/query/compiler.js
@@ -3,7 +3,7 @@
 
 import inherits from 'inherits';
 import QueryCompiler from '../../../query/compiler';
-import { assign, each, isEmpty, isString, noop, reduce, identity } from 'lodash'
+import { assign, each, isEmpty, isString, map, noop, reduce, identity } from 'lodash'
 import { warn } from '../../../helpers';
 
 function QueryCompiler_SQLite3(client, builder) {
@@ -101,6 +101,18 @@ assign(QueryCompiler_SQLite3.prototype, {
         return this.query({
           sql: `delete from sqlite_sequence where name = '${table}'`
         }).catch(noop)
+      }
+    }
+  },
+
+  // Compiles a `listTables` query
+  listTables() {
+    return {
+      sql: `SELECT name FROM sqlite_master WHERE type='table';`,
+      output(resp) {
+        return map(resp, function (table) {
+          return table.name;
+        });
       }
     }
   },

--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -884,6 +884,12 @@ assign(Builder.prototype, {
     return this;
   },
 
+  // Lists tables
+  listTables() {
+    this._method = 'listTables';
+    return this;
+  },
+
   // Retrieves columns for the table specified by `knex(tableName)`
   columnInfo(column) {
     this._method = 'columnInfo';

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -216,6 +216,18 @@ module.exports = function(knex) {
       expect(knex.fn.now().toQuery()).to.equal('CURRENT_TIMESTAMP');
     });
 
+    it('should list tables', () => {
+      return knex().listTables().then(res => {
+        expect(res.sort()).to.deep.equal([
+          '10_test_table', 'BatchInsert', 'accounts', 'batchInsertDuplicateKey',
+          'bool_test', 'catch_test', 'charset_collate_test', 'composite_key_test',
+          'datatype_test', 'group', 'invalid_inTable_param_test', 'knex_migrations',
+          'knex_migrations_lock', 'sqlite_sequence', 'test_default_table',
+          'test_default_table2', 'test_table', 'test_table_two'
+        ]);
+      });
+    });
+
     it('gets the columnInfo', function() {
       return knex('datatype_test').columnInfo().testSql(function(tester) {
         tester('mysql',


### PR DESCRIPTION
Implements a new method `listTables` which queries and returns a list of table names in the current database. See https://github.com/tgriesser/knex/issues/360.

---

I'd like to keep the test explicit (`expect(resp).to.deep.equal([...])` is better than `expect(resp).to.include.items([...])`). Not sure how to handle that nicely here, because there's a lot of tables created and every time a new one is added, it needs to be added to this `listTables` test.

Thoughts?