### PR TITLE
fix #3605 not releasing connection from pool on disconnect

### DIFF
--- a/lib/dialects/oracledb/transaction.js
+++ b/lib/dialects/oracledb/transaction.js
@@ -70,18 +70,17 @@ module.exports = class Oracle_Transaction extends Transaction {
       } finally {
         debugTx('%s: releasing connection', this.txid);
         connection.isTransaction = false;
-        connection
-          .commitAsync()
-          .catch(function(err) {
-            t._rejecter(err);
-          })
-          .finally(function() {
-            if (!configConnection) {
-              t.client.releaseConnection(connection);
-            } else {
-              debugTx('%s: not releasing external connection', t.txid);
-            }
-          });
+        try {
+          await connection.commitAsync();
+        } catch (err) {
+          t._rejecter(err);
+        } finally {
+          if (!configConnection) {
+            await t.client.releaseConnection(connection);
+          } else {
+            debugTx('%s: not releasing external connection', t.txid);
+          }
+        }
       }
     });
   }

--- a/lib/dialects/oracledb/transaction.js
+++ b/lib/dialects/oracledb/transaction.js
@@ -48,39 +48,23 @@ module.exports = class Oracle_Transaction extends Transaction {
     return this.query(conn, `SAVEPOINT ${this.txid}`);
   }
 
-  acquireConnection(config, cb) {
+  async acquireConnection(config, cb) {
     const configConnection = config && config.connection;
-    const t = this;
-    return new Bluebird((resolve, reject) => {
-      try {
-        this.client
-          .acquireConnection()
-          .then((cnx) => {
-            cnx.__knexTxId = this.txid;
-            cnx.isTransaction = true;
-            resolve(cnx);
-          })
-          .catch(reject);
-      } catch (e) {
-        reject(e);
+    const connection = await this.client.acquireConnection();
+    connection.__knexTxId = this.txid;
+    connection.isTransaction = true;
+
+    try {
+      await cb(connection);
+      connection.isTransaction = false;
+      await connection.commitAsync();
+    } finally {
+      debugTx('%s: releasing connection', this.txid);
+      if (!configConnection) {
+        this.client.releaseConnection(connection);
+      } else {
+        debugTx('%s: not releasing external connection', this.txid);
       }
-    }).then(async (connection) => {
-      try {
-        return await cb(connection);
-      } finally {
-        debugTx('%s: releasing connection', this.txid);
-        connection.isTransaction = false;
-        connection.commitAsync().then(function(err) {
-          if (err) {
-            this._rejecter(err);
-          }
-          if (!configConnection) {
-            t.client.releaseConnection(connection);
-          } else {
-            debugTx('%s: not releasing external connection', t.txid);
-          }
-        });
-      }
-    });
+    }
   }
 };

--- a/lib/dialects/oracledb/transaction.js
+++ b/lib/dialects/oracledb/transaction.js
@@ -48,23 +48,41 @@ module.exports = class Oracle_Transaction extends Transaction {
     return this.query(conn, `SAVEPOINT ${this.txid}`);
   }
 
-  async acquireConnection(config, cb) {
+  acquireConnection(config, cb) {
     const configConnection = config && config.connection;
-    const connection = await this.client.acquireConnection();
-    connection.__knexTxId = this.txid;
-    connection.isTransaction = true;
-
-    try {
-      await cb(connection);
-      connection.isTransaction = false;
-      await connection.commitAsync();
-    } finally {
-      debugTx('%s: releasing connection', this.txid);
-      if (!configConnection) {
-        this.client.releaseConnection(connection);
-      } else {
-        debugTx('%s: not releasing external connection', this.txid);
+    const t = this;
+    return new Bluebird((resolve, reject) => {
+      try {
+        this.client
+          .acquireConnection()
+          .then((cnx) => {
+            cnx.__knexTxId = this.txid;
+            cnx.isTransaction = true;
+            resolve(cnx);
+          })
+          .catch(reject);
+      } catch (e) {
+        reject(e);
       }
-    }
+    }).then(async (connection) => {
+      try {
+        return await cb(connection);
+      } finally {
+        debugTx('%s: releasing connection', this.txid);
+        connection.isTransaction = false;
+        connection
+          .commitAsync()
+          .catch(function(err) {
+            t._rejecter(err);
+          })
+          .finally(function() {
+            if (!configConnection) {
+              t.client.releaseConnection(connection);
+            } else {
+              debugTx('%s: not releasing external connection', t.txid);
+            }
+          });
+      }
+    });
   }
 };


### PR DESCRIPTION
I took the liberty to use async/await as the code is much cleaner. Let me know if you want a less drastic change. I confirmed this works correctly against a live oracle database.