### PR TITLE
fix(types): Client.validateConnection must be sync

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1927,7 +1927,7 @@ declare namespace Knex {
 
     acquireRawConnection(): Promise<any>;
     destroyRawConnection(connection: any): Promise<void>;
-    validateConnection(connection: any): Promise<boolean>;
+    validateConnection(connection: any): boolean;
     logger: Logger;
     version?: string;
     connectionConfigProvider: any;

--- a/types/test.ts
+++ b/types/test.ts
@@ -82,6 +82,12 @@ type _T8 = ExtendsWitness<Knex.QueryBuilder<User, number[]>, Knex.QueryBuilder>;
 type _T9 = ExtendsWitness<Knex.QueryBuilder<any, any[]>, Knex.QueryBuilder>;
 type _T10 = ExtendsWitness<Knex.QueryBuilder<User, number>, Knex.QueryBuilder>;
 
+class TestClient extends Knex.Client {
+  validateConnection(connection: any): boolean {
+    return super.validateConnection(connection) && 1 < 42;
+  }
+}
+
 const main = async () => {
   // # Select:
 


### PR DESCRIPTION
The result of this method is passed directly to tarn `validate`, which does not resolve the value only truthy checks it.