### PR TITLE
Add OracleDB handling for buffer type in fetchAsString

### DIFF
--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -34,9 +34,14 @@ Client_Oracledb.prototype._driver = function() {
       if (!_.isString(type)) return;
       type = type.toUpperCase();
       if (oracledb[type]) {
-        if (type !== 'NUMBER' && type !== 'DATE' && type !== 'CLOB' && type !== 'BUFFER') {
+        if (
+          type !== 'NUMBER' &&
+          type !== 'DATE' &&
+          type !== 'CLOB' &&
+          type !== 'BUFFER'
+        ) {
           this.logger.warn(
-            'Only "date", "number" and "clob" are supported for fetchAsString'
+            'Only "date", "number", "clob" and "buffer" are supported for fetchAsString'
           );
         }
         client.fetchAsString.push(oracledb[type]);
@@ -339,7 +344,11 @@ Client_Oracledb.prototype._query = function(connection, obj) {
     }
     await connection.commitAsync();
     if (obj.returningSql) {
-      const response = await connection.executeAsync(obj.returningSql(), rowIds, { resultSet: true })
+      const response = await connection.executeAsync(
+        obj.returningSql(),
+        rowIds,
+        { resultSet: true }
+      );
       obj.response = response.rows;
     }
     return obj;

--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -34,7 +34,7 @@ Client_Oracledb.prototype._driver = function() {
       if (!_.isString(type)) return;
       type = type.toUpperCase();
       if (oracledb[type]) {
-        if (type !== 'NUMBER' && type !== 'DATE' && type !== 'CLOB') {
+        if (type !== 'NUMBER' && type !== 'DATE' && type !== 'CLOB' && type !== 'BUFFER') {
           this.logger.warn(
             'Only "date", "number" and "clob" are supported for fetchAsString'
           );

--- a/test/unit/dialects/oracledb.js
+++ b/test/unit/dialects/oracledb.js
@@ -48,7 +48,7 @@ describe('OracleDb parameters', function() {
 
     before(function() {
       const conf = _.clone(config.oracledb);
-      conf.fetchAsString = ['number', 'DATE', 'cLOb'];
+      conf.fetchAsString = ['number', 'DATE', 'cLOb', 'BUFFER'];
       knexClient = knex(conf);
       return knexClient;
     });
@@ -77,6 +77,15 @@ describe('OracleDb parameters', function() {
         .then(function(result) {
           expect(result[0]).to.be.ok;
           expect(result[0].field).to.be.equal('LONG CONTENT');
+        });
+    });
+
+    it('on raw', function() {
+      return knexClient
+        .raw('select UTL_RAW.CAST_TO_RAW(3) as "field" from dual')
+        .then(function(result) {
+          expect(result[0]).to.be.ok;
+          expect(result[0].field).to.be.equal('33');
         });
     });
 
@@ -121,6 +130,15 @@ describe('OracleDb parameters', function() {
       );
     });
 
+    it('on raw', function() {
+      return knexClient
+        .raw('select UTL_RAW.CAST_TO_RAW(3) as "field" from dual')
+        .then(function(result) {
+          expect(result[0]).to.be.ok;
+          expect(result[0].field).to.be.instanceOf(Buffer);
+        });
+    });
+
     after(function() {
       return knexClient.destroy();
     });
@@ -132,7 +150,7 @@ describe('OracleDb unit tests', function() {
 
   before(function() {
     const conf = _.clone(config.oracledb);
-    conf.fetchAsString = ['number', 'DATE', 'cLOb'];
+    conf.fetchAsString = ['number', 'DATE', 'cLOb', 'BUFFER'];
     knexClient = knex(conf);
     return knexClient;
   });


### PR DESCRIPTION
As released in [2.3.0](https://github.com/oracle/node-oracledb/blob/master/CHANGELOG.md#node-oracledb-v230-7-jun-2018) of node-oracledb, this adds handling to fetchAsString for the `BUFFER` type, allowing fetchAsString to interpret `RAW` fields.

