### PR TITLE
Make sqlite3 hasColumn case insensitive

### DIFF
--- a/lib/dialects/sqlite3/schema/compiler.js
+++ b/lib/dialects/sqlite3/schema/compiler.js
@@ -29,8 +29,8 @@ SchemaCompiler_SQLite3.prototype.hasColumn = function(tableName, column) {
     output(resp) {
       return some(resp, (col) => {
         return (
-          this.client.wrapIdentifier(col.name) ===
-          this.client.wrapIdentifier(column)
+          this.client.wrapIdentifier(col.name.toLowerCase()) ===
+          this.client.wrapIdentifier(column.toLowerCase())
         );
       });
     },

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -1058,12 +1058,13 @@ module.exports = function(knex) {
             return Promise.resolve();
           }
 
-          it('checks whether a column exists without being case sensitive, resolving with a boolean', function() {
-            return knex.schema
-              .hasColumn('accounts', 'FIRST_NAME')
-              .then(function(exists) {
-                expect(exists).to.equal(true);
-              });
+          it('checks whether a column exists without being case sensitive, resolving with a boolean', async () => {
+            const exists = await knex.schema.hasColumn(
+              'accounts',
+              'FIRST_NAME'
+            );
+
+            expect(exists).to.equal(true);
           });
         });
       });

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -1048,6 +1048,24 @@ module.exports = function(knex) {
               expect(exists).to.equal(true);
             });
         });
+
+        describe('sqlite only', function() {
+          if (
+            !knex ||
+            !knex.client ||
+            !/sqlite3/i.test(knex.client.driverName)
+          ) {
+            return Promise.resolve();
+          }
+
+          it('checks whether a column exists without being case sensitive, resolving with a boolean', function() {
+            return knex.schema
+              .hasColumn('accounts', 'FIRST_NAME')
+              .then(function(exists) {
+                expect(exists).to.equal(true);
+              });
+          });
+        });
       });
 
       describe('using processorss', function() {


### PR DESCRIPTION
This PR makes the sqlite3 `hasColumn` function case insensitive to respect sqlite3 convention.

Fix #3434.

It might some new tests ? let me know and I'll add the necessary ones.