### PR TITLE
Cleanup/remove dead oracle code

### DIFF
--- a/lib/dialects/oracle/DEAD_CODE.md
+++ b/lib/dialects/oracle/DEAD_CODE.md
@@ -1,0 +1,5 @@
+# Warning: Dead Code #
+
+The `oracle` dialect is mostly dead code at this point.  However, a handful of its methods are still referenced by the `oracledb` dialect.  So, we are in the process of migrating those methods over to the `oracledb` dialect where they belong.  Once that task is completed, we will officially remove the `oracle` dialect.
+
+In short: do not use the `oracle` dialect.  Use the `oracledb` dialect instead.

--- a/lib/dialects/oracle/index.js
+++ b/lib/dialects/oracle/index.js
@@ -49,20 +49,6 @@ Object.assign(Client_Oracle.prototype, {
     return new TableCompiler(this, ...arguments);
   },
 
-  prepBindings(bindings) {
-    return map(bindings, (value) => {
-      // returning helper uses always ROWID as string
-      if (value instanceof ReturningHelper && this.driver) {
-        return new this.driver.OutParam(this.driver.OCCISTRING);
-      } else if (typeof value === 'boolean') {
-        return value ? 1 : 0;
-      } else if (Buffer.isBuffer(value)) {
-        return bufferToString(value);
-      }
-      return value;
-    });
-  },
-
   // Return the database for the Oracle client.
   database() {
     return this.connectionSettings.database;

--- a/lib/dialects/oracle/index.js
+++ b/lib/dialects/oracle/index.js
@@ -1,19 +1,13 @@
 // Oracle Client
 // -------
-const { map, flatten, values } = require('lodash');
-const { promisify } = require('util');
-
 const inherits = require('inherits');
 const Client = require('../../client');
-const { bufferToString } = require('../../query/string');
-const Formatter = require('./formatter');
 
-const QueryCompiler = require('./query/compiler');
 const SchemaCompiler = require('./schema/compiler');
 const ColumnBuilder = require('./schema/columnbuilder');
 const ColumnCompiler = require('./schema/columncompiler');
 const TableCompiler = require('./schema/tablecompiler');
-const { ReturningHelper, isConnectionError } = require('./utils');
+const { isConnectionError } = require('./utils');
 
 // Always initialize with the "QueryBuilder" and "QueryCompiler"
 // objects, which extend the base 'lib/query/builder' and

--- a/lib/dialects/oracle/index.js
+++ b/lib/dialects/oracle/index.js
@@ -99,33 +99,6 @@ Object.assign(Client_Oracle.prototype, {
     });
   },
 
-  // Runs the query on the specified connection, providing the bindings
-  // and any other necessary prep work.
-  _query(connection, obj) {
-    if (!obj.sql) throw new Error('The query is empty');
-
-    return connection
-      .executeAsync(obj.sql, obj.bindings)
-      .then(function(response) {
-        if (!obj.returning) return response;
-        const rowIds = obj.outParams.map(
-          (v, i) => response[`returnParam${i ? i : ''}`]
-        );
-        return connection.executeAsync(obj.returningSql, rowIds);
-      })
-      .then(function(response) {
-        obj.response = response;
-        obj.rowsAffected = response.updateCount;
-        return obj;
-      })
-      .catch((err) => {
-        if (isConnectionError(err)) {
-          connection.__knex__disposed = err;
-        }
-        throw err;
-      });
-  },
-
   // Process the response as returned from the query.
   processResponse(obj, runner) {
     let { response } = obj;

--- a/lib/dialects/oracle/index.js
+++ b/lib/dialects/oracle/index.js
@@ -98,34 +98,6 @@ Object.assign(Client_Oracle.prototype, {
       });
     });
   },
-
-  // Process the response as returned from the query.
-  processResponse(obj, runner) {
-    let { response } = obj;
-    const { method } = obj;
-    if (obj.output) return obj.output.call(runner, response);
-    switch (method) {
-      case 'select':
-      case 'pluck':
-      case 'first':
-        if (obj.method === 'pluck') response = map(response, obj.pluck);
-        return obj.method === 'first' ? response[0] : response;
-      case 'insert':
-      case 'del':
-      case 'update':
-      case 'counter':
-        if (obj.returning) {
-          if (obj.returning.length > 1 || obj.returning[0] === '*') {
-            return response;
-          }
-          // return an array with values if only one returning value was specified
-          return flatten(map(response, values));
-        }
-        return obj.rowsAffected;
-      default:
-        return response;
-    }
-  },
 });
 
 module.exports = Client_Oracle;

--- a/lib/dialects/oracle/index.js
+++ b/lib/dialects/oracle/index.js
@@ -23,10 +23,6 @@ Object.assign(Client_Oracle.prototype, {
 
   driverName: 'oracle',
 
-  _driver() {
-    return require('oracle');
-  },
-
   schemaCompiler() {
     return new SchemaCompiler(this, ...arguments);
   },

--- a/lib/dialects/oracle/index.js
+++ b/lib/dialects/oracle/index.js
@@ -8,7 +8,6 @@ const Client = require('../../client');
 const { bufferToString } = require('../../query/string');
 const Formatter = require('./formatter');
 
-const Transaction = require('./transaction');
 const QueryCompiler = require('./query/compiler');
 const SchemaCompiler = require('./schema/compiler');
 const ColumnBuilder = require('./schema/columnbuilder');
@@ -32,10 +31,6 @@ Object.assign(Client_Oracle.prototype, {
 
   _driver() {
     return require('oracle');
-  },
-
-  transaction() {
-    return new Transaction(this, ...arguments);
   },
 
   formatter() {

--- a/lib/dialects/oracle/index.js
+++ b/lib/dialects/oracle/index.js
@@ -33,14 +33,6 @@ Object.assign(Client_Oracle.prototype, {
     return require('oracle');
   },
 
-  formatter() {
-    return new Formatter(this, ...arguments);
-  },
-
-  queryCompiler() {
-    return new QueryCompiler(this, ...arguments);
-  },
-
   schemaCompiler() {
     return new SchemaCompiler(this, ...arguments);
   },

--- a/lib/dialects/oracle/index.js
+++ b/lib/dialects/oracle/index.js
@@ -76,30 +76,6 @@ Object.assign(Client_Oracle.prototype, {
     });
   },
 
-  // Get a raw connection, called by the `pool` whenever a new
-  // connection needs to be added to the pool.
-  acquireRawConnection() {
-    return new Promise((resolver, rejecter) => {
-      this.driver.connect(this.connectionSettings, (err, connection) => {
-        if (err) return rejecter(err);
-        connection.executeAsync = promisify(connection.execute);
-        if (this.connectionSettings.prefetchRowCount) {
-          connection.setPrefetchRowCount(
-            this.connectionSettings.prefetchRowCount
-          );
-        }
-        resolver(connection);
-      });
-    });
-  },
-
-  // Used to explicitly close a connection, called internally by the pool
-  // when a connection times out or the pool is shutdown.
-  async destroyRawConnection(connection) {
-    const close = promisify((cb) => connection.close(cb));
-    return close();
-  },
-
   // Return the database for the Oracle client.
   database() {
     return this.connectionSettings.database;

--- a/lib/dialects/oracle/transaction.js
+++ b/lib/dialects/oracle/transaction.js
@@ -2,40 +2,4 @@ const Transaction = require('../../transaction');
 const { isUndefined } = require('lodash');
 const debugTx = require('debug')('knex:tx');
 
-module.exports = class Oracle_Transaction extends Transaction {
-  // disable autocommit to allow correct behavior (default is true)
-  begin() {
-    return Promise.resolve();
-  }
-
-  commit(conn, value) {
-    this._completed = true;
-    return conn
-      .commitAsync()
-      .then(() => value)
-      .then(this._resolver, this._rejecter);
-  }
-
-  release(conn, value) {
-    return this._resolver(value);
-  }
-
-  rollback(conn, err) {
-    this._completed = true;
-    debugTx('%s: rolling back', this.txid);
-    return conn
-      .rollbackAsync()
-      .throw(err)
-      .catch((error) => {
-        if (isUndefined(error)) {
-          if (this.doNotRejectOnRollback) {
-            this._resolver();
-            return;
-          }
-          error = new Error(`Transaction rejected with non-error: ${error}`);
-        }
-
-        return this._rejecter(error);
-      });
-  }
-};
+module.exports = class Oracle_Transaction extends Transaction {};

--- a/lib/dialects/oracle/transaction.js
+++ b/lib/dialects/oracle/transaction.js
@@ -1,5 +1,0 @@
-const Transaction = require('../../transaction');
-const { isUndefined } = require('lodash');
-const debugTx = require('debug')('knex:tx');
-
-module.exports = class Oracle_Transaction extends Transaction {};

--- a/lib/dialects/oracle/transaction.js
+++ b/lib/dialects/oracle/transaction.js
@@ -38,39 +38,4 @@ module.exports = class Oracle_Transaction extends Transaction {
         return this._rejecter(error);
       });
   }
-
-  acquireConnection(config, cb) {
-    const configConnection = config && config.connection;
-    return new Promise((resolve, reject) => {
-      try {
-        resolve(configConnection || this.client.acquireConnection());
-      } catch (e) {
-        reject(e);
-      }
-    })
-      .then((connection) => {
-        connection.__knexTxId = this.txid;
-
-        return connection;
-      })
-      .then((connection) => {
-        if (!this.outerTx) {
-          connection.setAutoCommit(false);
-        }
-        return connection;
-      })
-      .then(async (connection) => {
-        try {
-          return await cb(connection);
-        } finally {
-          debugTx('%s: releasing connection', this.txid);
-          connection.setAutoCommit(true);
-          if (!configConnection) {
-            this.client.releaseConnection(connection);
-          } else {
-            debugTx('%s: not releasing external connection', this.txid);
-          }
-        }
-      });
-  }
 };


### PR DESCRIPTION
It appears that `/lib/dialects/oracle/` is mostly dead code.  More specifically:

1. It is not listed within the `SUPPORTED_CLIENTS` constant.
2. Portions of the code are subclassed by `/lib/dialects/oracledb/`, but...
3. ... `/lib/dialects/oracledb/` overrides many of the methods from `/lib/dialects/oracle/`

So, this PR just removes some of the dead code so that we can have less code to maintain going forward.