### PR TITLE
`fn.now` takes optionally a precision argument.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1912,7 +1912,7 @@ declare namespace Knex {
   }
 
   interface FunctionHelper {
-    now(): Raw;
+    now(precision?: number): Raw;
   }
 
   interface EnumOptions {


### PR DESCRIPTION
`fn.now` can optionally take a precision argument, so reflect that in the TypeScript definition.