### PR TITLE
Fixed unresolved promise in cancelQuery(..) ...

### DIFF
--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -171,27 +171,18 @@ Object.assign(Client_MySQL.prototype, {
 
   canCancelQuery: true,
 
-  cancelQuery(connectionToKill) {
-    const acquiringConn = this.acquireConnection();
-
-    // Error out if we can't acquire connection in time.
-    // Purposely not putting timeout on `KILL QUERY` execution because erroring
-    // early there would release the `connectionToKill` back to the pool with
-    // a `KILL QUERY` command yet to finish.
-    return timeout(acquiringConn, 100)
-      .then((conn) =>
-        this.query(conn, {
-          method: 'raw',
-          sql: 'KILL QUERY ?',
-          bindings: [connectionToKill.threadId],
-          options: {},
-        })
-      )
-      .finally(() => {
-        // NOT returning this promise because we want to release the connection
-        // in a non-blocking fashion
-        acquiringConn.then((conn) => this.releaseConnection(conn));
+  async cancelQuery(connectionToKill) {
+    const conn = await this.acquireConnection();
+    try {
+      return await this.query(conn, {
+        method: 'raw',
+        sql: 'KILL QUERY ?',
+        bindings: [connectionToKill.threadId],
+        options: {},
       });
+    } finally {
+      await this.releaseConnection(conn);
+    }
   },
 });
 

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -4,7 +4,6 @@ const inherits = require('inherits');
 const { map, defer } = require('lodash');
 const { promisify } = require('util');
 const Client = require('../../client');
-const { timeout } = require('../../util/timeout');
 const Bluebird = require('bluebird');
 
 const Transaction = require('./transaction');


### PR DESCRIPTION
... more specifically: cancelQuery(..) was attempting to
"cancel the cancellation" after 100ms.  However, it was not
actually achieving this objective.  In reality, the cancellation
was still running in the background even though the caller had
already moved on.

Later on, the cancellation would ACTUALLY fail due to a resource
allocation issue (ie: no more connections in the Tarn pool).
This would then result in an unhandled Promise rejection.