### PR TITLE
Update index.d.ts, interface MsSqlConnectionConfig enableArithAbort: null | boolean is required now.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1701,7 +1701,7 @@ declare namespace Knex {
       appName?: string;
       abortTransactionOnError?: boolean;
       trustedConnection?: boolean;
-      enableArithAbort?: boolean,
+      enableArithAbort?: boolean;
     };
     pool?: {
       min?: number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1701,6 +1701,7 @@ declare namespace Knex {
       appName?: string;
       abortTransactionOnError?: boolean;
       trustedConnection?: boolean;
+      enableArithAbort: null | boolean,
     };
     pool?: {
       min?: number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1701,7 +1701,7 @@ declare namespace Knex {
       appName?: string;
       abortTransactionOnError?: boolean;
       trustedConnection?: boolean;
-      enableArithAbort: null | boolean,
+      enableArithAbort?: boolean,
     };
     pool?: {
       min?: number;


### PR DESCRIPTION
Config object for mssql: see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mssql/index.d.ts is outdated. in tedious https://github.com/tediousjs/tedious/blob/master/src/connection.ts line 154, enableArithAbort: null | boolean is required now.