### PR TITLE
Fixes types for Seeder#run

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1826,7 +1826,7 @@ declare namespace Knex {
   class Seeder {
     constructor(knex: Knex);
     setConfig(config: SeederConfig): SeederConfig;
-    run(config?: SeederConfig): Promise<string[]>;
+    run(config?: SeederConfig): Promise<[string[]]>;
     make(name: string, config?: SeederConfig): Promise<string>;
   }
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -1203,10 +1203,10 @@ const main = async () => {
       directory: 'lib/seeds'
   });
 
-  // $ExpectType string[]
+  // $ExpectType [string[]]
   await knex.seed.run();
 
-  // $ExpectType string[]
+  // $ExpectType [string[]]
   await knex.seed.run({
       extension: 'ts',
       directory: 'lib/seeds'


### PR DESCRIPTION
The `seed.run` command returns a array of a single item, and that item contains the array of strings (filepaths of seeds that were run).

This comes from here: 
- https://github.com/tgriesser/knex/blob/master/lib/seed/Seeder.js#L37
- https://github.com/tgriesser/knex/blob/master/lib/seed/Seeder.js#L90
- https://github.com/tgriesser/knex/blob/master/lib/seed/Seeder.js#L162