### PR TITLE
Update deprecated `dialect` to `client` in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ We have several examples [on the website](http://knexjs.org). Here is the first 
 
 ```js
 const knex = require('knex')({
-  dialect: 'sqlite3',
+  client: 'sqlite3',
   connection: {
     filename: './data.db',
   },


### PR DESCRIPTION
The code sample in the README.md uses a deprecated config option. When using `dialect`, one gets the warning: "Using 'this.dialect' to identify the client is deprecated and support for it will be removed in the future. Please use configuration option 'client' instead."