### PR TITLE
Updated .gitignore files to ignore testing artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ tmp
 bin/migrations-folder
 bin/db.sqlite3
 
+# Other artifacts created during testing
+/knexfile.js
+
+
 # Bench stuff
 test/bench/temp
 test/coverage/*

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,3 @@
+# Random artifacts that are generated during testing
+*.sqlite3
+


### PR DESCRIPTION
Various testing artifacts get left on disk if you kill the tests while they're still running.  I updated the `.gitignore` files so that it would be less likely for these to get committed by accident.