### PR TITLE
Fix queryContext function defintion

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1330,6 +1330,7 @@ declare namespace Knex {
     wrap<TResult2 = TResult>(before: string, after: string): Raw<TResult>;
     toSQL(): Sql;
     queryContext(context: any): Raw<TResult>;
+    queryContext(): any;
   }
 
   interface RawBuilder<TRecord extends {} = any, TResult = any> {
@@ -1390,6 +1391,7 @@ declare namespace Knex {
     on(event: string, callback: Function): QueryBuilder<TRecord, TResult>;
 
     queryContext(context: any): QueryBuilder<TRecord, TResult>;
+    queryContext(): any;
 
     clone(): QueryBuilder<TRecord, TResult>;
     timeout(ms: number, options?: {cancel?: boolean}): QueryBuilder<TRecord, TResult>;

--- a/types/test.ts
+++ b/types/test.ts
@@ -1333,4 +1333,7 @@ const main = async () => {
   await knex
     .select('*')
     .from('users', { only: true });
+
+  // $ExpectType any
+  knex.queryBuilder().queryContext();
 };


### PR DESCRIPTION
According to the docs, calling `queryContext` with no arguments returns the context object. (ref: https://knexjs.org/#Builder-queryContext)

This PR adds the relevant overload to the function definition for that use case.