### PR TITLE
timeout(..) function clears unnecessary timeouts

### DIFF
--- a/lib/util/timeout.js
+++ b/lib/util/timeout.js
@@ -7,11 +7,21 @@ class KnexTimeoutError extends Error {
   }
 }
 
+function timeout(promise, ms) {
+  return new Promise(async function(resolve, reject) {
+    const id = setTimeout(function() {
+      reject(new KnexTimeoutError('operation timed out'));
+    }, ms);
+
+    try {
+      resolve(await promise);
+    } catch (err) {
+      reject(err);
+    } finally {
+      clearTimeout(id);
+    }
+  });
+}
+
 module.exports.KnexTimeoutError = KnexTimeoutError;
-module.exports.timeout = (promise, ms) =>
-  Promise.race([
-    promise,
-    delay(ms).then(() =>
-      Promise.reject(new KnexTimeoutError('operation timed out'))
-    ),
-  ]);
+module.exports.timeout = timeout;

--- a/lib/util/timeout.js
+++ b/lib/util/timeout.js
@@ -1,5 +1,3 @@
-const delay = require('./delay');
-
 class KnexTimeoutError extends Error {
   constructor(message) {
     super(message);
@@ -8,18 +6,22 @@ class KnexTimeoutError extends Error {
 }
 
 function timeout(promise, ms) {
-  return new Promise(async function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     const id = setTimeout(function() {
       reject(new KnexTimeoutError('operation timed out'));
     }, ms);
 
-    try {
-      resolve(await promise);
-    } catch (err) {
-      reject(err);
-    } finally {
+    function wrappedResolve(value) {
       clearTimeout(id);
+      resolve(value);
     }
+
+    function wrappedReject(err) {
+      clearTimeout(id);
+      reject(err);
+    }
+
+    promise.then(wrappedResolve, wrappedReject);
   });
 }
 


### PR DESCRIPTION
As noted in #3699 , the `timeout(..)` function wasn't clearing the calls to `setTimeout(..)` once the wrapped Promise had completed.  As a result, this would cause programs to hang for a few seconds if they attempted to exit shortly after resolving a `timeout(..)`.