### PR TITLE
Pass date objects through to the MySQL driver instead of modifying them

### DIFF
--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -52,7 +52,12 @@ Object.assign(Client_MySQL.prototype, {
     return new Transaction(this, ...arguments);
   },
 
-  _escapeBinding: makeEscape(),
+  _escapeBinding: makeEscape({
+      // Let mysql handle dates in the driver
+      escapeDate(val) {
+          return val;
+      }
+  }),
 
   wrapIdentifierImpl(value) {
     return value !== '*' ? `\`${value.replace(/`/g, '``')}\`` : '*';


### PR DESCRIPTION
This resolves #3577 by making knex pass dates through to the driver instead of modifying them. However, this causes a single test failure that raises a question.

Since the dates are not being encoded by knex anymore, the `toString()` (aka `toQuery()`) methods get the raw `Date` object which causes it to print out the default Date `.toString()` value in the query.

I can't think of an easy way to work around this since the date actually gets modified by the driver... but since `toString()` according to the docs is "Useful for debugging, but should not be used to create queries for running them against DB." maybe this is okay? If so I can modify the test.

```
AssertionError: expected 'select * from `users` where updtime = \'2016-01-05 10:19:30.599\'' to equal 'select * from `users` where updtime = \'Tue Jan 05 2016 10:19:30 GMT+0000 (Coordinated Universal Time)\''
      + expected - actual
      -select * from `users` where updtime = '2016-01-05 10:19:30.599'
      +select * from `users` where updtime = 'Tue Jan 05 2016 10:19:30 GMT+0000 (Coordinated Universal Time)'
```