### PR TITLE
Add raw support to QueryBuilder

### DIFF
--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -201,7 +201,7 @@ assign(Builder.prototype, {
     this._statements.push({
       grouping: 'columns',
       value,
-      distinctOn: true
+      distinctOn: true,
     });
     return this;
   },
@@ -866,6 +866,18 @@ assign(Builder.prototype, {
 
   orHavingRaw(sql, bindings) {
     return this._bool('or').havingRaw(sql, bindings);
+  },
+
+  raw(sql, bindings) {
+    const raw = sql instanceof Raw ? sql : this.client.raw(sql, bindings);
+    this._statements.push({
+      grouping: 'raws',
+      type: 'raw',
+      value: raw,
+      bool: this._bool(),
+      not: this._not(),
+    });
+    return this;
   },
 
   // Only allow a single "offset" to be set for the current query.

--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -50,6 +50,7 @@ const components = [
   'offset',
   'lock',
   'waitMode',
+  'raws',
 ];
 
 assign(QueryCompiler.prototype, {
@@ -396,6 +397,20 @@ assign(QueryCompiler.prototype, {
     return sql.length > 1 ? sql.join(' ') : '';
   },
 
+  // Compiles all `raw` statements on the query.
+  raws() {
+    const raws = this.grouped.raws;
+    if (!raws) return;
+    const sql = [];
+    let i = -1;
+    while (++i < raws.length) {
+      const stmt = raws[i];
+      const val = this[stmt.type](stmt);
+      sql.push(val);
+    }
+    return sql.join(' ');
+  },
+
   group() {
     return this._groupsOrders('group');
   },
@@ -579,9 +594,7 @@ assign(QueryCompiler.prototype, {
   },
 
   distinctOn(value) {
-    throw new Error(
-      '.distinctOn() is currently only supported on PostgreSQL'
-    )
+    throw new Error('.distinctOn() is currently only supported on PostgreSQL');
   },
 
   // On Clause
@@ -704,6 +717,10 @@ assign(QueryCompiler.prototype, {
   // Compiles a "whereRaw" query.
   whereRaw(statement) {
     return this._not(statement, '') + this.formatter.unwrapRaw(statement.value);
+  },
+
+  raw(statement) {
+    return this.formatter.unwrapRaw(statement.value);
   },
 
   wrap(str) {

--- a/lib/query/methods.js
+++ b/lib/query/methods.js
@@ -88,4 +88,5 @@ module.exports = [
   'truncate',
   'transacting',
   'connection',
+  'raw',
 ];

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3839,6 +3839,22 @@ describe('QueryBuilder', () => {
     );
   });
 
+  it('raw', () => {
+    testsql(
+      qb()
+        .select('*')
+        .from('users')
+        .whereRaw('1 = ?', [1])
+        .raw('FOR SYSTEM_TIME AS OF ?', ['12/24/2019']),
+      {
+        pg: {
+          sql: 'select * from "users" where 1 = ? FOR SYSTEM_TIME AS OF ?',
+          bindings: [1, '12/24/2019'],
+        },
+      }
+    );
+  });
+
   it('limits', () => {
     testsql(
       qb()


### PR DESCRIPTION
- Introduces a new grouping named `raws` in order to support the new command
- Append only

Looking for feedback on the interface. If the implementation is acceptable, I can add more tests.

Closes #3032