### PR TITLE
Fix benign use of sync API (#3595)

### DIFF
--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -70,7 +70,7 @@ assign(QueryCompiler.prototype, {
       timeout: this.timeout,
       cancelOnTimeout: this.cancelOnTimeout,
       bindings: this.formatter.bindings || [],
-      __knexQueryUid: uuid.v4(),
+      __knexQueryUid: uuid.v1(),
     };
 
     Object.defineProperties(query, {

--- a/lib/raw.js
+++ b/lib/raw.js
@@ -113,7 +113,7 @@ assign(Raw.prototype, {
       );
     }
 
-    obj.__knexQueryUid = uuid.v4();
+    obj.__knexQueryUid = uuid.v1();
 
     return obj;
   },


### PR DESCRIPTION
Running a program that uses knex with node --trace-sync-io results in
warnings such as this one:

    (node:10232) WARNING: Detected use of sync API
        at randomBytes (internal/crypto/random.js:54:31)
        at nodeRNG ([...]/node_modules/uuid/lib/rng.js:7:17)
        at v4 ([...]/node_modules/uuid/v4.js:13:52)
        at toSQL ([...]/node_modules/knex/lib/query/compiler.js:73:28)
        at toSQL ([...]/node_modules/knex/lib/query/builder.js:77:44)
        at [...]/node_modules/knex/lib/runner.js:30:36
        at [...]/node_modules/knex/lib/runner.js:253:24
        at tryCatcher ([...]/node_modules/knex/node_modules/bluebird/js/release/util.js:16:23)
        at [...]/node_modules/knex/node_modules/bluebird/js/release/promise.js:547:31

uuid.v1() provides more than adequate collision guarantees, is 5 times
faster than uuid.v4() and most importantly do not trigger the warning
above.