### PR TITLE
Rewrote Transaction#acquireConnection() methods to use async

### DIFF
--- a/lib/dialects/mssql/transaction.js
+++ b/lib/dialects/mssql/transaction.js
@@ -55,48 +55,38 @@ module.exports = class Transaction_MSSQL extends Transaction {
   // Acquire a connection and create a disposer - either using the one passed
   // via config or getting one off the client. The disposer will be called once
   // the original promise is marked completed.
-  acquireConnection(config, cb) {
+  async acquireConnection(config, cb) {
     const configConnection = config && config.connection;
-    return new Promise((resolve, reject) => {
-      try {
-        resolve(
-          (this.outerTx ? this.outerTx.conn : null) ||
-            configConnection ||
-            this.client.acquireConnection()
-        );
-      } catch (e) {
-        reject(e);
+    const conn =
+      (this.outerTx && this.outerTx.conn) ||
+      configConnection ||
+      (await this.client.acquireConnection());
+
+    try {
+      conn.__knexTxId = this.txid;
+      if (!this.outerTx) {
+        this.conn = conn;
+        conn.tx_ = conn.transaction();
       }
-    })
-      .then((conn) => {
-        conn.__knexTxId = this.txid;
-        if (!this.outerTx) {
-          this.conn = conn;
-          conn.tx_ = conn.transaction();
-        }
-        return conn;
-      })
-      .then(async (conn) => {
-        try {
-          return await cb(conn);
-        } finally {
-          if (!this.outerTx) {
-            if (conn.tx_) {
-              if (!this._completed) {
-                debug('%s: unreleased transaction', this.txid);
-                conn.tx_.rollback();
-              }
-              conn.tx_ = null;
-            }
-            this.conn = null;
-            if (!configConnection) {
-              debug('%s: releasing connection', this.txid);
-              this.client.releaseConnection(conn);
-            } else {
-              debug('%s: not releasing external connection', this.txid);
-            }
+
+      return await cb(conn);
+    } finally {
+      if (!this.outerTx) {
+        if (conn.tx_) {
+          if (!this._completed) {
+            debug('%s: unreleased transaction', this.txid);
+            conn.tx_.rollback();
           }
+          conn.tx_ = null;
         }
-      });
+        this.conn = null;
+        if (!configConnection) {
+          debug('%s: releasing connection', this.txid);
+          this.client.releaseConnection(conn);
+        } else {
+          debug('%s: not releasing external connection', this.txid);
+        }
+      }
+    }
   }
 };

--- a/lib/dialects/oracledb/transaction.js
+++ b/lib/dialects/oracledb/transaction.js
@@ -50,40 +50,28 @@ module.exports = class Oracle_Transaction extends Transaction {
     return this.query(conn, `SAVEPOINT ${this.txid}`);
   }
 
-  acquireConnection(config, cb) {
+  async acquireConnection(config, cb) {
     const configConnection = config && config.connection;
-    const t = this;
-    return new Promise((resolve, reject) => {
+
+    const connection = await this.client.acquireConnection();
+    try {
+      connection.__knexTxId = this.txid;
+      connection.isTransaction = true;
+      return await cb(connection);
+    } finally {
+      debugTx('%s: releasing connection', this.txid);
+      connection.isTransaction = false;
       try {
-        this.client
-          .acquireConnection()
-          .then((cnx) => {
-            cnx.__knexTxId = this.txid;
-            cnx.isTransaction = true;
-            resolve(cnx);
-          })
-          .catch(reject);
-      } catch (e) {
-        reject(e);
-      }
-    }).then(async (connection) => {
-      try {
-        return await cb(connection);
+        await connection.commitAsync();
+      } catch (err) {
+        this._rejecter(err);
       } finally {
-        debugTx('%s: releasing connection', this.txid);
-        connection.isTransaction = false;
-        try {
-          await connection.commitAsync();
-        } catch (err) {
-          t._rejecter(err);
-        } finally {
-          if (!configConnection) {
-            await t.client.releaseConnection(connection);
-          } else {
-            debugTx('%s: not releasing external connection', t.txid);
-          }
+        if (!configConnection) {
+          await this.client.releaseConnection(connection);
+        } else {
+          debugTx('%s: not releasing external connection', this.txid);
         }
       }
-    });
+    }
   }
 };

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -215,27 +215,22 @@ class Transaction extends EventEmitter {
   // Acquire a connection and create a disposer - either using the one passed
   // via config or getting one off the client. The disposer will be called once
   // the original promise is marked completed.
-  acquireConnection(config, cb) {
+  async acquireConnection(config, cb) {
     const configConnection = config && config.connection;
-    return new Promise((resolve, reject) => {
-      try {
-        resolve(configConnection || this.client.acquireConnection());
-      } catch (e) {
-        reject(e);
+    const connection =
+      configConnection || (await this.client.acquireConnection());
+
+    try {
+      connection.__knexTxId = this.txid;
+      return await cb(connection);
+    } finally {
+      if (!configConnection) {
+        debug('%s: releasing connection', this.txid);
+        this.client.releaseConnection(connection);
+      } else {
+        debug('%s: not releasing external connection', this.txid);
       }
-    }).then(async (connection) => {
-      try {
-        connection.__knexTxId = this.txid;
-        return await cb(connection);
-      } finally {
-        if (!configConnection) {
-          debug('%s: releasing connection', this.txid);
-          this.client.releaseConnection(connection);
-        } else {
-          debug('%s: not releasing external connection', this.txid);
-        }
-      }
-    });
+    }
   }
 
   then(onResolve, onReject) {


### PR DESCRIPTION
The code should be functionally equivalent before and after this change.  It's mostly a minor cleanup so that the next phase of refactoring will be easier.