### PR TITLE
WIP: Improving support for introducing adhoc (unsafe) transformations before SQL generation

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,64 +1,9 @@
 const QueryBuilder = require('./query/builder');
 const Raw = require('./raw');
-const { transform } = require('lodash');
+const {operators} = require('./operators');
 
 // Valid values for the `order by` clause generation.
 const orderBys = ['asc', 'desc'];
-
-// Turn this into a lookup map
-const operators = transform(
-  [
-    '=',
-    '<',
-    '>',
-    '<=',
-    '>=',
-    '<>',
-    '!=',
-    'like',
-    'not like',
-    'between',
-    'not between',
-    'ilike',
-    'not ilike',
-    'exists',
-    'not exist',
-    'rlike',
-    'not rlike',
-    'regexp',
-    'not regexp',
-    '&',
-    '|',
-    '^',
-    '<<',
-    '>>',
-    '~',
-    '~*',
-    '!~',
-    '!~*',
-    '#',
-    '&&',
-    '@>',
-    '<@',
-    '||',
-    '&<',
-    '&>',
-    '-|-',
-    '@@',
-    '!!',
-    ['?', '\\?'],
-    ['?|', '\\?|'],
-    ['?&', '\\?&'],
-  ],
-  (result, key) => {
-    if (Array.isArray(key)) {
-      result[key[0]] = key[1];
-    } else {
-      result[key] = key;
-    }
-  },
-  {}
-);
 
 class Formatter {
   constructor(client, builder) {

--- a/lib/operators.js
+++ b/lib/operators.js
@@ -1,0 +1,56 @@
+const { transform } = require('lodash');
+
+// Turn this into a lookup map
+exports.operators = transform(
+    [
+      '=',
+      '<',
+      '>',
+      '<=',
+      '>=',
+      '<>',
+      '!=',
+      'like',
+      'not like',
+      'between',
+      'not between',
+      'ilike',
+      'not ilike',
+      'exists',
+      'not exist',
+      'rlike',
+      'not rlike',
+      'regexp',
+      'not regexp',
+      '&',
+      '|',
+      '^',
+      '<<',
+      '>>',
+      '~',
+      '~*',
+      '!~',
+      '!~*',
+      '#',
+      '&&',
+      '@>',
+      '<@',
+      '||',
+      '&<',
+      '&>',
+      '-|-',
+      '@@',
+      '!!',
+      ['?', '\\?'],
+      ['?|', '\\?|'],
+      ['?&', '\\?&'],
+    ],
+    (result, key) => {
+      if (Array.isArray(key)) {
+        result[key[0]] = key[1];
+      } else {
+        result[key] = key;
+      }
+    },
+    {}
+  );

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -80,6 +80,7 @@ assign(Builder.prototype, {
   transformRawTokens(transformer) {
     this._tokenTransformers = this._tokenTransformers || [];
     this._tokenTransformers.push(transformer);
+    return this;
   },
 
   // Create a shallow clone of the current query builder.

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -77,6 +77,11 @@ assign(Builder.prototype, {
     return this.client.queryCompiler(this).toSQL(method || this._method, tz);
   },
 
+  transformRawTokens(transformer) {
+    this._tokenTransformers = this._tokenTransformers || [];
+    this._tokenTransformers.push(transformer);
+  },
+
   // Create a shallow clone of the current query builder.
   clone() {
     const cloned = new this.constructor(this.client);

--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -6,6 +6,8 @@ const QueryBuilder = require('./builder');
 const JoinClause = require('./joinclause');
 const debug = require('debug');
 
+const { TokenListVisitor } = require('./token-visitors');
+
 const {
   assign,
   bind,
@@ -18,6 +20,7 @@ const {
   omitBy,
   reduce,
   has,
+  isFunction
 } = require('lodash');
 const uuid = require('uuid');
 
@@ -52,6 +55,7 @@ class QueryCompiler {
     this.formatter = client.formatter(builder);
     // Used when the insert call is empty.
     this._emptyInsertValue = 'default values';
+    this._tokenTransformers = builder._tokenTransformers;
     this.first = this.select;
   }
 
@@ -88,6 +92,14 @@ class QueryCompiler {
       query.sql = val;
     } else {
       assign(query, val);
+    }
+
+    if (isString(query.sql) && Array.isArray(this._tokenTransformers)) {
+      const visitor = new TokenListVisitor(tokenList);
+      for (let i = 0; i < this._tokenTransformers.length; i++) {
+        this._tokenTransformers[i](visitor);
+      }
+      query.sql = visitor.toString();
     }
 
     if (method === 'select' || method === 'first') {

--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -6,7 +6,7 @@ const QueryBuilder = require('./builder');
 const JoinClause = require('./joinclause');
 const debug = require('debug');
 
-const { TokenListVisitor } = require('./token-visitors');
+const { SQLTokenListVisitor } = require('./token-visitors');
 
 const {
   assign,
@@ -19,8 +19,7 @@ const {
   map,
   omitBy,
   reduce,
-  has,
-  isFunction
+  has
 } = require('lodash');
 const uuid = require('uuid');
 
@@ -94,8 +93,8 @@ class QueryCompiler {
       assign(query, val);
     }
 
-    if (isString(query.sql) && Array.isArray(this._tokenTransformers)) {
-      const visitor = new TokenListVisitor(tokenList);
+    if (Array.isArray(this._tokenTransformers) && isString(query.sql)) {
+      const visitor = new SQLTokenListVisitor(query.sql);
       for (let i = 0; i < this._tokenTransformers.length; i++) {
         this._tokenTransformers[i](visitor);
       }

--- a/lib/query/token-visitors.js
+++ b/lib/query/token-visitors.js
@@ -1,0 +1,168 @@
+const { isEmpty, compact, isNil, isFunction, isString, cloneDeep, castArray } = require("lodash");
+const Tokenizer = require("tokenize-this");
+
+class TokenListVisitor {
+    constructor(tokens) {
+        if (isString(tokens)) tokens = this.tokenize(tokens);
+        this.tokens = tokens;
+    }
+    tokenize(rawStr) {
+        const tokens = [];
+        const tokenizer = new Tokenizer();
+        tokenizer.tokenize(rawStr, (token) => {
+            tokens.push(token);
+        });
+        return tokens;
+    }
+    toString() {
+        return compact(this.tokens).join(' ');
+    }
+    findToken(value, isCaseSensitive = false, startIdx = 0) {
+        const lowerValue = value.toLowerCase();
+        for (let idx = startIdx; idx < this.tokens.length; idx++) {
+            const didMatch = isCaseSensitive
+                ? this.tokens[idx] === value
+                : this.tokens[idx].toLowerCase() === lowerValue;
+            if (didMatch) return new TokenItemVisitor(idx, this);
+        }
+        return null;
+    }
+    first() {
+        return new TokenItemVisitor(0, this);
+    }
+    last() {
+        return new TokenItemVisitor(this.tokens.length-1, this);
+    }
+    _replaceRange(startIdx, endIdx, tokenList) {
+        const normalized = this._normalizeTokenList(tokenList);
+        this.tokens.splice(startIdx, endIdx - startIdx, ...normalized);
+        return new TokenRangeVisitor(startIdx, normalized.length, this);
+    }
+    _replaceAtIndex(i, tokenList) {
+        const normalized = this._normalizeTokenList(tokenList);
+        this.tokens.splice(i, 1, ...normalized);
+        return new TokenRangeVisitor(i, normalized.length, this);
+    }
+    _insertAtIndex(i, tokenList) {
+        const normalized = this._normalizeTokenList(tokenList);
+        if (normalized.length === 0) return null;
+        this.tokens.splice(i, 0, ...normalized);
+        return new TokenRangeVisitor(i, normalized.length, this);
+    }
+    _normalizeTokenList(tokenList) {
+        return compact(castArray(tokenList));
+    }
+    _selectRange(start, step, predicate) {
+        const { tokens } = this.tokenListVisitor;
+        const range = { start: null, end: null };
+        for (let i = start; i < tokens.length && i >= 0; i += step) {
+            const token = tokens[i];
+            const shouldSelect = predicate(token, i);
+            if (shouldSelect) {
+                if (i <= start) {
+                    range.start = i;
+                }
+                if (i >= start) {
+                    range.end = i;
+                }
+            } else break;
+        }
+        if (isNil(range.start) || isNil(range.next)) {
+            return null;
+        }
+        return new TokenRangeVisitor(range.start, range.end, this);
+    }
+}
+
+class TokenItemVisitor {
+    constructor(index, tokenListVisitor) {
+        this.index = index;
+        this.tokenListVisitor = tokenListVisitor;
+    }
+    token() {
+        return this.tokenListVisitor.tokens[this.index];
+    }
+    peek(count = 1) {
+        return this.tokenListVisitor.tokens.slice(this.index, this.index + count).join(' ');
+    }
+    next(token, isCaseSensitive = false) {
+        if (!isNil(token)) {
+            return this.tokenListVisitor.findToken(token, isCaseSensitive, this.index + 1);
+        }
+        this.index += 1;
+        return this;
+    }
+    replace(replacement) {
+        if (isFunction(replacement)) {
+            let token = cloneDeep(this.tokenListVisitor.tokens[this.index])
+            replacement = replacement(token)
+        }
+        if (isString(replacement)) replacement = this.tokenListVisitor.tokenize(replacement);
+        return this.tokenListVisitor._replaceAtIndex(this.index, replacement)
+    }
+    insertBefore(tokens) {
+        if (isString(tokens)) tokens = this.tokenListVisitor.tokenize(tokens);
+        if (isEmpty(tokens)) throw new Error("Expected to find atleast one token");
+        return this.tokenListVisitor._insertAtIndex(this.index, tokens);
+    }
+    insertAfter(tokens) {
+        if (isString(tokens)) tokens = this.tokenListVisitor.tokenize(tokens);
+        if (isEmpty(tokens)) throw new Error("Expected to find atleast one token");
+        return this.tokenListVisitor._insertAtIndex(this.index + 1, tokens);
+    }
+    select(until) {
+        return this.tokenListVisitor._selectRange(this.index, 1, until || takeOneAt(this.index));
+    }
+    selectPrev(until) {
+        const start = this.index - 1;
+        return this.tokenListVisitor._selectRange(start, -1, until || takeOneAt(start));
+    }
+    selectNext(until) {
+        const start = this.index + 1;
+        return this.tokenListVisitor._selectRange(start, 1, until || takeOneAt(start));
+    }
+}
+
+class TokenRangeVisitor {
+    constructor(startIndex, endIndex, tokenListVisitor) {
+        this.startIndex = startIndex;
+        this.endIndex = endIndex;
+        this.tokenListVisitor = tokenListVisitor;
+    }
+    start() {
+        return new TokenItemVisitor(this.startIndex, this.tokenListVisitor);
+    }
+    end() {
+        return new TokenItemVisitor(this.endIndex, this.tokenListVisitor);
+    }
+    extendLeft(until) {
+        const rangeVisitor = this.tokenListVisitor._selectRange(this.startIndex, -1, until);
+        if (!isNil(rangeVisitor)) {
+            rangeVisitor.endIndex = this.endIndex;
+        }
+        return rangeVisitor;
+    }
+    extendRight(until) {
+        const rangeVisitor = this.tokenListVisitor._selectRange(this.endIndex, 1, until);
+        if (!isNil(rangeVisitor)) {
+            rangeVisitor.startIndex = this.startIndex;
+        }
+        return rangeVisitor
+    }
+    replace(replacement) {
+        if (isFunction(replacement)) {
+            let tokens = cloneDeep(this.tokenListVisitor.tokens.slice(this.startIndex, this.endIndex))
+            replacement = replacement(tokens)
+        }
+        if (isString(replacement)) replacement = this.tokenListVisitor.tokenize(replacement);
+        return this.tokenListVisitor._replaceRange(
+            this.startIndex,
+            this.endIndex,
+            replacement
+        );
+    }
+}
+
+const takeOneAt = (index) => (_token, i) => i === index;
+
+module.exports = { TokenListVisitor, TokenItemVisitor, TokenRangeVisitor };

--- a/lib/query/token-visitors.js
+++ b/lib/query/token-visitors.js
@@ -1,90 +1,223 @@
-const { isEmpty, compact, isNil, isFunction, isString, cloneDeep, castArray } = require("lodash");
+const { times, findIndex, isEmpty, compact, isNil, isFunction, isString, cloneDeep, castArray } = require("lodash");
 const Tokenizer = require("tokenize-this");
+const { operators } = require("../operators");
 
-class TokenListVisitor {
+/**
+ * Provides a fluent API to statefully traverse a token list, and perform token-level and
+ * range-level manipulations.
+ */
+class SQLTokenListVisitor {
+    /**
+     * @param {string[]} tokens List of tokens extracted from raw SQL
+     */
     constructor(tokens) {
         if (isString(tokens)) tokens = this.tokenize(tokens);
         this.tokens = tokens;
     }
+
+    /**
+     * Splits the SQL string into list of tokens.
+     * 
+     * @param {string} rawStr 
+     */
     tokenize(rawStr) {
         const tokens = [];
         const tokenizer = new Tokenizer();
-        tokenizer.tokenize(rawStr, (token) => {
+        tokenizer.tokenize(rawStr, (_token, surroundedBy) => {
+            const token = `${surroundedBy || ''}${_token}${surroundedBy || ''}`;
+
+            // Tokenizer is not SQL aware.
+            //
+            // We need to look back and check if combining this token with the
+            // last one gives us a valid SQL operator, in which case we will need
+            // to put them in the same token.
+            //
+            // This ensures that when joining them back we don't end up with invalid
+            // SQL (eg. && -> & &).
+            if (!surroundedBy) {
+                const operatorCandidates = [];
+                if (tokens.length > 0) {
+                    operatorCandidates.push(tokens[tokens.length - 1] + token);
+                }
+                if (tokens.length > 1) {
+                    operatorCandidates.push(
+                        tokens[tokens.length - 2] + 
+                        tokens[tokens.length - 1] +
+                        token
+                    );
+                }
+                for (const candidate of operatorCandidates) {
+                    const isKnownOperator = !!operators[operatorCandidates];
+                    if (isKnownOperator) {
+                        times(candidate.length-1, () => tokens.pop());
+                        tokens.push(candidate);
+                        return;
+                    }
+                }
+            }
             tokens.push(token);
         });
         return tokens;
     }
+
+    /**
+     * Combine tokens to SQL string
+     */
     toString() {
         return compact(this.tokens).join(' ');
     }
-    findToken(value, isCaseSensitive = false, startIdx = 0) {
-        const lowerValue = value.toLowerCase();
-        for (let idx = startIdx; idx < this.tokens.length; idx++) {
+
+    /**
+     * Return TokenItemVisitor for specified token
+     * 
+     * @param {string} token token to seek
+     * @param {boolean} isCaseSensitive if match should be case sensitive
+     * @param {number} startIdx position from where we should start looking (towards right)
+     */
+    findToken(token, isCaseSensitive = false, startIdx = 0) {
+        if (!isString(token)) {
+            throw new TypeError(`Expected token to be a string but found: ${token} (type: ${typeof token}) instead`)
+        }
+        const lowerValue = token.toLowerCase();
+        for (let i = startIdx; i < this.tokens.length; i++) {
+            const token = this.tokens[i];
             const didMatch = isCaseSensitive
-                ? this.tokens[idx] === value
-                : this.tokens[idx].toLowerCase() === lowerValue;
-            if (didMatch) return new TokenItemVisitor(idx, this);
+                ? token === token
+                : token.toLowerCase() === lowerValue;
+            if (didMatch) return new TokenItemVisitor(i, this);
         }
         return null;
     }
+
+    /**
+     * @return TokenItemVisitor for first token in the list
+     */
     first() {
         return new TokenItemVisitor(0, this);
     }
+
+    /**
+     * @return TokenItemVisitor for last token in the list
+     */
     last() {
-        return new TokenItemVisitor(this.tokens.length-1, this);
+        return new TokenItemVisitor(this.tokens.length - 1, this);
     }
+
+    /**
+     * Replace range of tokens
+     * 
+     * @param {number} startIdx 
+     * @param {number} endIdx 
+     * @param {string | string[]} tokenList 
+     */
     _replaceRange(startIdx, endIdx, tokenList) {
         const normalized = this._normalizeTokenList(tokenList);
         this.tokens.splice(startIdx, endIdx - startIdx, ...normalized);
         return new TokenRangeVisitor(startIdx, normalized.length, this);
     }
-    _replaceAtIndex(i, tokenList) {
+
+    /**
+     * Replace token at specified index
+     * 
+     * @param {number} index 
+     * @param {string | string[]} tokenList token(s) to be inserted
+     */
+    _replaceAtIndex(index, tokenList) {
         const normalized = this._normalizeTokenList(tokenList);
-        this.tokens.splice(i, 1, ...normalized);
-        return new TokenRangeVisitor(i, normalized.length, this);
+        this.tokens.splice(index, 1, ...normalized);
+        return new TokenRangeVisitor(index, normalized.length, this);
     }
-    _insertAtIndex(i, tokenList) {
+
+    /**
+     * Insert new token(s) at specified index
+     * 
+     * @param {number} index
+     * @param {string | string[]} tokenList token(s) to be inserted
+     */
+    _insertAtIndex(index, tokenList) {
         const normalized = this._normalizeTokenList(tokenList);
         if (normalized.length === 0) return null;
-        this.tokens.splice(i, 0, ...normalized);
-        return new TokenRangeVisitor(i, normalized.length, this);
+        this.tokens.splice(index, 0, ...normalized);
+        return new TokenRangeVisitor(index, normalized.length, this);
     }
+
+    /**
+     * Ensure array and remove empty tokens
+     * 
+     * @param {string[] | string} tokenList 
+     */
     _normalizeTokenList(tokenList) {
         return compact(castArray(tokenList));
     }
+
+    /**
+     * Select a range of tokens 
+     * 
+     * @param {number} start the index where to begin (inclusive)
+     * @param {number} step +1 if we are going forward, -1 if we are going back
+     * @param {(token: string, index: number) => boolean} predicate Condition evaluated for each token to determine if we should proceed.
+     * @return TokenRangeVisitor
+     */
     _selectRange(start, step, predicate) {
-        const { tokens } = this.tokenListVisitor;
         const range = { start: null, end: null };
-        for (let i = start; i < tokens.length && i >= 0; i += step) {
-            const token = tokens[i];
+        for (let i = start; i < this.tokens.length && i >= 0; i += step) {
+            const token = this.tokens[i];
             const shouldSelect = predicate(token, i);
             if (shouldSelect) {
                 if (i <= start) {
+                    // Going backward: Update the start
                     range.start = i;
                 }
                 if (i >= start) {
-                    range.end = i;
+                    // Going forward: Update the end
+                    range.end = i + 1;
                 }
             } else break;
         }
-        if (isNil(range.start) || isNil(range.next)) {
+        if (isNil(range.start) || isNil(range.end)) {
             return null;
         }
         return new TokenRangeVisitor(range.start, range.end, this);
     }
 }
 
+/**
+ * Visitor that tracks a position (index) in a token list
+ */
 class TokenItemVisitor {
+    /**
+     * @param {number} index 
+     * @param {string[]} tokenListVisitor 
+     */
     constructor(index, tokenListVisitor) {
         this.index = index;
         this.tokenListVisitor = tokenListVisitor;
     }
+
+    /**
+     * Get token at current index
+     */
     token() {
         return this.tokenListVisitor.tokens[this.index];
     }
+
+    /**
+     * Peek next token in list without actually changing visitor state. 
+     * 
+     * Useful for finite lookahead.
+     * 
+     * @param {number} count Number of steps to look ahead. Use negative number to look behind.
+     */
     peek(count = 1) {
         return this.tokenListVisitor.tokens.slice(this.index, this.index + count).join(' ');
     }
+
+    /**
+     * Visit next occurance of specified token towards the right from current position.
+     * 
+     * @param {string} token 
+     * @param {boolean} isCaseSensitive 
+     */
     next(token, isCaseSensitive = false) {
         if (!isNil(token)) {
             return this.tokenListVisitor.findToken(token, isCaseSensitive, this.index + 1);
@@ -92,49 +225,127 @@ class TokenItemVisitor {
         this.index += 1;
         return this;
     }
+
+    /**
+     * Replace the currently visited token.
+     * 
+     * @param {string | string[] | (token: string) => string | string[]} 
+     *     If a single string is passed it will be tokenized
+     *     If an array of strings is passed, they will be considered to be already tokenized
+     *     If function is passed, it will be invoked with previous token and its returned value 
+     *         will be treated as above
+     */
     replace(replacement) {
         if (isFunction(replacement)) {
-            let token = cloneDeep(this.tokenListVisitor.tokens[this.index])
+            const token = cloneDeep(this.tokenListVisitor.tokens[this.index])
             replacement = replacement(token)
         }
         if (isString(replacement)) replacement = this.tokenListVisitor.tokenize(replacement);
         return this.tokenListVisitor._replaceAtIndex(this.index, replacement)
     }
+
+    /**
+     * Insert one of more tokens before current token.
+     * 
+     * @param {string | string[]} tokens tokenized only if a single string is passed
+     */
     insertBefore(tokens) {
         if (isString(tokens)) tokens = this.tokenListVisitor.tokenize(tokens);
         if (isEmpty(tokens)) throw new Error("Expected to find atleast one token");
         return this.tokenListVisitor._insertAtIndex(this.index, tokens);
     }
+
+    /**
+     * Insert one or more tokens after current token.
+     * 
+     * @param {string | string[]} tokens tokenized only if a single string is passed
+     */
     insertAfter(tokens) {
         if (isString(tokens)) tokens = this.tokenListVisitor.tokenize(tokens);
         if (isEmpty(tokens)) throw new Error("Expected to find atleast one token");
         return this.tokenListVisitor._insertAtIndex(this.index + 1, tokens);
     }
-    select(until) {
-        return this.tokenListVisitor._selectRange(this.index, 1, until || takeOneAt(this.index));
+
+    _normalizeSelectionPredicate(predicate, targetIndex) {
+        if (isNil(predicate)) return takeOneAt(targetIndex);
+        if (isFunction(predicate)) return predicate;
+        throw new Error(`Invalid predicate supplied: ${predicate}. Expected function or token`);
     }
+
+    /**
+     * Select some tokens starting from current position (Current token is included)
+     * 
+     * @param {undefined | ((token: string) => boolean)} until
+     *     If undefined, next token will be selected.
+     *     If function, every token in sequence will be called with that predicate and will
+     *         be selected until the predicate returns false, at which point range will end.
+     */
+    select(until) {
+        const predicate = this._normalizeSelectionPredicate(until, this.index);
+        return this.tokenListVisitor._selectRange(this.index, 1, predicate);
+    }
+
+    /**
+     * Select some tokens going back from current position (current token is not included)
+     * 
+     * @param {undefined | ((token: string) => boolean)} until 
+     *     Refer select docs for this param
+     */
     selectPrev(until) {
         const start = this.index - 1;
-        return this.tokenListVisitor._selectRange(start, -1, until || takeOneAt(start));
+        const predicate = this._normalizeSelectionPredicate(until, start)
+        return this.tokenListVisitor._selectRange(start, -1, predicate);
     }
+
+    /**
+     * Select some tokens going forward from current position (current token is not included)
+     * 
+     * @param {undefined | ((token: string) => boolean)} until 
+     *     Refer select docs for this param
+     */
     selectNext(until) {
         const start = this.index + 1;
-        return this.tokenListVisitor._selectRange(start, 1, until || takeOneAt(start));
+        const predicate = this._normalizeSelectionPredicate(until, start)
+        return this.tokenListVisitor._selectRange(start, 1, predicate);
     }
 }
 
+/**
+ * Visitor that tracks a range (start index to end index) in a token list
+ */
 class TokenRangeVisitor {
+    /**
+     * @param {number} startIndex 
+     * @param {number} endIndex 
+     * @param {string[]} tokenListVisitor 
+     */
     constructor(startIndex, endIndex, tokenListVisitor) {
         this.startIndex = startIndex;
         this.endIndex = endIndex;
         this.tokenListVisitor = tokenListVisitor;
     }
-    start() {
+
+    /**
+     * Get TokenItemVisitor for first token in the selected range
+     */
+    first() {
         return new TokenItemVisitor(this.startIndex, this.tokenListVisitor);
     }
-    end() {
+
+    /**
+     * Get TokenItemVisitor for last token in the selected range
+     */
+    last() {
         return new TokenItemVisitor(this.endIndex, this.tokenListVisitor);
     }
+
+    /**
+     * Extend selection to left until the predicate returns false.
+     * 
+     * If predicate is not provided then one token to left is added to selection.
+     * 
+     * @param {(token: string) => booleab} [until] predicate used to determine when to stop
+     */
     extendLeft(until) {
         const rangeVisitor = this.tokenListVisitor._selectRange(this.startIndex, -1, until);
         if (!isNil(rangeVisitor)) {
@@ -142,6 +353,14 @@ class TokenRangeVisitor {
         }
         return rangeVisitor;
     }
+
+    /**
+     * Extend selection to right until the predicate returns false.
+     * 
+     * If predicate is not provided then one token to right is added to selection.
+     * 
+     * @param {(token: string) => booleab} [until] predicate used to determine when to stop
+     */
     extendRight(until) {
         const rangeVisitor = this.tokenListVisitor._selectRange(this.endIndex, 1, until);
         if (!isNil(rangeVisitor)) {
@@ -149,9 +368,15 @@ class TokenRangeVisitor {
         }
         return rangeVisitor
     }
+
+    /**
+     * Replace selection with specified token(s)
+     * 
+     * @param {string | string[]} replacement tokenized only if a single string is passed.
+     */
     replace(replacement) {
         if (isFunction(replacement)) {
-            let tokens = cloneDeep(this.tokenListVisitor.tokens.slice(this.startIndex, this.endIndex))
+            const tokens = cloneDeep(this.tokenListVisitor.tokens.slice(this.startIndex, this.endIndex))
             replacement = replacement(tokens)
         }
         if (isString(replacement)) replacement = this.tokenListVisitor.tokenize(replacement);
@@ -165,4 +390,4 @@ class TokenRangeVisitor {
 
 const takeOneAt = (index) => (_token, i) => i === index;
 
-module.exports = { TokenListVisitor, TokenItemVisitor, TokenRangeVisitor };
+module.exports = { SQLTokenListVisitor };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "pg-connection-string": "2.1.0",
     "tarn": "^2.0.0",
     "tildify": "2.0.0",
+    "tokenize-this": "^1.4.2",
     "uuid": "^3.3.3",
     "v8flags": "^3.1.3"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,7 @@ process.on('exit', (code) => {
 describe('Util Tests', function() {
   // Unit Tests for utilities.
   require('./unit/query/string');
+  require('./unit/query/token-visitors');
 });
 
 describe('Query Building Tests', function() {

--- a/test/unit/query/token-visitors.js
+++ b/test/unit/query/token-visitors.js
@@ -1,0 +1,83 @@
+const Knex = require('../../../lib/index');
+const { expect } = require('chai');
+const { SQLTokenListVisitor } = require('../../../lib/query/token-visitors');
+
+describe("Token visitor", () => {
+    const knex = Knex({
+        client: 'sqlite3',
+        connection: {
+            filename: ':memory:'
+        }
+    });
+    describe("tokenization and serializers", () => {
+        it('allows transformation of token list through a fluent API', () => {
+            const input = 'select id from users where user_id = 1';
+            let visitor = new SQLTokenListVisitor(input);
+            const tokens = visitor.tokens;
+            expect(tokens).to.eql([
+                'select',
+                'id',
+                'from',
+                'users',
+                'where',
+                'user_id',
+                '=',
+                '1'
+            ]);
+            expect(visitor.toString()).to.eql(input);
+            visitor
+                .findToken('select')
+                .insertAfter('name')
+                .last()
+                .insertAfter(',');
+            expect(visitor.toString()).to.eql('select name , id from users where user_id = 1');
+            visitor = new SQLTokenListVisitor(input);
+            visitor
+                .findToken('select')
+                .insertAfter(['name', ','])
+            expect(visitor.toString()).to.eql('select name , id from users where user_id = 1');
+            visitor = new SQLTokenListVisitor(input);
+            visitor
+                .findToken('select')
+                .insertAfter('name,')
+            expect(visitor.toString()).to.eql('select name , id from users where user_id = 1');
+            visitor = new SQLTokenListVisitor(input);
+            visitor
+                .findToken('select')
+                .next('where')
+                .selectPrev()
+                .replace('teams');
+            expect(visitor.toString()).to.eql('select id from teams where user_id = 1');
+            visitor
+                .findToken('where')
+                .next('=')
+                .select()
+                .replace('<>');
+            expect(visitor.toString()).to.eql('select id from teams where user_id <> 1');
+            visitor
+                .findToken('select')
+                .next('from')
+                .next('where')
+                .next('<>')
+                .selectNext()
+                .replace('2');
+            expect(visitor.toString()).to.eql('select id from teams where user_id <> 2');
+        })
+    });
+    describe("QueryBuilder#transformToken", () => {
+        it("allows transformation of tokens through visitors", () => {
+            const sql = knex('users')
+                .select('*')
+                .from('users')
+                .where({ user_id: 1 })
+                .transformRawTokens((t) => {
+                    t.findToken('select')
+                        .next('*')
+                        .select()
+                        .replace('id')
+                })
+                .toString();
+            expect(sql).to.eql('select id from `users` where `user_id` = 1');
+        });
+    });
+});


### PR DESCRIPTION
This primarily follows from the thread here: https://github.com/knex/knex/pull/3593#issuecomment-580346520

Proposed API adds a `transformRawTokens` to the `QueryBuilder` which enables users to transform the token list through a fluent visitor before the final SQL is generated. 

This is of course unsafe in the sense it is easy to construct invalid sql but can be an easy escape hatch when advanced users (who know what they are doing) want to insert dialect specific fragments 
 (for features that are not supported by knex) at appropriate places.

Example:

```js
knex('books')
  .insert([...])
  .transformRawTokens(t => {
    // t is a token visitor that allows you to easily traverse through the token list and 
    // insert custom tokens at adhoc places or substitute a range of tokens with another.
    t.findToken('insert').insertAfter('top 10')
  })
```

Generates: 

```sql
insert top 10 into [books] ...
```
Similarly,
```js
knex('dbo.DimCustomer as a')
  .innerJoin('dbo.FactInternetSales as b', 'a.CustomerKey', 'b.CustomerKey')
  .select('count(*)')
  .transformRawTokens(t => {
    t.last().insertAfter('OPTION (HASH JOIN)');
  })

```

Generates: 

```sql
SELECT COUNT (*) FROM [dbo].[DimCustomer] AS [a]  
INNER JOIN [dbo].[FactInternetSales] AS [b]   
ON ([a].[CustomerKey] = [b].[CustomerKey])  
OPTION (HASH JOIN); 
```

---

# TODO:

- [ ] Add support for placeholder bindings
- [ ] Update type definitions
- [ ] Add tests
- [ ] Update docs