### PR TITLE
Add support for 'CASCADE' in PostgreSQL 'DROP SCHEMA' queries

### DIFF
--- a/lib/dialects/postgres/schema/compiler.js
+++ b/lib/dialects/postgres/schema/compiler.js
@@ -76,12 +76,20 @@ SchemaCompiler_PG.prototype.createSchemaIfNotExists = function(schemaName) {
   );
 };
 
-SchemaCompiler_PG.prototype.dropSchema = function(schemaName) {
-  this.pushQuery(`drop schema ${this.formatter.wrap(schemaName)}`);
+SchemaCompiler_PG.prototype.dropSchema = function(schemaName, cascade = false) {
+  this.pushQuery(
+    `drop schema ${this.formatter.wrap(schemaName)}${cascade && ' CASCADE'}`
+  );
 };
 
-SchemaCompiler_PG.prototype.dropSchemaIfExists = function(schemaName) {
-  this.pushQuery(`drop schema if exists ${this.formatter.wrap(schemaName)}`);
+SchemaCompiler_PG.prototype.dropSchemaIfExists = function(
+  schemaName,
+  cascade = false
+) {
+  this.pushQuery(
+    `drop schema if exists ${this.formatter.wrap(schemaName)}${cascade &&
+      ' CASCADE'}`
+  );
 };
 
 SchemaCompiler_PG.prototype.dropExtension = function(extensionName) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1498,8 +1498,8 @@ declare namespace Knex {
       callback: (tableBuilder: AlterTableBuilder) => any
     ): Promise<void>;
     dropTableIfExists(tableName: string): SchemaBuilder;
-    dropSchema(schemaName: string): SchemaBuilder;
-    dropSchemaIfExists(schemaName: string): SchemaBuilder;
+    dropSchema(schemaName: string, cascade: boolean): SchemaBuilder;
+    dropSchemaIfExists(schemaName: string, cascade: boolean): SchemaBuilder;
     raw(statement: string): SchemaBuilder;
     withSchema(schemaName: string): SchemaBuilder;
     queryContext(context: any): SchemaBuilder;


### PR DESCRIPTION
This commit adds the option of specifying `CASCADE` to the `dropSchema` and `dropSchemaIfExists` methods.  Both methods maintain the current defaults.

See the [PostgreSQL: DROP SCHEMA](https://www.postgresql.org/docs/current/sql-dropschema.html) documentation for more information.