### PR TITLE
Add connection string qs to connection params

### DIFF
--- a/lib/util/parse-connection.js
+++ b/lib/util/parse-connection.js
@@ -56,7 +56,7 @@ function connectionObject(parsed) {
     }
   }
   if (parsed.query) {
-    for (var key in parsed.query) {
+    for (const key in parsed.query) {
       connection[key] = parsed.query[key];
     }
   }

--- a/lib/util/parse-connection.js
+++ b/lib/util/parse-connection.js
@@ -3,7 +3,7 @@ const { parse } = require('pg-connection-string');
 const parsePG = parse;
 
 module.exports = function parseConnectionString(str) {
-  const parsed = url.parse(str);
+  const parsed = url.parse(str, true);
   let { protocol } = parsed;
   if (protocol === null) {
     return {
@@ -53,6 +53,11 @@ function connectionObject(parsed) {
       }
     } else {
       connection.user = parsed.auth;
+    }
+  }
+  if (parsed.query) {
+    for (var key in parsed.query) {
+      connection[key] = parsed.query[key];
     }
   }
   return connection;

--- a/test/tape/parse-connection.js
+++ b/test/tape/parse-connection.js
@@ -44,7 +44,7 @@ test('mysql connection protocol with query string params', function(t) {
       client: 'mysql',
       connection: {
         user: 'user',
-        user: 'pass',
+        password: 'pass',
         host: 'path.to.some-url',
         port: '3306',
         database: 'testdb',

--- a/test/tape/parse-connection.js
+++ b/test/tape/parse-connection.js
@@ -36,6 +36,24 @@ test('parses standard connections without password', function(t) {
   );
 });
 
+test('mysql connection protocol with query string params', function(t) {
+  t.plan(1);
+  t.deepEqual(
+    parseConnection('mysql://user:pass@path.to.some-url:3306/testdb?foo=bar'),
+    {
+      client: 'mysql',
+      connection: {
+        user: 'user',
+        user: 'pass',
+        host: 'path.to.some-url',
+        port: '3306',
+        database: 'testdb',
+        foo: 'bar',
+      },
+    }
+  );
+});
+
 test('parses mssql connections, aliasing host to server', function(t) {
   t.plan(1);
   const mssql = {
@@ -50,6 +68,27 @@ test('parses mssql connections, aliasing host to server', function(t) {
   };
   t.deepEqual(
     parseConnection('mssql://username:pass@path.to.some-url:6000/testdb'),
+    mssql
+  );
+});
+
+test('parses mssql connections, aliasing host to server and adding extra params', function(t) {
+  t.plan(1);
+  const mssql = {
+    client: 'mssql',
+    connection: {
+      user: 'user',
+      password: 'pass',
+      server: 'path.to.some-url',
+      port: '6000',
+      database: 'testdb',
+      param: 'value',
+    },
+  };
+  t.deepEqual(
+    parseConnection(
+      'mssql://user:pass@path.to.some-url:6000/testdb?param=value'
+    ),
     mssql
   );
 });


### PR DESCRIPTION
Like mentioned in here https://github.com/knex/knex/issues/2354#issuecomment-555968462 this will allow query string params to be passed to driver used. It already works like this in other libraries, and seems like it be helpful for multiple cases.

Example in MySql https://github.com/mysqljs/mysql/blob/master/lib/ConnectionConfig.js#L186