### PR TITLE
Separate each alter column into a separate statement in MSSQL

### DIFF
--- a/lib/dialects/mssql/schema/tablecompiler.js
+++ b/lib/dialects/mssql/schema/tablecompiler.js
@@ -85,6 +85,20 @@ Object.assign(TableCompiler_MSSQL.prototype, {
 
   changeType() {},
 
+  alterColumns(columns, colBuilders) {
+    for (const col of columns.sql) {
+      this.pushQuery({
+        sql:
+          (this.lowerCase ? 'alter table ' : 'ALTER TABLE ') +
+          this.tableName() +
+          ' ' +
+          this.alterColumnPrefix +
+          col,
+        bindings: columns.bindings,
+      });
+    }
+  },
+
   // Renames a column on the table.
   renameColumn(from, to) {
     this.pushQuery(


### PR DESCRIPTION
MSSQL does not allow more than one column to be altered in a single statement. This patch overrides the default behaviour that combines them and will instead generate separate statements for each.

For example, this changes the behaviour of:

```
knex.schema.alterTable('test', function(t) {
     t.timestamp('foo').alter();
     t.timestamp('bar').alter();
})
```

from

`ALTER TABLE [test] ALTER COLUMN [foo] datetime2, [bar] datetime2`

to

```
ALTER TABLE [test] ALTER COLUMN [foo] datetime2
ALTER TABLE [test] ALTER COLUMN [bar] datetime2
```