### PR TITLE
Gracefully handle global promise pollution

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1401,7 +1401,7 @@ declare namespace Knex {
   // Chainable interface
   //
 
-  interface ChainableInterface<T = any> extends Promise<T> {
+  interface ChainableInterface<T = any> extends Pick<Promise<T>, "then" | "catch" | "finally"> {
     toQuery(): string;
     options(options: { [key: string]: any }): this;
     connection(connection: any): this;


### PR DESCRIPTION
- Update QueryInterface to proxy to only standard promise methods
- Update QueryInterface type to be explicit about the methods being
  proxied

This primarily handles pollution of global Promise (either the type or
the global object at runtime) by other libraries.

Fixes: https://github.com/knex/knex/issues/3422#issuecomment-546930375