### PR TITLE
(WIP) Add tests for some of the string utility functions 

### DIFF
--- a/lib/query/string.js
+++ b/lib/query/string.js
@@ -54,7 +54,7 @@ function makeEscape(config = {}) {
 }
 
 function escapeObject(val, finalEscape, ctx) {
-  if (typeof val.toSQL === 'function') {
+  if (val && typeof val.toSQL === 'function') {
     return val.toSQL(ctx);
   } else {
     return JSON.stringify(val);

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,11 @@ process.on('exit', (code) => {
   console.log('No unhandled exceptions');
 });
 
+describe('Util Tests', function() {
+  // Unit Tests for utilities.
+  require('./unit/query/string');
+});
+
 describe('Query Building Tests', function() {
   this.timeout(process.env.KNEX_TEST_TIMEOUT || 5000);
 

--- a/test/unit/query/string.js
+++ b/test/unit/query/string.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const { expect } = require('chai');
-const { escapeObject, arrayToList } = require('../../../lib/query/string');
+const {
+  escapeObject,
+  arrayToList,
+  escapeString,
+} = require('../../../lib/query/string');
 
 describe('String utility functions', () => {
   describe('arrayToList', () => {
@@ -12,14 +16,14 @@ describe('String utility functions', () => {
       const input = [];
       const output = '';
 
-      expect(arrayToList(input, escapeFunc), output);
+      expect(arrayToList(input, escapeFunc)).to.equal(output);
     });
 
     it('should return a string with empty parenthesis for a nested array with empty array', () => {
       const input = [[]];
       const output = '()';
 
-      expect(arrayToList(input, escapeFunc), output);
+      expect(arrayToList(input, escapeFunc)).to.equal(output);
     });
 
     it('should convert an array to a string', () => {
@@ -27,8 +31,8 @@ describe('String utility functions', () => {
       const output1 = '1, 2, 3, 4, 5';
       const output2 = "'1', '2', '3', '4', '5'";
 
-      expect(arrayToList(input, escapeFunc), output1);
-      expect(arrayToList(input, escapeQuotedFunc), output2);
+      expect(arrayToList(input, escapeFunc)).to.equal(output1);
+      expect(arrayToList(input, escapeQuotedFunc)).to.equal(output2);
     });
 
     it('should convert a nested array to string', () => {
@@ -36,29 +40,29 @@ describe('String utility functions', () => {
       const output1 = '0, (1, 2), (3, 4), 5';
       const output2 = "'0', ('1', '2'), ('3', '4'), '5'";
 
-      expect(arrayToList(input, escapeFunc), output1);
-      expect(arrayToList(input, escapeQuotedFunc), output2);
+      expect(arrayToList(input, escapeFunc)).to.equal(output1);
+      expect(arrayToList(input, escapeQuotedFunc)).to.equal(output2);
     });
 
     it('should convert an array with single value to string', () => {
       const input = [0];
       const output = "'0'";
 
-      expect(arrayToList(input, escapeQuotedFunc), output);
+      expect(arrayToList(input, escapeQuotedFunc)).to.equal(output);
     });
 
     it('should convert a nested array with single value to string', () => {
       const input = [[0]];
       const output = "('0')";
 
-      expect(arrayToList(input, escapeQuotedFunc), output);
+      expect(arrayToList(input, escapeQuotedFunc)).to.equal(output);
     });
 
     it('should support an array with multiple levels of nesting', () => {
       const input = [0, [1, 2, [3, 4, [5, 6, [7]]]], 8];
       const output = '0, (1, 2, (3, 4, (5, 6, (7)))), 8';
 
-      expect(arrayToList(input, escapeFunc), output);
+      expect(arrayToList(input, escapeFunc)).to.equal(output);
     });
   });
 
@@ -66,26 +70,26 @@ describe('String utility functions', () => {
     it('should use the `toSQL()` method on an object if it has it as a member', () => {
       const obj = {
         value: 'foo',
-        toSQL: (ctx) => {
+        toSQL(ctx) {
           return this.value + ctx;
         },
       };
-      expect(escapeObject(obj, 'bar'), 'foobar');
+      expect(escapeObject(obj, undefined, 'bar')).to.equal('foobar');
     });
 
     it('should give a stringified (json friendly) value if any scalar value is provided', () => {
-      expect(escapeObject('foo'), '"foo"');
-      expect(escapeObject('"foobar"'), '"\\"foobar\\""');
-      expect(escapeObject("'foobar'"), `"'foobar'"`);
-      expect(escapeObject(0), '0');
-      expect(escapeObject(-5), '-5');
-      expect(escapeObject(null), 'null');
-      expect(escapeObject(true), 'true');
-      expect(escapeObject(false), 'false');
+      expect(escapeObject('foo')).to.equal('"foo"');
+      expect(escapeObject('"foobar"')).to.equal('"\\"foobar\\""');
+      expect(escapeObject("'foobar'")).to.equal(`"'foobar'"`);
+      expect(escapeObject(0)).to.equal('0');
+      expect(escapeObject(-5)).to.equal('-5');
+      expect(escapeObject(null)).to.equal('null');
+      expect(escapeObject(true)).to.equal('true');
+      expect(escapeObject(false)).to.equal('false');
     });
 
     it('should return undefined if undefined is provided as an input', () => {
-      expect(escapeObject(undefined), undefined);
+      expect(escapeObject(undefined)).to.equal(undefined);
     });
   });
 });

--- a/test/unit/query/string.js
+++ b/test/unit/query/string.js
@@ -92,4 +92,45 @@ describe('String utility functions', () => {
       expect(escapeObject(undefined)).to.equal(undefined);
     });
   });
+
+  describe('escapeString', () => {
+    it('should return a quoted string for a regular string', () => {
+      expect(escapeString('Foo Bar')).to.equal("'Foo Bar'");
+    });
+
+    it('should return a quoted empty string for an empty string', () => {
+      expect(escapeString('')).to.equal("''");
+    });
+
+    it('should escape a string with quotes', () => {
+      expect(escapeString('foo = "bar"')).to.equal('\'foo = \\"bar\\"\'');
+      expect(escapeString("foo = 'bar'")).to.equal("'foo = \\'bar\\''");
+    });
+
+    it('should escape a encoded json string', () => {
+      const input = '{"foo": "bar"}';
+      const output = '\'{\\"foo\\": \\"bar\\"}\'';
+
+      expect(escapeString(input)).to.equal(output);
+    });
+
+    it('should escape strings with newline or other whitespace characters', () => {
+      const input1 = `
+      Foo Bar
+      `;
+      const output1 = "'\\n      Foo Bar\\n      '";
+      const input2 =
+        String.fromCharCode(13) +
+        String.fromCharCode(10) +
+        'Foo' +
+        String.fromCharCode(9) +
+        String.fromCharCode(9) +
+        'Bar' +
+        String.fromCharCode(13) +
+        String.fromCharCode(10);
+      const output2 = "'" + '\\r\\nFoo\\t\\tBar\\r\\n' + "'";
+      expect(escapeString(input1)).to.equal(output1);
+      expect(escapeString(input2)).to.equal(output2);
+    });
+  });
 });

--- a/test/unit/query/string.js
+++ b/test/unit/query/string.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const { arrayToList } = require('../../../lib/query/string');
+const { escapeObject, arrayToList } = require('../../../lib/query/string');
 
 describe('String utility functions', () => {
   describe('arrayToList', () => {
@@ -31,7 +31,7 @@ describe('String utility functions', () => {
       expect(arrayToList(input, escapeQuotedFunc), output2);
     });
 
-    it('should convert a nested array to a string', () => {
+    it('should convert a nested array to string', () => {
       const input = [0, [1, 2], [3, 4], 5];
       const output1 = '0, (1, 2), (3, 4), 5';
       const output2 = "'0', ('1', '2'), ('3', '4'), '5'";
@@ -59,6 +59,33 @@ describe('String utility functions', () => {
       const output = '0, (1, 2, (3, 4, (5, 6, (7)))), 8';
 
       expect(arrayToList(input, escapeFunc), output);
+    });
+  });
+
+  describe('escapeObject', () => {
+    it("should use the `toSQL()` method on an object if it has it as it's member", () => {
+      const obj = {
+        value: 'foo',
+        toSQL: (ctx) => {
+          return this.value + ctx;
+        },
+      };
+      expect(escapeObject(obj, 'bar'), 'foobar');
+    });
+
+    it('should give a stringified (json friendly) value if any scalar value is provided', () => {
+      expect(escapeObject('foo'), '"foo"');
+      expect(escapeObject('"foobar"'), '"\\"foobar\\""');
+      expect(escapeObject("'foobar'"), `"'foobar'"`);
+      expect(escapeObject(0), '0');
+      expect(escapeObject(-5), '-5');
+      expect(escapeObject(null), 'null');
+      expect(escapeObject(true), 'true');
+      expect(escapeObject(false), 'false');
+    });
+
+    it('should return undefined if undefined is provided as an input', () => {
+      expect(escapeObject(undefined), undefined);
     });
   });
 });

--- a/test/unit/query/string.js
+++ b/test/unit/query/string.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const chai = require('chai');
+const { arrayToList } = require('../../../lib/query/string');
+
+describe('String utility functions', () => {
+  describe('arrayToList', () => {
+    const escapeFunc = (value) => value;
+    const escapeQuotedFunc = (value) => `'${value}'`;
+
+    it('should return empty string for an empty array', () => {
+      const input = [];
+      const output = '';
+
+      expect(arrayToList(input, escapeFunc), output);
+    });
+
+    it('should return a string with empty parenthesis for a nested array with empty array', () => {
+      const input = [[]];
+      const output = '()';
+
+      expect(arrayToList(input, escapeFunc), output);
+    });
+
+    it('should convert an array to a string', () => {
+      const input = [1, 2, 3, 4, 5];
+      const output1 = '1, 2, 3, 4, 5';
+      const output2 = "'1', '2', '3', '4', '5'";
+
+      expect(arrayToList(input, escapeFunc), output1);
+      expect(arrayToList(input, escapeQuotedFunc), output2);
+    });
+
+    it('should convert a nested array to a string', () => {
+      const input = [0, [1, 2], [3, 4], 5];
+      const output1 = '0, (1, 2), (3, 4), 5';
+      const output2 = "'0', ('1', '2'), ('3', '4'), '5'";
+
+      expect(arrayToList(input, escapeFunc), output1);
+      expect(arrayToList(input, escapeQuotedFunc), output2);
+    });
+
+    it('should convert an array with single value to string', () => {
+      const input = [0];
+      const output = "'0'";
+
+      expect(arrayToList(input, escapeQuotedFunc), output);
+    });
+
+    it('should convert a nested array with single value to string', () => {
+      const input = [[0]];
+      const output = "('0')";
+
+      expect(arrayToList(input, escapeQuotedFunc), output);
+    });
+
+    it('should support an array with multiple levels of nesting', () => {
+      const input = [0, [1, 2, [3, 4, [5, 6, [7]]]], 8];
+      const output = '0, (1, 2, (3, 4, (5, 6, (7)))), 8';
+
+      expect(arrayToList(input, escapeFunc), output);
+    });
+  });
+});

--- a/test/unit/query/string.js
+++ b/test/unit/query/string.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const chai = require('chai');
+const { expect } = require('chai');
 const { escapeObject, arrayToList } = require('../../../lib/query/string');
 
 describe('String utility functions', () => {

--- a/test/unit/query/string.js
+++ b/test/unit/query/string.js
@@ -63,7 +63,7 @@ describe('String utility functions', () => {
   });
 
   describe('escapeObject', () => {
-    it("should use the `toSQL()` method on an object if it has it as it's member", () => {
+    it('should use the `toSQL()` method on an object if it has it as a member', () => {
       const obj = {
         value: 'foo',
         toSQL: (ctx) => {

--- a/test/unit/query/string.js
+++ b/test/unit/query/string.js
@@ -129,8 +129,39 @@ describe('String utility functions', () => {
         String.fromCharCode(13) +
         String.fromCharCode(10);
       const output2 = "'" + '\\r\\nFoo\\t\\tBar\\r\\n' + "'";
+
       expect(escapeString(input1)).to.equal(output1);
       expect(escapeString(input2)).to.equal(output2);
+    });
+
+    it('should quote the values well when used in SQL queries', () => {
+      const user = 'foo';
+      const password = "Test;$3`'[/*;";
+      const sql =
+        'SELECT * FROM users WHERE user = ' +
+        escapeString(user) +
+        ' AND password = ' +
+        escapeString(password) +
+        ';';
+      const sqlOutput =
+        "SELECT * FROM users WHERE user = 'foo' AND password = 'Test;$3`\\'[/*;';";
+
+      expect(sql).to.equal(sqlOutput);
+    });
+
+    it('should quote the values subjective to SQL injection too when used in SQL queries', () => {
+      const user = "' OR 0 = 0";
+      const password = "' OR 1 = 1; DROP TABLE users; /*";
+      const sql =
+        'SELECT * FROM users WHERE user = ' +
+        escapeString(user) +
+        ' AND password = ' +
+        escapeString(password) +
+        ';';
+      const sqlOutput =
+        "SELECT * FROM users WHERE user = '\\' OR 0 = 0' AND password = '\\' OR 1 = 1; DROP TABLE users; /*';";
+
+      expect(sql).to.equal(sqlOutput);
     });
   });
 });


### PR DESCRIPTION
Looking at the [code coverage](https://coveralls.io/github/tgriesser/knex) I found some of the core utility functions were not fully covered - I've added tests for some string functions. 

**WIP - I will add few more tests into this PR as listed below.**

**Tests**
Add unit tests for string utility functions:
  - [x] `arrayToList`
  - [x] `escapeObject`
  - [ ] `bufferToString`
  - [ ] `dateToString`
  - [x] `escapeString`
  - [ ] `makeEscape`

**Other Changes**
  - Make `escapeObject` handle the case for an empty input - previously it would have thrown `TypeError: Cannot read property 'toSQL' of undefined`