### PR TITLE
Override --connection if specified through cmd line arguments (#3305)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -65,6 +65,16 @@ function initKnex(env, opts) {
   }
 
   const resolvedConfig = resolveEnvironmentConfig(opts, env.configuration);
+
+  // override connection, client and migrationsTableName
+  // if specified through cmd line arguments
+
+  if (opts.connection) resolvedConfig.connection = opts.connection;
+  if (opts.client) resolvedConfig.client = opts.client;
+  if (opts.migrationsTableName) {
+    resolvedConfig.migrations.tableName = opts.migrationsTableName;
+  }
+
   const knex = require(env.modulePath);
   return knex(resolvedConfig);
 }

--- a/test/jake/jakelib/migrate-test.js
+++ b/test/jake/jakelib/migrate-test.js
@@ -9,6 +9,7 @@ const rimrafSync = require('rimraf').sync;
 const path = require('path');
 const sqlite3 = require('sqlite3');
 const { assert } = require('chai');
+const { promisify } = require('util');
 const { assertExec } = require('../../jake-util/helpers/migration-test-helper');
 const knexfile = require('../../jake-util/knexfile/knexfile.js');
 
@@ -641,6 +642,24 @@ test('migrate:list prints migrations both completed and pending', async (temp) =
     migrationsList2Result.stdout,
     `No Pending Migration files Found.`
   );
+});
+
+test('override connection, client and migrations-table-name if specified through cmd line arguments', async (temp) => {
+  const { stdout } = await assertExec(`${KNEX} migrate:latest \
+              --client=sqlite3  --connection=${temp}/db2 \
+              --migrations-directory=test/jake-util/knexfile_migrations \
+              --migrations-table-name=custom_migrations_table`);
+  assert.include(
+    stdout,
+    `Using environment: development\nBatch 1 run: 1 migrations`
+  );
+
+  const db = await new sqlite3.Database(temp + '/db2');
+  const sqlite3GetProm = promisify(db.get.bind(db));
+  const row = await sqlite3GetProm(
+    "SELECT name FROM sqlite_master where type='table' AND name='custom_migrations_table'"
+  );
+  assert.equal(row.name, 'custom_migrations_table');
 });
 
 module.exports = {


### PR DESCRIPTION
override connection, client, and migrations-table-name if specified through cmd line arguments.

[Fixes #3305](https://github.com/tgriesser/knex/issues/3305)