### PR TITLE
Fix typing file

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1802,9 +1802,7 @@ declare namespace Knex {
 
   interface PoolConfig {
     name?: string;
-    create?: Function;
     afterCreate?: Function;
-    destroy?: Function;
     min?: number;
     max?: number;
     refreshIdle?: boolean;
@@ -1812,7 +1810,6 @@ declare namespace Knex {
     reapIntervalMillis?: number;
     returnToHead?: boolean;
     priorityRange?: number;
-    validate?: Function;
     log?: (message: string, logLevel: string) => void;
 
     // generic-pool v3 configs

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1813,7 +1813,7 @@ declare namespace Knex {
     returnToHead?: boolean;
     priorityRange?: number;
     validate?: Function;
-    log?: boolean;
+    log?: (message: string, logLevel: string) => void;
 
     // generic-pool v3 configs
     maxWaitingClients?: number;

--- a/types/test.ts
+++ b/types/test.ts
@@ -27,6 +27,9 @@ const knex2 = Knex({
     ...clientConfig,
     log: {
         debug(msg: string) {}
+    },
+    pool: {
+      log: (msg: string, level: string) => {}
     }
 });
 


### PR DESCRIPTION
Two changes in the typings file:

- Fixed the type of `log` method in PoolConfig interface
- Removed `create`, `destroy` and `validate` methods from PoolConfig interface, because Knex is overriding these methods, and any user provided implementations of these methods are being ignored. Having these methods in the typings file will only confuse users.