### PR TITLE
Dispose oracle connection on connection error

### DIFF
--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -176,7 +176,21 @@ Client_Oracledb.prototype.acquireRawConnection = function() {
             fetchRowsFromRS(connection, result.resultSet, numRows);
           });
         } else {
-          connection.execute(sql, bindParams || [], options, cb);
+          connection.execute(sql, bindParams || [], options, function(
+            err,
+            result
+          ) {
+            if (err) {
+              // dispose the connection on connection error
+              if (isConnectionError(err)) {
+                connection.close().catch(function(err) {});
+                connection.__knex__disposed = err;
+              }
+              return cb(err);
+            }
+
+            return cb(null, result);
+          });
         }
       });
       connection.executeAsync = function(sql, bindParams, options) {


### PR DESCRIPTION
Similar to what is already implemented for queries with `resultSet` option as true. This option is set for select queries.

https://github.com/knex/knex/blob/f87b28c3e3a6e2624d83ab9c4c68ecffc913aee5/lib/dialects/oracledb/index.js#L139-L150

Previously, the connection was disposed on connection error only for select queries. After this change, it will be disposed on connection error for any type of query. This will any non-usable connections from the connection pool.