### PR TITLE
Fix race condition in non-container transactions

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -225,12 +225,11 @@ class Transaction extends EventEmitter {
       .then((connection) => {
         connection.__knexTxId = this.txid;
 
-        return (this._previousSibling
-          ? this._previousSibling.catch(() => {})
-          : Promise.resolve()
-        ).then(function() {
-          return connection;
-        });
+        return this._previousSibling
+          .catch(() => {}) // TODO: Investigate this line
+          .then(function() {
+            return connection;
+          });
       })
       .then(async (connection) => {
         try {

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -55,7 +55,11 @@ class Transaction extends EventEmitter {
       outerTx ? 'nested' : 'top level'
     );
 
-    this._promise = this.acquireConnection(config, (connection) => {
+    // FYI: As you will see in a moment, this Promise will be used to construct
+    //      2 separate Promise Chains.  This ensures that each Promise Chain
+    //      can establish its error-handling semantics without interfering
+    //      with the other Promise Chain.
+    const basePromise = this.acquireConnection(config, (connection) => {
       const trxClient = (this.trxClient = makeTxClient(
         this,
         client,
@@ -109,6 +113,11 @@ class Transaction extends EventEmitter {
       }
     });
 
+
+    // FYI: This is the Promise Chain for EXTERNAL use.  It ensures that the
+    //      caller must handle any exceptions that result from `basePromise`.
+    this._promise = basePromise.then((x)=> x);
+
     this._completed = false;
 
     // If there's a wrapping transaction, we need to wait for any older sibling
@@ -118,7 +127,11 @@ class Transaction extends EventEmitter {
     this._previousSibling = Bluebird.resolve(true);
     if (outerTx) {
       if (outerTx._lastChild) this._previousSibling = outerTx._lastChild;
-      outerTx._lastChild = this._promise;
+
+      // FYI: This is the Promise Chain for INTERNAL use.  It serves as a signal
+      //      for when the next sibling should begin its execution.  Therefore,
+      //      exceptions are caught and ignored.
+      outerTx._lastChild = basePromise.catch(()=> {});
     }
   }
 
@@ -220,7 +233,7 @@ class Transaction extends EventEmitter {
         connection.__knexTxId = this.txid;
 
         return this._previousSibling
-          .catch(() => {}) // TODO: Investigate this line
+          // .catch(() => {}) // TODO: Investigate this line
           .then(function() {
             return connection;
           });

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -74,13 +74,7 @@ class Transaction extends EventEmitter {
           return makeTransactor(this, connection, trxClient);
         })
         .then((transactor) => {
-          if (this.initPromise) {
-            transactor.executionPromise = executionPromise.catch((err) => {
-              throw err;
-            });
-          } else {
-            transactor.executionPromise = executionPromise;
-          }
+          transactor.executionPromise = executionPromise;
 
           // If we've returned a "thenable" from the transaction container, assume
           // the rollback and commit are chained to this object's success / failure.


### PR DESCRIPTION
Minor cleanup to some of the Transaction logic.  However, it looks like this cleanup might have also inadvertently fixed the race condition that was being investigated here:

https://github.com/knex/knex/pull/3665

cc: @maximelkin + @kibertoad 