### PR TITLE
feat: Add types to the Migrator interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1828,7 +1828,6 @@ declare namespace Knex {
     currentVersion(config?: MigratorConfig): Promise<string>;
     up(config?: MigratorConfig): Promise<any>;
     down(config?: MigratorConfig): Promise<any>;
-    list(config?: MigratorConfig): Promise<any>;
     forceFreeMigrationsLock(config?: MigratorConfig): Promise<any>;
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1828,6 +1828,8 @@ declare namespace Knex {
     currentVersion(config?: MigratorConfig): Promise<string>;
     up(config?: MigratorConfig): Promise<any>;
     down(config?: MigratorConfig): Promise<any>;
+    list(config?: MigratorConfig): Promise<any>;
+    forceFreeMigrationsLock(config?: MigratorConfig): Promise<any>;
   }
 
   interface SeederConfig {


### PR DESCRIPTION
Add typings to the `list` and `forceFreeMigrationsLock` methods.