### PR TITLE
Fix/method binding on knex proxy

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -255,7 +255,7 @@ finallyMixin(Transaction.prototype);
 function makeTransactor(trx, connection, trxClient) {
   const transactor = makeKnex(trxClient);
 
-  transactor.withUserParams = () => {
+  transactor.context.withUserParams = () => {
     throw new Error(
       'Cannot set user params on a transaction - it can only inherit params from main knex instance'
     );

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -271,14 +271,9 @@ function makeTransactor(trx, connection, trxClient) {
       options.doNotRejectOnRollback = true;
     }
 
-    if (container) {
-      return trxClient.transaction(container, options, trx);
-    } else {
-      return new Promise((resolve, _reject) => {
-        trxClient.transaction(resolve, options, trx).catch(_reject);
-      });
-    }
+    return this._transaction(container, options, trx);
   };
+
   transactor.savepoint = function(container, options) {
     return transactor.transaction(container, options);
   };

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -264,7 +264,7 @@ function makeTransactor(trx, connection, trxClient) {
   transactor.isTransaction = true;
   transactor.userParams = trx.userParams || {};
 
-  transactor.transaction = function(container, options) {
+  transactor.context.transaction = function(container, options) {
     if (!options) {
       options = { doNotRejectOnRollback: true };
     } else if (isUndefined(options.doNotRejectOnRollback)) {

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -38,15 +38,14 @@ function initContext(knexFn) {
     // when transaction is ready to be used.
     transaction(container, _config) {
       const config = Object.assign({}, _config);
-      config.userParams = this.userParams || {}
-      if(isUndefined(config.doNotRejectOnRollback)) {
+      config.userParams = this.userParams || {};
+      if (isUndefined(config.doNotRejectOnRollback)) {
         // Backwards-compatibility: default value changes depending upon
         // whether or not a `container` was provided.
         config.doNotRejectOnRollback = !container;
       }
 
-
-      if(container) {
+      if (container) {
         const trx = this.client.transaction(container, config);
         return trx;
       } else {
@@ -145,6 +144,26 @@ function redefineProperties(knex, client) {
     };
   });
 
+  const METHOD_PROXIES = [
+    'raw',
+    'batchInsert',
+    'transaction',
+    'transactionProvider',
+    'initialize',
+    'destroy',
+    'ref',
+    'withUserParams',
+    'queryBuilder',
+    'disableProcessing',
+    'enableProcessing',
+  ];
+
+  for (const m of METHOD_PROXIES) {
+    knex[m] = function(...args) {
+      return knex.context[m](...args);
+    };
+  }
+
   Object.defineProperties(knex, {
     context: {
       get() {
@@ -154,17 +173,17 @@ function redefineProperties(knex, client) {
         knex._context = context;
 
         // Redefine public API for knex instance that would be proxying methods from correct context
-        knex.raw = context.raw;
-        knex.batchInsert = context.batchInsert;
-        knex.transaction = context.transaction;
-        knex.transactionProvider = context.transactionProvider;
-        knex.initialize = context.initialize;
-        knex.destroy = context.destroy;
-        knex.ref = context.ref;
-        knex.withUserParams = context.withUserParams;
-        knex.queryBuilder = context.queryBuilder;
-        knex.disableProcessing = context.disableProcessing;
-        knex.enableProcessing = context.enableProcessing;
+        // knex.raw = context.raw;
+        // knex.batchInsert = context.batchInsert;
+        // knex.transaction = context.transaction;
+        // knex.transactionProvider = context.transactionProvider;
+        // knex.initialize = context.initialize;
+        // knex.destroy = context.destroy;
+        // knex.ref = context.ref;
+        // knex.withUserParams = context.withUserParams;
+        // knex.queryBuilder = context.queryBuilder;
+        // knex.disableProcessing = context.disableProcessing;
+        // knex.enableProcessing = context.enableProcessing;
       },
       configurable: true,
     },

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -21,6 +21,66 @@ const CONTEXT_METHODS = [
   'enableProcessing',
 ];
 
+const KNEX_PROPERTY_DEFINITIONS = {
+  context: {
+    get() {
+      return this._context;
+    },
+    set(context) {
+      this._context = context;
+    },
+    configurable: true,
+  },
+
+  client: {
+    get() {
+      return this.context.client;
+    },
+    set(client) {
+      this.context.client = client;
+    },
+    configurable: true,
+  },
+
+  userParams: {
+    get() {
+      return this.context.userParams;
+    },
+    set(userParams) {
+      this.context.userParams = userParams;
+    },
+    configurable: true,
+  },
+
+  schema: {
+    get() {
+      return this.client.schemaBuilder();
+    },
+    configurable: true,
+  },
+
+  migrate: {
+    get() {
+      return new Migrator(this);
+    },
+    configurable: true,
+  },
+
+  seed: {
+    get() {
+      return new Seeder(this);
+    },
+    configurable: true,
+  },
+
+  fn: {
+    get() {
+      return new FunctionHelper(this.client);
+    },
+    configurable: true,
+  },
+};
+
 function makeKnex(client) {
   // The object we're potentially using to kick off an initial chain.
   function knex(tableName, options) {
@@ -164,65 +224,7 @@ function redefineProperties(knex, client) {
     };
   }
 
-  Object.defineProperties(knex, {
-    context: {
-      get() {
-        return knex._context;
-      },
-      set(context) {
-        knex._context = context;
-      },
-      configurable: true,
-    },
-
-    client: {
-      get() {
-        return this.context.client;
-      },
-      set(client) {
-        this.context.client = client;
-      },
-      configurable: true,
-    },
-
-    userParams: {
-      get() {
-        return this.context.userParams;
-      },
-      set(userParams) {
-        this.context.userParams = userParams;
-      },
-      configurable: true,
-    },
-
-    schema: {
-      get() {
-        return knex.client.schemaBuilder();
-      },
-      configurable: true,
-    },
-
-    migrate: {
-      get() {
-        return new Migrator(knex);
-      },
-      configurable: true,
-    },
-
-    seed: {
-      get() {
-        return new Seeder(knex);
-      },
-      configurable: true,
-    },
-
-    fn: {
-      get() {
-        return new FunctionHelper(knex.client);
-      },
-      configurable: true,
-    },
-  });
+  Object.defineProperties(knex, KNEX_PROPERTY_DEFINITIONS);
 
   initContext(knex);
   knex.client = client;

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -22,16 +22,6 @@ const CONTEXT_METHODS = [
 ];
 
 const KNEX_PROPERTY_DEFINITIONS = {
-  context: {
-    get() {
-      return this._context;
-    },
-    set(context) {
-      this._context = context;
-    },
-    configurable: true,
-  },
-
   client: {
     get() {
       return this.context.client;
@@ -291,7 +281,7 @@ function shallowCloneFunction(originalFunction) {
 
   const clonedFunction = knexFnWrapper.bind(fnContext);
   Object.assign(clonedFunction, originalFunction);
-  clonedFunction._context = knexContext;
+  clonedFunction.context = knexContext;
   return clonedFunction;
 }
 

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -109,12 +109,18 @@ function initContext(knexFn) {
         config.doNotRejectOnRollback = !container;
       }
 
+      return this._transaction(container, config);
+    },
+
+    // Internal method that actually establishes the Transaction.  It makes no assumptions
+    // about the `config` or `outerTx`, and expects the caller to handle these details.
+    _transaction(container, config, outerTx = null) {
       if (container) {
-        const trx = this.client.transaction(container, config);
+        const trx = this.client.transaction(container, config, outerTx);
         return trx;
       } else {
         return new Promise((resolve, reject) => {
-          const trx = this.client.transaction(resolve, config);
+          const trx = this.client.transaction(resolve, config, outerTx);
           trx.catch(reject);
         });
       }

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -153,14 +153,14 @@ function redefineProperties(knex, client) {
   // any other information is specified.
   QueryInterface.forEach(function(method) {
     knex[method] = function() {
-      const builder = knex.queryBuilder();
+      const builder = this.queryBuilder();
       return builder[method].apply(builder, arguments);
     };
   });
 
   for (const m of CONTEXT_METHODS) {
     knex[m] = function(...args) {
-      return knex.context[m](...args);
+      return this.context[m](...args);
     };
   }
 
@@ -177,20 +177,20 @@ function redefineProperties(knex, client) {
 
     client: {
       get() {
-        return knex.context.client;
+        return this.context.client;
       },
       set(client) {
-        knex.context.client = client;
+        this.context.client = client;
       },
       configurable: true,
     },
 
     userParams: {
       get() {
-        return knex.context.userParams;
+        return this.context.userParams;
       },
       set(userParams) {
-        knex.context.userParams = userParams;
+        this.context.userParams = userParams;
       },
       configurable: true,
     },

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -229,6 +229,30 @@ function _copyEventListeners(eventName, sourceKnex, targetKnex) {
 function redefineProperties(knex, client) {
   // Allow chaining methods from the root object, before
   // any other information is specified.
+  //
+  // TODO: `QueryBuilder.extend(..)` allows new QueryBuilder
+  //       methods to be introduced via external components.
+  //       As a side-effect, it also pushes the new method names
+  //       into the `QueryInterface` array.
+  //
+  //       The Problem: due to the way the code is currently
+  //       structured, these new methods cannot be retroactively
+  //       injected into existing `knex` instances!  As a result,
+  //       some `knex` instances will support the methods, and
+  //       others will not.
+  //
+  //       We should revisit this once we figure out the desired
+  //       behavior / usage.  For instance: do we really want to
+  //       allow external components to directly manipulate `knex`
+  //       data structures?  Or, should we come up w/ a different
+  //       approach that avoids side-effects / mutation?
+  //
+  //      (FYI: I noticed this issue because I attempted to integrate
+  //       this logic directly into the `KNEX_PROPERTY_DEFINITIONS`
+  //       construction.  However, `KNEX_PROPERTY_DEFINITIONS` is
+  //       constructed before any `knex` instances are created.
+  //       As a result, the method extensions were missing from all
+  //       `knex` instances.)
   QueryInterface.forEach(function(method) {
     knex[method] = function() {
       const builder = this.queryBuilder();

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -7,20 +7,15 @@ const QueryInterface = require('../query/methods');
 const { merge, isUndefined } = require('lodash');
 const batchInsert = require('./batchInsert');
 
-const CONTEXT_METHODS = [
-  'raw',
-  'batchInsert',
-  'transaction',
-  'transactionProvider',
-  'initialize',
-  'destroy',
-  'ref',
-  'withUserParams',
-  'queryBuilder',
-  'disableProcessing',
-  'enableProcessing',
-];
-
+// Javascript does not officially support "callable objects".  Instead,
+// you must create a regular Function and inject properties/methods
+// into it.  In other words: you can't leverage Prototype Inheritance
+// to share the property/method definitions.
+//
+// To work around this, we're creating an Object Property Definition.
+// This allow us to quickly inject everything into the `knex` function
+// via the `Object.defineProperties(..)` function.  More importantly,
+// it allows the same definitions to be shared across `knex` instances.
 const KNEX_PROPERTY_DEFINITIONS = {
   client: {
     get() {
@@ -70,6 +65,33 @@ const KNEX_PROPERTY_DEFINITIONS = {
     configurable: true,
   },
 };
+
+// `knex` instances serve as proxies around `context` objects.  So, calling
+// any of these methods on the `knex` instance will forward the call to
+// the `knex.context` object. This ensures that `this` will correctly refer
+// to `context` within each of these methods.
+const CONTEXT_METHODS = [
+  'raw',
+  'batchInsert',
+  'transaction',
+  'transactionProvider',
+  'initialize',
+  'destroy',
+  'ref',
+  'withUserParams',
+  'queryBuilder',
+  'disableProcessing',
+  'enableProcessing',
+];
+
+for (const m of CONTEXT_METHODS) {
+  KNEX_PROPERTY_DEFINITIONS[m] = {
+    value: function(...args) {
+      return this.context[m](...args);
+    },
+    configurable: true,
+  };
+}
 
 function makeKnex(client) {
   // The object we're potentially using to kick off an initial chain.
@@ -213,12 +235,6 @@ function redefineProperties(knex, client) {
       return builder[method].apply(builder, arguments);
     };
   });
-
-  for (const m of CONTEXT_METHODS) {
-    knex[m] = function(...args) {
-      return this.context[m](...args);
-    };
-  }
 
   Object.defineProperties(knex, KNEX_PROPERTY_DEFINITIONS);
 

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -7,6 +7,20 @@ const QueryInterface = require('../query/methods');
 const { merge, isUndefined } = require('lodash');
 const batchInsert = require('./batchInsert');
 
+const CONTEXT_METHODS = [
+  'raw',
+  'batchInsert',
+  'transaction',
+  'transactionProvider',
+  'initialize',
+  'destroy',
+  'ref',
+  'withUserParams',
+  'queryBuilder',
+  'disableProcessing',
+  'enableProcessing',
+];
+
 function makeKnex(client) {
   // The object we're potentially using to kick off an initial chain.
   function knex(tableName, options) {
@@ -144,21 +158,7 @@ function redefineProperties(knex, client) {
     };
   });
 
-  const METHOD_PROXIES = [
-    'raw',
-    'batchInsert',
-    'transaction',
-    'transactionProvider',
-    'initialize',
-    'destroy',
-    'ref',
-    'withUserParams',
-    'queryBuilder',
-    'disableProcessing',
-    'enableProcessing',
-  ];
-
-  for (const m of METHOD_PROXIES) {
+  for (const m of CONTEXT_METHODS) {
     knex[m] = function(...args) {
       return knex.context[m](...args);
     };
@@ -171,19 +171,6 @@ function redefineProperties(knex, client) {
       },
       set(context) {
         knex._context = context;
-
-        // Redefine public API for knex instance that would be proxying methods from correct context
-        // knex.raw = context.raw;
-        // knex.batchInsert = context.batchInsert;
-        // knex.transaction = context.transaction;
-        // knex.transactionProvider = context.transactionProvider;
-        // knex.initialize = context.initialize;
-        // knex.destroy = context.destroy;
-        // knex.ref = context.ref;
-        // knex.withUserParams = context.withUserParams;
-        // knex.queryBuilder = context.queryBuilder;
-        // knex.disableProcessing = context.disableProcessing;
-        // knex.enableProcessing = context.enableProcessing;
       },
       configurable: true,
     },

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -240,7 +240,11 @@ function redefineProperties(knex, client) {
 
   initContext(knex);
   knex.client = client;
+
+  // TODO: It looks like this field is never actually used.
+  //       It should probably be removed in a future PR.
   knex.client.makeKnex = makeKnex;
+
   knex.userParams = {};
 
   // Hook up the "knex" object as an EventEmitter.

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -1089,7 +1089,7 @@ module.exports = function(knex) {
       });
       it('should capture stack trace on raw query', () => {
         return knex.raw('select * from some_nonexisten_table').catch((err) => {
-          expect(err.stack.split('\n')[2]).to.match(/at Function\.raw \(/); // the index 2 might need adjustment if the code is refactored
+          expect(err.stack.split('\n')[2]).to.match(/at Object\.raw \(/); // the index 2 might need adjustment if the code is refactored
           expect(typeof err.originalStack).to.equal('string');
         });
       });


### PR DESCRIPTION
The `make-knex.js` module was taking a few shortcuts when creating the `knex` proxy.  As a result, most (all?) of the methods within the `context` object were bound to `knex` instead of `context`.  This would then cause reference errors when one `context` method attempted to call another `context` method.