### PR TITLE
Cleanup/remove transaction stalling

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -45,6 +45,10 @@ class Transaction extends EventEmitter {
       outerTx ? 'nested' : 'top level'
     );
 
+    // `this` can potentially serve as an `outerTx` for another
+    // Transaction.  So, go ahead and establish `_lastChild` now.
+    this._lastChild = Promise.resolve();
+
     // FYI: As you will see in a moment, this Promise will be used to construct
     //      2 separate Promise Chains.  This ensures that each Promise Chain
     //      can establish its error-handling semantics without interfering
@@ -63,7 +67,7 @@ class Transaction extends EventEmitter {
     // siblings can wait for us to complete before they can start.
     this._previousSibling = Promise.resolve(true);
     if (outerTx) {
-      if (outerTx._lastChild) this._previousSibling = outerTx._lastChild;
+      this._previousSibling = outerTx._lastChild;
 
       // FYI: This is the Promise Chain for INTERNAL use.  It serves as a signal
       //      for when the next sibling should begin its execution.  Therefore,

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -37,6 +37,7 @@ class Transaction extends EventEmitter {
     this.logger = client.logger;
     this.outerTx = outerTx;
     this.trxClient = undefined;
+    this._completed = false;
     this._debug = client.config && client.config.debug;
 
     debug(
@@ -49,6 +50,8 @@ class Transaction extends EventEmitter {
     // Transaction.  So, go ahead and establish `_lastChild` now.
     this._lastChild = Promise.resolve();
 
+    this._previousSibling = outerTx ? outerTx._lastChild : Promise.resolve();
+
     // FYI: As you will see in a moment, this Promise will be used to construct
     //      2 separate Promise Chains.  This ensures that each Promise Chain
     //      can establish its error-handling semantics without interfering
@@ -59,16 +62,7 @@ class Transaction extends EventEmitter {
     //      caller must handle any exceptions that result from `basePromise`.
     this._promise = basePromise.then((x) => x);
 
-    this._completed = false;
-
-    // If there's a wrapping transaction, we need to wait for any older sibling
-    // transactions to settle (commit or rollback) before we can start, and we
-    // need to register ourselves with the parent transaction so any younger
-    // siblings can wait for us to complete before they can start.
-    this._previousSibling = Promise.resolve(true);
     if (outerTx) {
-      this._previousSibling = outerTx._lastChild;
-
       // FYI: This is the Promise Chain for INTERNAL use.  It serves as a signal
       //      for when the next sibling should begin its execution.  Therefore,
       //      exceptions are caught and ignored.
@@ -159,11 +153,6 @@ class Transaction extends EventEmitter {
   }
 
   async _evaluateContainer(config, container) {
-    // FYI: This is temporarily stalling things so that the constructor
-    //      can finish initializing the Transaction.  Otherwise,
-    //      `this.previousSibling` will still be `undefined`.
-    await Promise.resolve();
-
     // Wait for the earlier Transactions to complete before proceeding.
     await this._previousSibling;
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -50,13 +50,15 @@ class Transaction extends EventEmitter {
     // Transaction.  So, go ahead and establish `_lastChild` now.
     this._lastChild = Promise.resolve();
 
-    this._previousSibling = outerTx ? outerTx._lastChild : Promise.resolve();
+    const _previousSibling = outerTx ? outerTx._lastChild : Promise.resolve();
 
     // FYI: As you will see in a moment, this Promise will be used to construct
     //      2 separate Promise Chains.  This ensures that each Promise Chain
     //      can establish its error-handling semantics without interfering
     //      with the other Promise Chain.
-    const basePromise = this._evaluateContainer(config, container);
+    const basePromise = _previousSibling.then(() =>
+      this._evaluateContainer(config, container)
+    );
 
     // FYI: This is the Promise Chain for EXTERNAL use.  It ensures that the
     //      caller must handle any exceptions that result from `basePromise`.
@@ -153,9 +155,6 @@ class Transaction extends EventEmitter {
   }
 
   async _evaluateContainer(config, container) {
-    // Wait for the earlier Transactions to complete before proceeding.
-    await this._previousSibling;
-
     return this.acquireConnection(config, (connection) => {
       const trxClient = (this.trxClient = makeTxClient(
         this,


### PR DESCRIPTION
This removes the `await Process.resolve()` work-around from the Transaction initialization logic.