### PR TITLE
fix(cli): prevent warning showing up with root command

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -341,12 +341,11 @@ function invoke(env) {
         .catch(exit);
     });
 
-  commander.parse(process.argv);
-
-  Promise.resolve(pending).then(() => {
+  if (!commander._args.length) {
     commander.outputHelp();
-    exit('Unknown command-line options, exiting');
-  });
+  }
+
+  commander.parse(process.argv);
 }
 
 const cli = new Liftoff({


### PR DESCRIPTION
closes #3603 

Tweaked the code-base to make use of `commander.js` API that handles the scenario when no arguments were passed in.