### PR TITLE
Cleanup and extract Transaction Workflow logic (rebase)

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -14,23 +14,11 @@ const { uniqueId, isUndefined } = require('lodash');
 // Acts as a facade for a Promise, keeping the internal state
 // and managing any child transactions.
 class Transaction extends EventEmitter {
-  constructor(client, container, config, outerTx) {
+  constructor(client, container, config = {}, outerTx = null) {
     super();
     this.doNotRejectOnRollback = config.doNotRejectOnRollback;
 
     const txid = (this.txid = uniqueId('trx'));
-
-    // If there is no container provided, assume user wants to get instance of transaction and use it directly
-    if (!container) {
-
-
-      this.initPromise = new Promise((resolve, reject) => {
-        this.initRejectFn = reject;
-        container = (transactor) => {
-          resolve(transactor);
-        };
-      });
-    }
 
     this.client = client;
     this.logger = client.logger;
@@ -94,12 +82,6 @@ class Transaction extends EventEmitter {
         });
 
       return executionPromise;
-    }).catch((err) => {
-      if (this.initRejectFn) {
-        this.initRejectFn(err);
-      } else {
-        throw err;
-      }
     });
 
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -16,17 +16,13 @@ const { uniqueId, isUndefined } = require('lodash');
 class Transaction extends EventEmitter {
   constructor(client, container, config, outerTx) {
     super();
+    this.doNotRejectOnRollback = config.doNotRejectOnRollback;
 
     const txid = (this.txid = uniqueId('trx'));
 
     // If there is no container provided, assume user wants to get instance of transaction and use it directly
     if (!container) {
-      // Default behaviour for new style of transactions is not to reject on rollback
-      if (!config || isUndefined(config.doNotRejectOnRollback)) {
-        this.doNotRejectOnRollback = true;
-      } else {
-        this.doNotRejectOnRollback = config.doNotRejectOnRollback;
-      }
+
 
       this.initPromise = new Promise((resolve, reject) => {
         this.initRejectFn = reject;
@@ -34,13 +30,6 @@ class Transaction extends EventEmitter {
           resolve(transactor);
         };
       });
-    } else {
-      // Default behaviour for old style of transactions is to reject on rollback
-      if (!config || isUndefined(config.doNotRejectOnRollback)) {
-        this.doNotRejectOnRollback = false;
-      } else {
-        this.doNotRejectOnRollback = config.doNotRejectOnRollback;
-      }
     }
 
     this.client = client;

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -11,10 +11,20 @@ const debug = Debug('knex:tx');
 
 const { uniqueId, isUndefined } = require('lodash');
 
+// FYI: This is defined as a function instead of a constant so that
+//      each Transactor can have its own copy of the default config.
+//      This will minimize the impact of bugs that might be introduced
+//      if a Transactor ever mutates its config.
+function DEFAULT_CONFIG() {
+  return {
+    doNotRejectOnRollback: true,
+  };
+}
+
 // Acts as a facade for a Promise, keeping the internal state
 // and managing any child transactions.
 class Transaction extends EventEmitter {
-  constructor(client, container, config = {}, outerTx = null) {
+  constructor(client, container, config = DEFAULT_CONFIG(), outerTx = null) {
     super();
     this.doNotRejectOnRollback = config.doNotRejectOnRollback;
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -17,6 +17,7 @@ const { uniqueId, isUndefined } = require('lodash');
 //      if a Transactor ever mutates its config.
 function DEFAULT_CONFIG() {
   return {
+    userParams: {},
     doNotRejectOnRollback: true,
   };
 }
@@ -26,6 +27,7 @@ function DEFAULT_CONFIG() {
 class Transaction extends EventEmitter {
   constructor(client, container, config = DEFAULT_CONFIG(), outerTx = null) {
     super();
+    this.userParams = config.userParams;
     this.doNotRejectOnRollback = config.doNotRejectOnRollback;
 
     const txid = (this.txid = uniqueId('trx'));

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -37,27 +37,27 @@ function initContext(knexFn) {
     // If container is not provided, returns a promise with a transaction that is resolved
     // when transaction is ready to be used.
     transaction(container, _config) {
-      // Shallow copy _config to avoid side-effects
-      const config = Object.assign({}, _config);
+      const PRE = {
+        // Backwards-compatibility: default value changes depending upon
+        // whether or not a `container` was provided.
+        doNotRejectOnRollback: !container,
+      };
 
-      // Backwards-compatibility: the default value of `config.doNotRejectOnRollback`
-      // changes depending upon whether or not a `container` was provided.
-      if(isUndefined(config.doNotRejectOnRollback)) {
-        config.doNotRejectOnRollback = !container;
-      }
+      const POST = {
+        userParams: this.userParams || {},
+      };
+
+      const config = Object.assign(PRE, _config, POST);
 
       if(container) {
         const trx = this.client.transaction(container, config);
-        trx.userParams = this.userParams;
         return trx;
       } else {
         return new Promise((resolve, reject) => {
           const trx = this.client.transaction(resolve, config);
-          trx.userParams = this.userParams;
           trx.catch(reject);
         });
       }
-
     },
 
     transactionProvider(config) {

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -4,7 +4,7 @@ const { Migrator } = require('../migrate/Migrator');
 const Seeder = require('../seed/Seeder');
 const FunctionHelper = require('../functionhelper');
 const QueryInterface = require('../query/methods');
-const { merge } = require('lodash');
+const { merge, isUndefined } = require('lodash');
 const batchInsert = require('./batchInsert');
 
 function makeKnex(client) {
@@ -37,17 +37,14 @@ function initContext(knexFn) {
     // If container is not provided, returns a promise with a transaction that is resolved
     // when transaction is ready to be used.
     transaction(container, _config) {
-      const PRE = {
+      const config = Object.assign({}, _config);
+      config.userParams = this.userParams || {}
+      if(isUndefined(config.doNotRejectOnRollback)) {
         // Backwards-compatibility: default value changes depending upon
         // whether or not a `container` was provided.
-        doNotRejectOnRollback: !container,
-      };
+        config.doNotRejectOnRollback = !container;
+      }
 
-      const POST = {
-        userParams: this.userParams || {},
-      };
-
-      const config = Object.assign(PRE, _config, POST);
 
       if(container) {
         const trx = this.client.transaction(container, config);

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -51,15 +51,11 @@ function initContext(knexFn) {
         trx.userParams = this.userParams;
         return trx;
       } else {
-        const initPromise = new Promise((resolve, reject) => {
-          _resolve = resolve;
-          _reject = reject;
+        return new Promise((resolve, reject) => {
+          const trx = this.client.transaction(resolve, config);
+          trx.userParams = this.userParams;
+          trx.catch(reject);
         });
-
-        const trx = this.client.transaction(_resolve, config);
-        trx.userParams = this.userParams;
-        trx.catch(_reject);
-        return initPromise;
       }
 
     },

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -4,7 +4,7 @@ const { Migrator } = require('../migrate/Migrator');
 const Seeder = require('../seed/Seeder');
 const FunctionHelper = require('../functionhelper');
 const QueryInterface = require('../query/methods');
-const { merge } = require('lodash');
+const { merge, isUndefined } = require('lodash');
 const batchInsert = require('./batchInsert');
 
 function makeKnex(client) {
@@ -36,7 +36,16 @@ function initContext(knexFn) {
     // If container is provided, returns a promise for when the transaction is resolved.
     // If container is not provided, returns a promise with a transaction that is resolved
     // when transaction is ready to be used.
-    transaction(container, config) {
+    transaction(container, _config) {
+      // Shallow copy _config to avoid side-effects
+      const config = Object.assign({}, _config);
+
+      // Backwards-compatibility: the default value of `config.doNotRejectOnRollback`
+      // changes depending upon whether or not a `container` was provided.
+      if(isUndefined(config.doNotRejectOnRollback)) {
+        config.doNotRejectOnRollback = !container;
+      }
+
       const trx = this.client.transaction(container, config);
       trx.userParams = this.userParams;
 

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -4,7 +4,7 @@ const { Migrator } = require('../migrate/Migrator');
 const Seeder = require('../seed/Seeder');
 const FunctionHelper = require('../functionhelper');
 const QueryInterface = require('../query/methods');
-const { merge, isUndefined } = require('lodash');
+const { merge } = require('lodash');
 const batchInsert = require('./batchInsert');
 
 function makeKnex(client) {

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -46,16 +46,22 @@ function initContext(knexFn) {
         config.doNotRejectOnRollback = !container;
       }
 
-      const trx = this.client.transaction(container, config);
-      trx.userParams = this.userParams;
-
-      if (container) {
+      if(container) {
+        const trx = this.client.transaction(container, config);
+        trx.userParams = this.userParams;
         return trx;
+      } else {
+        const initPromise = new Promise((resolve, reject) => {
+          _resolve = resolve;
+          _reject = reject;
+        });
+
+        const trx = this.client.transaction(_resolve, config);
+        trx.userParams = this.userParams;
+        trx.catch(_reject);
+        return initPromise;
       }
-      // If no container was passed, assume user wants to get a transaction and use it directly
-      else {
-        return trx.initPromise;
-      }
+
     },
 
     transactionProvider(config) {


### PR DESCRIPTION
This extracts the "operational" logic related to container / non-container Transactions. Saying it another way: it means that the `Transaction` class no longer needs to be aware of "how" it was instantiated.

(Rebase of #3673 )