### PR TITLE
Treat offset and limit input the same way

### DIFF
--- a/src/query/builder.js
+++ b/src/query/builder.js
@@ -851,7 +851,12 @@ assign(Builder.prototype, {
 
   // Only allow a single "offset" to be set for the current query.
   offset(value) {
-    this._single.offset = value;
+    const val = parseInt(value, 10);
+    if (isNaN(val)) {
+      this.client.logger.warn('A valid integer must be provided to offset');
+    } else {
+      this._single.offset = val;
+    }
     return this;
   },
 


### PR DESCRIPTION
Currently, if you give offset a string, it will throw an error like this:
```
code: 'ER_PARSE_ERROR',
  errno: 1064,
  sqlMessage:
   'You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'\'0\'\' at line 1',
  sqlState: '42000',
  index: 0,
  sql:
   'select * from `Alert` inner join `AlertType` on `Alert`.`AlertTypeID` = `AlertType`.`AlertTypeID` order by `AlertDate` desc limit 2 offset \'0\'' }
```
This is problematic, seeing how offset is likely used in pagination using a query in the url, which is usually treated as a string. It's weird to me that it's not like this already since `limit`, a relatively similar method, is implemented this way.