### PR TITLE
Print help only when there are no arguments

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -341,7 +341,7 @@ function invoke(env) {
         .catch(exit);
     });
 
-  if (!commander._args.length) {
+  if (!process.argv.slice(2).length) {
     commander.outputHelp();
   }
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "JSONStream": "^1.3.5",
     "chai": "^4.2.0",
     "chai-subset-in-order": "^2.1.3",
-    "cli-testlab": "^1.8.0",
+    "cli-testlab": "^1.10.0",
     "coveralls": "^3.0.9",
     "cross-env": "^6.0.3",
     "dtslint": "2.0.2",

--- a/test/cli/help.spec.js
+++ b/test/cli/help.spec.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const { execCommand } = require('cli-testlab');
 
-const cliPkg = require('../../package');
 const KNEX = path.normalize(__dirname + '/../../bin/cli.js');
 
 describe('help', () => {
@@ -26,8 +25,8 @@ describe('help', () => {
   });
 
   it('Does not print help when argument is given', () => {
-    return execCommand(`node ${KNEX} -V`).then(({ stdout, _ }) => {
-      expect(stdout).to.not.include('Usage');
+    return execCommand(`node ${KNEX} -V`, {
+      notExpectedOutput: 'Usage',
     });
   });
 });

--- a/test/cli/help.spec.js
+++ b/test/cli/help.spec.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const path = require('path');
+const { execCommand } = require('cli-testlab');
+
+const cliPkg = require('../../package');
+const KNEX = path.normalize(__dirname + '/../../bin/cli.js');
+
+describe('help', () => {
+  it('Prints help', () => {
+    return execCommand(`node ${KNEX} --help`, {
+      expectedOutput: 'Usage',
+    });
+  });
+
+  it('Prints help using -h flag', () => {
+    return execCommand(`node ${KNEX} -h`, {
+      expectedOutput: 'Usage',
+    });
+  });
+
+  it('Prints help when no arguments are given', () => {
+    return execCommand(`node ${KNEX}`, {
+      expectedOutput: 'Usage',
+    });
+  });
+
+  it('Does not print help when argument is given', () => {
+    return execCommand(`node ${KNEX} -V`).then(({ stdout, _ }) => {
+      expect(stdout).to.not.include('Usage');
+    });
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -93,4 +93,5 @@ describe('CLI tests', function() {
   require('./cli/migrate-make.spec');
   require('./cli/seed-make.spec');
   require('./cli/version.spec');
+  require('./cli/help.spec');
 });


### PR DESCRIPTION
knex cli should print help only when there are no arguments.
current implementation always prints help even when given correct arguments, such as `knex migrate:status`.
the correct way to check argument length is via process.argv.
reference: https://github.com/tj/commander.js/#outputhelpcb