### PR TITLE
Expand SeedsConfig types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1622,7 +1622,7 @@ declare namespace Knex {
     nullable: boolean;
   }
 
-  interface Config {
+  interface Config<SV extends object = object> {
     debug?: boolean;
     client?: string | typeof Client;
     dialect?: string;
@@ -1636,7 +1636,7 @@ declare namespace Knex {
       origImpl: (value: string) => string,
       queryContext: any
     ) => string;
-    seeds?: SeedsConfig;
+    seeds?: SeedsConfig<SV>;
     acquireConnectionTimeout?: number;
     useNullAsDefault?: boolean;
     searchPath?: string | string[];
@@ -1868,9 +1868,12 @@ declare namespace Knex {
     migrationSource?: any;
   }
 
-  interface SeedsConfig {
+  interface SeedsConfig<V extends object = object> {
     directory?: string;
+    extension?: string;
+    loadExtensions?: string[];
     stub?: string;
+    variables?: V;
   }
 
   interface Migrator {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1622,7 +1622,7 @@ declare namespace Knex {
     nullable: boolean;
   }
 
-  interface Config<SV extends object = object> {
+  interface Config<SV extends {} = any> {
     debug?: boolean;
     client?: string | typeof Client;
     dialect?: string;
@@ -1868,7 +1868,7 @@ declare namespace Knex {
     migrationSource?: any;
   }
 
-  interface SeedsConfig<V extends object = object> {
+  interface SeedsConfig<V extends {} = any> {
     directory?: string;
     extension?: string;
     loadExtensions?: string[];


### PR DESCRIPTION
This is not a change to behavior; it's just an update to the TypeScript types to reflect the actuality of what's in the codebase. Inspecting `lib/seed/Seeder.js` there are five unique references to `this.config.`, but only two were previously represented in the types.

I'm a big fan of generics and how they can help us write more explicit code but if you want to eliminate that for something more broad, like just `variables?: object` or `variables?: any` that's fine; I'm not using it.

I'm submitting this PR because I encountered the following issue:

`knexfile.ts` has the following:

```js
seeds: {
  directory: './db/seeds',
  stub: './db/seed.stub.ts',
}
```

Using the `.ts` stub file by way of `npx knex seed:make thing` generates a migration with a `.js` extension. Obviously that's not right. I can add `-x ts` in the command line, but it seems silly to need to do that every time when it's the only way I want to use it in the project.

So I thought, can I add `extension` as I can with `migrations`? TypeScript says no. But I tried it, with `} as any` for the seeds value, and it worked. So then I dug into the code, and yep there it is.

tl;dr `SeedsConfig` respects `extension` but the Type doesn't allow it currently. Everything else is secondary.

Since this isn't a change to behavior, and all added keys are optional, it shouldn't be a breaking change and I haven't written any tests. Please let me know if there's more I can do to ensure this meets the standards of the repo.