### PR TITLE
Fix undefined value error

### DIFF
--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -352,7 +352,7 @@ function readStream(stream, cb) {
   const oracledb = require('oracledb');
   let data = '';
 
-  if (stream.iLob.type === oracledb.CLOB) {
+  if (stream.iLob && stream.iLob.type === oracledb.CLOB) {
     stream.setEncoding('utf-8');
   } else {
     data = Buffer.alloc(0);
@@ -361,7 +361,7 @@ function readStream(stream, cb) {
     cb(err);
   });
   stream.on('data', function(chunk) {
-    if (stream.iLob.type === oracledb.CLOB) {
+    if (stream.iLob && stream.iLob.type === oracledb.CLOB) {
       data += chunk;
     } else {
       data = Buffer.concat([data, chunk]);


### PR DESCRIPTION
Since version 0.19.5, Oracle is throwing `type is undefined` when we call `.columnInfo()`. This fixes it.