### PR TITLE
Fix knex initialization

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -42,12 +42,13 @@ function checkLocalModule(env) {
 
 function initKnex(env, opts) {
   checkLocalModule(env);
-  if (process.cwd() !== env.cwd) {
-    process.chdir(env.cwd);
-    console.log('Working directory changed to', color.magenta(tildify(env.cwd)));
-  }
 
   if (!opts.knexfile) {
+    if (process.cwd() !== env.cwd) {
+      process.chdir(env.cwd);
+      console.log('Working directory changed to', color.magenta(tildify(env.cwd)));
+    }
+
     const configuration = tryLoadingDefaultConfiguration();
     env.configuration = configuration || mkConfigObj(opts);
   }
@@ -296,8 +297,7 @@ cli.on('requireFail', function(name) {
 cli.launch(
   {
     cwd: argv.cwd,
-    knexfile: argv.knexfile,
-    knexpath: argv.knexpath,
+    configPath: argv.knexfile,
     require: argv.require,
     completion: argv.completion,
   },


### PR DESCRIPTION
Closes #2998

Fixes a bug that was preventing loaders to parse files. With this change knex 0.16 successfully loads `knexfile.ts`