### PR TITLE
Fix: Knex CLI calls process.chdir() before opening Knexfile

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -29,6 +29,15 @@ const fsPromised = {
 };
 
 function initKnex(env, opts) {
+  checkLocalModule(env);
+  if (process.cwd() !== env.cwd) {
+    process.chdir(env.cwd);
+    console.log(
+      'Working directory changed to',
+      color.magenta(tildify(env.cwd))
+    );
+  }
+
   if (opts.esm) {
     // enable esm interop via 'esm' module
     require = require('esm')(module);
@@ -46,15 +55,6 @@ function initKnex(env, opts) {
 
     // TODO: Should this property be documented somewhere?
     env.configuration.ext = path.extname(p).replace('.', '');
-  }
-
-  checkLocalModule(env);
-  if (process.cwd() !== env.cwd) {
-    process.chdir(env.cwd);
-    console.log(
-      'Working directory changed to',
-      color.magenta(tildify(env.cwd))
-    );
   }
 
   const resolvedConfig = resolveEnvironmentConfig(opts, env.configuration);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,6 +28,17 @@ const fsPromised = {
   writeFile: promisify(fs.writeFile),
 };
 
+function openKnexfile(configPath) {
+  const config = require(configPath);
+
+  // FYI: By default, the extension for the migration files is inferred
+  //      from the knexfile's extension. So, the following lines are in
+  //      place for backwards compatibility purposes.
+  config.ext = config.ext || path.extname(configPath).replace('.', '');
+
+  return config;
+}
+
 function initKnex(env, opts) {
   checkLocalModule(env);
   if (process.cwd() !== env.cwd) {
@@ -44,18 +55,8 @@ function initKnex(env, opts) {
   }
 
   env.configuration = env.configPath
-    ? require(env.configPath)
+    ? openKnexfile(env.configPath)
     : mkConfigObj(opts);
-
-  // FYI: By default, the extension for the migration files is inferred
-  //      from the knexfile's extension. So, the following lines are in
-  //      place for backwards compatibility purposes.
-  if (!env.configuration.ext) {
-    const p = env.configPath || opts.knexpath;
-
-    // TODO: Should this property be documented somewhere?
-    env.configuration.ext = path.extname(p).replace('.', '');
-  }
 
   const resolvedConfig = resolveEnvironmentConfig(opts, env.configuration);
   const knex = require(env.modulePath);

--- a/test/cli/knexfile-test.spec.js
+++ b/test/cli/knexfile-test.spec.js
@@ -77,6 +77,27 @@ module.exports = {
         );
       });
 
+      // This addresses the issue that was reported here:
+      //
+      //   https://github.com/knex/knex/issues/3660
+      //
+      context(
+        'and the knexfile itself resolves paths relative to process.cwd()',
+        function() {
+          it("changes the process's cwd to the directory that contains the knexfile before opening the knexfile", () => {
+            const knexfile = 'test/jake-util/knexfile-relative/knexfile.js';
+            const expectedCWD = tildify(path.resolve(path.dirname(knexfile)));
+
+            return execCommand(
+              `node ${KNEX} migrate:latest --knexfile=test/jake-util/knexfile-relative/knexfile-with-resolve.js --knexpath=../knex.js`,
+              {
+                expectedOutput: `Working directory changed to ${expectedCWD}`,
+              }
+            );
+          });
+        }
+      );
+
       // FYI: This is only true because the Knex CLI changes the CWD to
       //      the directory of the knexfile.
       it('Resolves migrations relatively to knexfile', () => {

--- a/test/jake-util/knexfile-relative/knexfile-with-resolve.js
+++ b/test/jake-util/knexfile-relative/knexfile-with-resolve.js
@@ -1,0 +1,24 @@
+// This knexfile recreates the issue that was identified here:
+//
+//   https://github.com/knex/knex/issues/3660
+//
+
+const path = require('path');
+
+// Notice: this path will resolve relative to `process.cwd()` .
+// This will cause a problem if the Knex CLI opens the knexfile
+// before changing the cwd.
+const MIGRATIONS_DIR = path.resolve('knexfile_migrations');
+
+module.exports = {
+  client: 'sqlite3',
+  connection: {
+    filename: __dirname + '/../test.sqlite3',
+  },
+  migrations: {
+    directory: MIGRATIONS_DIR,
+  },
+  seeds: {
+    directory: './knexfile_seeds',
+  },
+};


### PR DESCRIPTION
Addresses the issue outlined here:

https://github.com/knex/knex/issues/3660

Short story: the Knex CLI was opening the Knexfile before calling `process.chdir(...)`.  Unfortunately, the Knexfile in question was resolving some paths relative to `process.cwd()`.  As a result, these paths ended up being relative to the wrong directory.