### PR TITLE
Mark missing test cases as "pending" rather than "passed"

### DIFF
--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -452,7 +452,7 @@ module.exports = function(knex) {
 
     it('#2184 - should properly escape table name for SQLite columnInfo', function() {
       if (knex.client.driverName !== 'sqlite3') {
-        return;
+        return this.skip();
       }
 
       return knex.schema
@@ -664,10 +664,10 @@ module.exports = function(knex) {
     it('.timeout() should throw TimeoutError', function() {
       const driverName = knex.client.driverName;
       if (driverName === 'sqlite3') {
-        return;
+        return this.skip();
       } //TODO -- No built-in support for sleeps
       if (/redshift/.test(driverName)) {
-        return;
+        return this.skip();
       }
       const testQueries = {
         pg: function() {
@@ -711,10 +711,10 @@ module.exports = function(knex) {
     it('.timeout(ms, {cancel: true}) should throw TimeoutError and cancel slow query', function() {
       const driverName = knex.client.driverName;
       if (driverName === 'sqlite3') {
-        return;
+        return this.skip();
       } //TODO -- No built-in support for sleeps
       if (/redshift/.test(driverName)) {
-        return;
+        return this.skip();
       }
 
       // There's unexpected behavior caused by knex releasing a connection back
@@ -758,7 +758,7 @@ module.exports = function(knex) {
         expect(addTimeout).to.throw(
           'Query cancelling not supported for this dialect'
         );
-        return;
+        return; // TODO: Use `this.skip()` here?
       }
 
       const getProcessesQueries = {
@@ -819,14 +819,14 @@ module.exports = function(knex) {
         });
     });
 
-    it('.timeout(ms, {cancel: true}) should throw error if cancellation cannot acquire connection', async () => {
+    it('.timeout(ms, {cancel: true}) should throw error if cancellation cannot acquire connection', async function() {
       // Only mysql/postgres query cancelling supported for now
       const driverName = knex.client.driverName;
       if (
         !_.startsWith(driverName, 'mysql') &&
         !_.startsWith(driverName, 'pg')
       ) {
-        return;
+        return this.skip();
       }
 
       // To make this test easier, I'm changing the pool settings to max 1.
@@ -880,7 +880,7 @@ module.exports = function(knex) {
       // Only mysql/postgres query cancelling supported for now
       const driverName = knex.client.driverName;
       if (!_.startsWith(driverName, 'pg')) {
-        return;
+        return this.skip();
       }
 
       // To make this test easier, I'm changing the pool settings to max 1.

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -494,7 +494,7 @@ module.exports = function(knex) {
 
     it('will fail when multiple inserts are made into a unique column', function() {
       if (/redshift/i.test(knex.client.driverName)) {
-        return;
+        return this.skip();
       }
       return knex('accounts')
         .where('id', '>', 1)
@@ -1011,7 +1011,7 @@ module.exports = function(knex) {
 
     it('should allow a * for returning in postgres and oracle', function() {
       if (/redshift/i.test(knex.client.driverName)) {
-        return;
+        return this.skip();
       }
       const insertData = {
         account_id: 10,
@@ -1145,7 +1145,7 @@ module.exports = function(knex) {
 
       it('#1880 - Duplicate keys in batchInsert should not throw unhandled exception', async function() {
         if (/redshift/i.test(knex.client.driverName)) {
-          return;
+          return this.skip();
         }
         this.timeout(10000);
 

--- a/test/integration/builder/joins.js
+++ b/test/integration/builder/joins.js
@@ -1792,7 +1792,7 @@ module.exports = function(knex) {
 
     it('supports joins with overlapping column names', function() {
       if (knex.client.driverName === 'oracledb') {
-        return;
+        return this.skip();
       }
 
       return knex('accounts as a1')

--- a/test/integration/builder/selects.js
+++ b/test/integration/builder/selects.js
@@ -216,7 +216,7 @@ module.exports = function(knex) {
 
     it('allows you to stream with mysql dialect options', function() {
       if (!_.includes(['mysql', 'mysql2'], knex.client.driverName)) {
-        return;
+        return this.skip();
       }
       const rows = [];
       return knex('accounts')
@@ -1178,7 +1178,7 @@ module.exports = function(knex) {
 
     it('select for update locks selected row', function() {
       if (knex.client.driverName === 'sqlite3') {
-        return;
+        return this.skip();
       }
 
       return knex('test_default_table')
@@ -1209,7 +1209,7 @@ module.exports = function(knex) {
 
     it('select for update locks only some tables, #2834', function() {
       if (knex.client.driverName !== 'pg') {
-        return;
+        return this.skip();
       }
 
       return knex('test_default_table')
@@ -1261,7 +1261,7 @@ module.exports = function(knex) {
         knex.client.driverName === 'sqlite3' ||
         knex.client.driverName === 'oracledb'
       ) {
-        return;
+        return this.skip();
       }
 
       return knex('test_default_table')
@@ -1303,7 +1303,7 @@ module.exports = function(knex) {
     it('forUpdate().skipLocked() with order by should return the first non-locked row', async function() {
       // Note: this test doesn't work properly on MySQL - see https://bugs.mysql.com/bug.php?id=67745
       if (knex.client.driverName !== 'pg') {
-        return;
+        return this.skip();
       }
 
       const rowName = 'row for skipLocked() test #1';
@@ -1341,7 +1341,7 @@ module.exports = function(knex) {
         knex.client.driverName !== 'pg' &&
         knex.client.driverName !== 'mysql'
       ) {
-        return;
+        return this.skip();
       }
 
       const rowName = 'row for skipLocked() test #2';
@@ -1375,7 +1375,7 @@ module.exports = function(knex) {
         knex.client.driverName !== 'pg' &&
         knex.client.driverName !== 'mysql'
       ) {
-        return;
+        return this.skip();
       }
 
       const rowName = 'row for noWait() test';

--- a/test/integration/datatype/bigint.js
+++ b/test/integration/datatype/bigint.js
@@ -97,7 +97,7 @@ module.exports = function(knex) {
 
   it('#1781 - decimal value must not be converted to integer', function() {
     if (!/mssql/i.test(knex.client.driverName)) {
-      return;
+      return this.skip();
     }
 
     const tableName = 'decimal_test';

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -32,9 +32,9 @@ const postProcessResponse = (response) => {
 module.exports = (knex) => {
   describe('Schema', () => {
     describe('errors for unsupported dialects', () => {
-      it('throws an error if client does not support createSchema', async () => {
+      it('throws an error if client does not support createSchema', async function() {
         if (!knex || !knex.client || /pg/i.test(knex.client.driverName)) {
-          return;
+          return this.skip();
         }
 
         let error;
@@ -48,9 +48,9 @@ module.exports = (knex) => {
         );
       });
 
-      it('throws an error if client does not support createSchemaIfNotExists', async () => {
+      it('throws an error if client does not support createSchemaIfNotExists', async function() {
         if (!knex || !knex.client || /pg/i.test(knex.client.driverName)) {
-          return;
+          return this.skip();
         }
 
         let error;
@@ -64,9 +64,9 @@ module.exports = (knex) => {
         );
       });
 
-      it('throws an error if client does not support dropSchema', async () => {
+      it('throws an error if client does not support dropSchema', async function() {
         if (!knex || !knex.client || /pg/i.test(knex.client.driverName)) {
-          return;
+          return this.skip();
         }
 
         let error;
@@ -80,9 +80,9 @@ module.exports = (knex) => {
         );
       });
 
-      it('throws an error if client does not support dropSchemaIfExists', async () => {
+      it('throws an error if client does not support dropSchemaIfExists', async function() {
         if (!knex || !knex.client || /pg/i.test(knex.client.driverName)) {
-          return;
+          return this.skip();
         }
 
         let error;
@@ -910,9 +910,9 @@ module.exports = (knex) => {
           t.json('json_data', true);
         }));
 
-      it('allows adding multiple columns at once', () => {
+      it('allows adding multiple columns at once', function() {
         if (/redshift/i.test(knex.client.driverName)) {
-          return;
+          return this.skip();
         }
         return knex.schema
           .table('test_table_two', (t) => {
@@ -940,7 +940,7 @@ module.exports = (knex) => {
           })
           .then(() => knex.schema.dropTable('test_table_numerics2')));
 
-      it('allows alter column syntax', () => {
+      it('allows alter column syntax', function() {
         if (
           knex.client.driverName.match('sqlite3') ||
           knex.client.driverName.match('pg-redshift') ||

--- a/test/tape/pool.js
+++ b/test/tape/pool.js
@@ -101,7 +101,16 @@ test('#2321 dead connections are not evicted from pool', async (t) => {
           });
         })
       );
-      await delay(50); // wait driver to notice connection errors (2ms was enough locally)
+
+      // TODO: It looks like this test case can trigger the race condition
+      //       outlined in this issue comment:
+      //
+      //         https://github.com/knex/knex/issues/3636#issuecomment-592005391
+      //
+      //       For now, we're working around this problem by introducing a
+      //       1 second delay.  But, we should revisit this once the connection
+      //       pool logic has been refactored.
+      await delay(1000); // wait driver to notice connection errors (2ms was enough locally)
 
       // all connections are dead, so they should be evicted from pool and this should work
       await Promise.all(

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -168,9 +168,9 @@ describe('knex', () => {
     ).to.equal(null);
   });
 
-  it('passes queryContext to wrapIdentifier in raw query', () => {
+  it('passes queryContext to wrapIdentifier in raw query', function() {
     if (!sqliteConfig) {
-      return;
+      return this.skip();
     }
 
     const knex = Knex(
@@ -210,9 +210,9 @@ describe('knex', () => {
       });
   });
 
-  it('passes queryContext to wrapIdentifier in raw query in transaction', () => {
+  it('passes queryContext to wrapIdentifier in raw query in transaction', function() {
     if (!sqliteConfig) {
-      return;
+      return this.skip();
     }
 
     const knex = Knex(
@@ -275,9 +275,9 @@ describe('knex', () => {
     ).to.equal(null);
   });
 
-  it('transaction of a copy with userParams retains userparams', () => {
+  it('transaction of a copy with userParams retains userparams', function() {
     if (!sqliteConfig) {
-      return;
+      return this.skip();
     }
 
     const knex = Knex(sqliteConfig);
@@ -469,9 +469,9 @@ describe('knex', () => {
     });
   });
 
-  it('creating transaction copy with user params should throw an error', () => {
+  it('creating transaction copy with user params should throw an error', function() {
     if (!sqliteConfig) {
-      return;
+      return this.skip();
     }
 
     const knex = Knex(sqliteConfig);
@@ -505,9 +505,9 @@ describe('knex', () => {
   });
 
   describe('async stack traces', () => {
-    it('should capture stack trace on query builder instantiation', () => {
+    it('should capture stack trace on query builder instantiation', function() {
       if (!sqliteConfig) {
-        return;
+        return this.skip();
       }
 
       const knex = Knex(


### PR DESCRIPTION
Currently, the Knex codebase marks several tests as "passing" even though no test was actually run.  This is then giving us a false sense of how well the codebase has really been tested.  So, this is a quick pass over the code that marks several of these missing test cases as `"pending"` instead of `"passing"`.  From there, we can then decide upon an appropriate way to refactor each of these test cases.