### PR TITLE
Initialize data to buffer instead of string for non-strings

### DIFF
--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -341,10 +341,7 @@ Client_Oracledb.prototype._query = function(connection, obj) {
  */
 function readStream(stream, type) {
   return new Promise((resolve, reject) => {
-    let data = '';
-    if (type !== 'string') {
-      data = Buffer(0);
-    }
+    let data = type === 'string' ? '' : Buffer(0);
 
     stream.on('error', function(err) {
       reject(err);

--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -342,6 +342,9 @@ Client_Oracledb.prototype._query = function(connection, obj) {
 function readStream(stream, type) {
   return new Promise((resolve, reject) => {
     let data = '';
+    if (type !== 'string') {
+      data = Buffer(0);
+    }
 
     stream.on('error', function(err) {
       reject(err);

--- a/test/unit/dialects/oracledb.js
+++ b/test/unit/dialects/oracledb.js
@@ -111,17 +111,14 @@ describe('OracleDb parameters', function() {
         });
     });
 
-    it('on blob', function() {
-      return knexClient
-        .raw(
-          'select TO_BLOB(\'67c1a1acaaca11a1b36fa6636166709b\') as "field" from dual'
-        )
-        .then(function(result) {
-          expect(result[0]).to.be.ok;
-          expect(result[0].field.toString('hex')).to.be.equal(
-            '67c1a1acaaca11a1b36fa6636166709b'
-          );
-        });
+    it('on blob', async () => {
+      const result = await knexClient.raw(
+        'select TO_BLOB(\'67c1a1acaaca11a1b36fa6636166709b\') as "field" from dual'
+      );
+      expect(result[0]).to.be.ok;
+      expect(result[0].field.toString('hex')).to.be.equal(
+        '67c1a1acaaca11a1b36fa6636166709b'
+      );
     });
 
     after(function() {

--- a/test/unit/dialects/oracledb.js
+++ b/test/unit/dialects/oracledb.js
@@ -111,6 +111,19 @@ describe('OracleDb parameters', function() {
         });
     });
 
+    it('on blob', function() {
+      return knexClient
+        .raw(
+          'select TO_BLOB(\'67c1a1acaaca11a1b36fa6636166709b\') as "field" from dual'
+        )
+        .then(function(result) {
+          expect(result[0]).to.be.ok;
+          expect(result[0].field.toString('hex')).to.be.equal(
+            '67c1a1acaaca11a1b36fa6636166709b'
+          );
+        });
+    });
+
     after(function() {
       return knexClient.destroy();
     });


### PR DESCRIPTION
A variable to hold the Stream data is initialized to a string.  In the case that the type of the stream is not "string", data is concat'ed to a Buffer, which fails.  This changes initializes data to a Buffer in case that it is not a string.