### PR TITLE
Cleanup and extract Transaction Workflow logic

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -14,23 +14,11 @@ const { uniqueId, isUndefined } = require('lodash');
 // Acts as a facade for a Promise, keeping the internal state
 // and managing any child transactions.
 class Transaction extends EventEmitter {
-  constructor(client, container, config, outerTx) {
+  constructor(client, container, config = {}, outerTx = null) {
     super();
     this.doNotRejectOnRollback = config.doNotRejectOnRollback;
 
     const txid = (this.txid = uniqueId('trx'));
-
-    // If there is no container provided, assume user wants to get instance of transaction and use it directly
-    if (!container) {
-
-
-      this.initPromise = new Promise((resolve, reject) => {
-        this.initRejectFn = reject;
-        container = (transactor) => {
-          resolve(transactor);
-        };
-      });
-    }
 
     this.client = client;
     this.logger = client.logger;
@@ -94,12 +82,6 @@ class Transaction extends EventEmitter {
         });
 
       return executionPromise;
-    }).catch((err) => {
-      if (this.initRejectFn) {
-        this.initRejectFn(err);
-      } else {
-        throw err;
-      }
     });
 
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -16,17 +16,13 @@ const { uniqueId, isUndefined } = require('lodash');
 class Transaction extends EventEmitter {
   constructor(client, container, config, outerTx) {
     super();
+    this.doNotRejectOnRollback = config.doNotRejectOnRollback;
 
     const txid = (this.txid = uniqueId('trx'));
 
     // If there is no container provided, assume user wants to get instance of transaction and use it directly
     if (!container) {
-      // Default behaviour for new style of transactions is not to reject on rollback
-      if (!config || isUndefined(config.doNotRejectOnRollback)) {
-        this.doNotRejectOnRollback = true;
-      } else {
-        this.doNotRejectOnRollback = config.doNotRejectOnRollback;
-      }
+
 
       this.initPromise = new Promise((resolve, reject) => {
         this.initRejectFn = reject;
@@ -34,13 +30,6 @@ class Transaction extends EventEmitter {
           resolve(transactor);
         };
       });
-    } else {
-      // Default behaviour for old style of transactions is to reject on rollback
-      if (!config || isUndefined(config.doNotRejectOnRollback)) {
-        this.doNotRejectOnRollback = false;
-      } else {
-        this.doNotRejectOnRollback = config.doNotRejectOnRollback;
-      }
     }
 
     this.client = client;

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -225,12 +225,11 @@ class Transaction extends EventEmitter {
       .then((connection) => {
         connection.__knexTxId = this.txid;
 
-        return (this._previousSibling
-          ? this._previousSibling.catch(() => {})
-          : Promise.resolve()
-        ).then(function() {
-          return connection;
-        });
+        return this._previousSibling
+          .catch(() => {}) // TODO: Investigate this line
+          .then(function() {
+            return connection;
+          });
       })
       .then(async (connection) => {
         try {

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -55,7 +55,11 @@ class Transaction extends EventEmitter {
       outerTx ? 'nested' : 'top level'
     );
 
-    this._promise = this.acquireConnection(config, (connection) => {
+    // FYI: As you will see in a moment, this Promise will be used to construct
+    //      2 separate Promise Chains.  This ensures that each Promise Chain
+    //      can establish its error-handling semantics without interfering
+    //      with the other Promise Chain.
+    const basePromise = this.acquireConnection(config, (connection) => {
       const trxClient = (this.trxClient = makeTxClient(
         this,
         client,
@@ -109,6 +113,11 @@ class Transaction extends EventEmitter {
       }
     });
 
+
+    // FYI: This is the Promise Chain for EXTERNAL use.  It ensures that the
+    //      caller must handle any exceptions that result from `basePromise`.
+    this._promise = basePromise.then((x)=> x);
+
     this._completed = false;
 
     // If there's a wrapping transaction, we need to wait for any older sibling
@@ -118,7 +127,11 @@ class Transaction extends EventEmitter {
     this._previousSibling = Bluebird.resolve(true);
     if (outerTx) {
       if (outerTx._lastChild) this._previousSibling = outerTx._lastChild;
-      outerTx._lastChild = this._promise;
+
+      // FYI: This is the Promise Chain for INTERNAL use.  It serves as a signal
+      //      for when the next sibling should begin its execution.  Therefore,
+      //      exceptions are caught and ignored.
+      outerTx._lastChild = basePromise.catch(()=> {});
     }
   }
 
@@ -220,7 +233,7 @@ class Transaction extends EventEmitter {
         connection.__knexTxId = this.txid;
 
         return this._previousSibling
-          .catch(() => {}) // TODO: Investigate this line
+          // .catch(() => {}) // TODO: Investigate this line
           .then(function() {
             return connection;
           });

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -74,13 +74,7 @@ class Transaction extends EventEmitter {
           return makeTransactor(this, connection, trxClient);
         })
         .then((transactor) => {
-          if (this.initPromise) {
-            transactor.executionPromise = executionPromise.catch((err) => {
-              throw err;
-            });
-          } else {
-            transactor.executionPromise = executionPromise;
-          }
+          transactor.executionPromise = executionPromise;
 
           // If we've returned a "thenable" from the transaction container, assume
           // the rollback and commit are chained to this object's success / failure.

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -4,7 +4,7 @@ const { Migrator } = require('../migrate/Migrator');
 const Seeder = require('../seed/Seeder');
 const FunctionHelper = require('../functionhelper');
 const QueryInterface = require('../query/methods');
-const { merge } = require('lodash');
+const { merge, isUndefined } = require('lodash');
 const batchInsert = require('./batchInsert');
 
 function makeKnex(client) {
@@ -36,7 +36,16 @@ function initContext(knexFn) {
     // If container is provided, returns a promise for when the transaction is resolved.
     // If container is not provided, returns a promise with a transaction that is resolved
     // when transaction is ready to be used.
-    transaction(container, config) {
+    transaction(container, _config) {
+      // Shallow copy _config to avoid side-effects
+      const config = Object.assign({}, _config);
+
+      // Backwards-compatibility: the default value of `config.doNotRejectOnRollback`
+      // changes depending upon whether or not a `container` was provided.
+      if(isUndefined(config.doNotRejectOnRollback)) {
+        config.doNotRejectOnRollback = !container;
+      }
+
       const trx = this.client.transaction(container, config);
       trx.userParams = this.userParams;
 

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -46,16 +46,22 @@ function initContext(knexFn) {
         config.doNotRejectOnRollback = !container;
       }
 
-      const trx = this.client.transaction(container, config);
-      trx.userParams = this.userParams;
-
-      if (container) {
+      if(container) {
+        const trx = this.client.transaction(container, config);
+        trx.userParams = this.userParams;
         return trx;
+      } else {
+        const initPromise = new Promise((resolve, reject) => {
+          _resolve = resolve;
+          _reject = reject;
+        });
+
+        const trx = this.client.transaction(_resolve, config);
+        trx.userParams = this.userParams;
+        trx.catch(_reject);
+        return initPromise;
       }
-      // If no container was passed, assume user wants to get a transaction and use it directly
-      else {
-        return trx.initPromise;
-      }
+
     },
 
     transactionProvider(config) {


### PR DESCRIPTION
This extracts the "operational" logic related to container / non-container Transactions.  Saying it another way: it means that the `Transaction` class no longer needs to be aware of "how" it was instantiated.