### PR TITLE
The project location has moved to knex/knex

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,18 +3,18 @@
 - Make changes in the `/lib` directory. 
 
 - Before sending a pull request for a feature or bug fix, be sure to have
-  [tests](https://github.com/tgriesser/knex/tree/master/test). Every pull request that changes the queries should have
+  [tests](https://github.com/knex/knex/tree/master/test). Every pull request that changes the queries should have
   also **integration tests which are ran against real database** (in addition to unit tests which checks which kind of queries
   are being created).
 
 - Use the same coding style as the rest of the
-  [codebase](https://github.com/tgriesser/knex/blob/master/knex.js).
+  [codebase](https://github.com/knex/knex/blob/master/knex.js).
 
 - All pull requests should be made to the `master` branch.
 
 - Pull request description should have link to corresponding PR of documentation branch.
 
-- All pull requests that modify the public API should be updated in [types/index.d.ts](https://github.com/tgriesser/knex/blob/master/types/index.d.ts)
+- All pull requests that modify the public API should be updated in [types/index.d.ts](https://github.com/knex/knex/blob/master/types/index.d.ts)
 
 ## Documentation
 
@@ -144,7 +144,7 @@ $ DB='postgres mysql' npm test
 
 ### Custom Configuration
 
-If you'd like to override the database configuration (to use a different host, for example), you can override the path to the [default test configuration](https://github.com/tgriesser/knex/blob/master/test/knexfile.js) using the `KNEX_TEST` environment variable.
+If you'd like to override the database configuration (to use a different host, for example), you can override the path to the [default test configuration](https://github.com/knex/knex/blob/master/test/knexfile.js) using the `KNEX_TEST` environment variable.
 
 ```bash
 $ KNEX_TEST='./path/to/my/config.js' npm test

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Node.js, featuring:
 - [connection pooling](http://knexjs.org/#Installation-pooling)
 - [streaming queries](http://knexjs.org/#Interfaces-Streams)
 - both a [promise](http://knexjs.org/#Interfaces-Promises) and [callback](http://knexjs.org/#Interfaces-Callbacks) API
-- a [thorough test suite](https://travis-ci.org/tgriesser/knex)
+- a [thorough test suite](https://travis-ci.org/knex/knex)
 - the ability to [run in the Browser](http://knexjs.org/#Installation-browser)
 
 Node.js versions 8+ are supported.
 
 [Read the full documentation to get started!](http://knexjs.org)  
-[Or check out our Recipes wiki to search for solutions to some specific problems](https://github.com/tgriesser/knex/wiki/Recipes)  
-If upgrading from older version, see [Upgrading instructions](https://github.com/tgriesser/knex/blob/master/UPGRADING.md)
+[Or check out our Recipes wiki to search for solutions to some specific problems](https://github.com/knex/knex/wiki/Recipes)  
+If upgrading from older version, see [Upgrading instructions](https://github.com/knex/knex/blob/master/UPGRADING.md)
 
 For support and questions, join the `#bookshelf` channel on freenode IRC
 

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/tgriesser/knex.git"
+    "url": "git://github.com/knex/knex.git"
   },
   "homepage": "https://knexjs.org",
   "keywords": [


### PR DESCRIPTION
This PR fixes some broken links, and since the project has moved, it guess it is better to change old location.

However, there are still some other references with the issues ID, but I am not sure if they also should be changed.