### PR TITLE
Restore __knexTxId on connection in transaction disposer

### DIFF
--- a/src/dialects/mssql/transaction.js
+++ b/src/dialects/mssql/transaction.js
@@ -74,6 +74,7 @@ export default class Transaction_MSSQL extends Transaction {
         }
       })
       .disposer(function(conn) {
+        conn.__knexTxId = t.outerTx ? t.outerTx.txid : undefined;
         if (t.outerTx) return;
         if (conn.tx_) {
           if (!t._completed) {

--- a/src/dialects/oracle/transaction.js
+++ b/src/dialects/oracle/transaction.js
@@ -51,6 +51,7 @@ export default class Oracle_Transaction extends Transaction {
       })
       .disposer((connection) => {
         debugTx('%s: releasing connection', t.txid);
+        connection.__knexTxId = t.outerTx ? t.outerTx.txid : undefined;
         connection.setAutoCommit(true);
         if (!config.connection) {
           t.client.releaseConnection(connection);

--- a/src/dialects/oracledb/transaction.js
+++ b/src/dialects/oracledb/transaction.js
@@ -54,6 +54,7 @@ export default class Oracle_Transaction extends Transaction {
       });
     }).disposer(function(connection) {
       debugTx('%s: releasing connection', t.txid);
+      connection.__knexTxId = t.outerTx ? t.outerTx.txid : undefined;
       connection.isTransaction = false;
       connection.commitAsync().then(function(err) {
         if (err) {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -162,6 +162,7 @@ export default class Transaction extends EventEmitter {
   // via config or getting one off the client. The disposer will be called once
   // the original promise is marked completed.
   acquireConnection(client, config, txid) {
+    const t = this;
     const configConnection = config && config.connection;
     return Promise.try(() => configConnection || client.acquireConnection())
       .then(function(connection) {
@@ -170,6 +171,7 @@ export default class Transaction extends EventEmitter {
         return connection;
       })
       .disposer(function(connection) {
+        connection.__knexTxId = t.outerTx ? t.outerTx.txid : undefined;
         if (!configConnection) {
           debug('%s: releasing connection', txid);
           client.releaseConnection(connection);


### PR DESCRIPTION
Hello,

Found a small issue with knex's debug logs today.

The transaction id in logs is obtained from connection's `__knexTxId` prop which is set around the start of the transaction, but is never removed.

Causes queries in the log to look like they come from a long-closed transaction - happens with nested transactions, or in mixed transactional / autocommit workflow.

In the example below, second `outer trx` query is logged with `trx3` transaction id, instead of `trx2`.

The proposed change resets connection's `__knexTxId` prop in disposer.

```javascript
process.env.DEBUG = 'knex:*';

const Knex = require('knex');

const knex = Knex({
    client: 'sqlite3',
    connection: {
        filename: "./db.sqlite"
    },
    useNullAsDefault: true
});

async function main() {
    await knex.raw(`select 1, 'no trx'`);
    await knex.transaction(async trx => {
        await trx.raw(`select 1, 'outer trx'`);
        await trx.transaction(async trx => {
            await trx.raw(`select 1, 'inner trx 1'`);
        });
        await trx.raw(`select 1, 'outer trx'`);
    });
    await knex.raw(`select 1, 'no trx'`);
}

main()
    .catch(console.log)
    .finally(() => knex.destroy());
```
```
  knex:client acquired connection from pool: __knexUid1 +0ms
  knex:query select 1, 'no trx' undefined +0ms
  knex:bindings [] undefined +0ms
  knex:client releasing connection to pool: __knexUid1 +6ms
  knex:tx trx2: Starting top level transaction +0ms
  knex:client acquired connection from pool: __knexUid1 +2ms
  knex:query BEGIN; trx2 +4ms
  knex:bindings undefined trx2 +5ms
  knex:query select 1, 'outer trx' trx2 +2ms
  knex:bindings [] trx2 +1ms
  knex:tx trx3: Starting nested transaction +4ms
  knex:query SAVEPOINT trx3; trx3 +1ms
  knex:bindings undefined trx3 +2ms
  knex:query select 1, 'inner trx 1' trx3 +2ms
  knex:bindings [] trx3 +1ms
  knex:query RELEASE SAVEPOINT trx3; trx3 +0ms
  knex:bindings undefined trx3 +0ms
  knex:tx trx3: releasing connection +3ms
  knex:query select 1, 'outer trx' trx3 +1ms
  knex:bindings [] trx3 +1ms
  knex:query COMMIT; trx3 +1ms
  knex:bindings undefined trx3 +1ms
  knex:tx trx2: releasing connection +2ms
  knex:client releasing connection to pool: __knexUid1 +8ms
  knex:client acquired connection from pool: __knexUid1 +0ms
  knex:query select 1, 'no trx' trx3 +2ms
  knex:bindings [] trx3 +2ms
  knex:client releasing connection to pool: __knexUid1 +1ms
```
