### PR TITLE
Typescript: Makes the ChainableInterface conform to Promise<T>

### DIFF
--- a/lib/interface.js
+++ b/lib/interface.js
@@ -93,7 +93,7 @@ module.exports = function(Target) {
   };
 
   Object.defineProperty(Target.prototype, Symbol.toStringTag, {
-    get: () => `Promise(${Target.name})`
+    get: () => 'object',
   });
 
   finallyMixin(Target.prototype);

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -92,5 +92,9 @@ module.exports = function(Target) {
     return this.then().catch(onReject);
   };
 
+  Object.defineProperty(Target.prototype, Symbol.toStringTag, {
+    get: () => `Promise(${Target.name})`
+  });
+
   finallyMixin(Target.prototype);
 };

--- a/test/unit/interface.js
+++ b/test/unit/interface.js
@@ -31,7 +31,7 @@ describe('interface', function() {
 
     _interface(SomeClass);
     const fakeInstance = new SomeClass();
-    chai.expect(fakeInstance[Symbol.toStringTag]).to.eq('Promise(SomeClass)');
+    chai.expect(fakeInstance[Symbol.toStringTag]).to.eq('object');
     fakeInstance._asyncStack = ['line1', 'line2', 'line3'];
     fakeInstance.then();
   });

--- a/test/unit/interface.js
+++ b/test/unit/interface.js
@@ -31,6 +31,7 @@ describe('interface', function() {
 
     _interface(SomeClass);
     const fakeInstance = new SomeClass();
+    chai.expect(fakeInstance[Symbol.toStringTag]).to.eq('Promise(SomeClass)');
     fakeInstance._asyncStack = ['line1', 'line2', 'line3'];
     fakeInstance.then();
   });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1433,7 +1433,11 @@ declare namespace Knex {
     | "catch"
     | "finally";
 
-  interface ChainableInterface<T = any> extends Promise<T>, Pick<Promise<T>, keyof Promise<T> & ExposedPromiseKeys> {
+  interface ChainableInterface<T = any> extends Pick<Promise<T>, keyof Promise<T> & ExposedPromiseKeys> {
+    readonly [Symbol.toStringTag]: string;
+  }
+
+  interface ChainableInterface<T = any> {
     toQuery(): string;
     options(options: Readonly<{ [key: string]: any }>): this;
     connection(connection: any): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1433,7 +1433,7 @@ declare namespace Knex {
     | "catch"
     | "finally";
 
-  interface ChainableInterface<T = any> extends Pick<Promise<T>, keyof Promise<T> & ExposedPromiseKeys> {
+  interface ChainableInterface<T = any> extends Promise<T>, Pick<Promise<T>, keyof Promise<T> & ExposedPromiseKeys> {
     toQuery(): string;
     options(options: Readonly<{ [key: string]: any }>): this;
     connection(connection: any): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1433,11 +1433,10 @@ declare namespace Knex {
     | "catch"
     | "finally";
 
-  interface ChainableInterface<T = any> extends Pick<Promise<T>, keyof Promise<T> & ExposedPromiseKeys> {
+  interface StringTagSupport {
     readonly [Symbol.toStringTag]: string;
   }
-
-  interface ChainableInterface<T = any> {
+  interface ChainableInterface<T = any> extends Pick<Promise<T>, keyof Promise<T> & ExposedPromiseKeys>, StringTagSupport {
     toQuery(): string;
     options(options: Readonly<{ [key: string]: any }>): this;
     connection(connection: any): this;


### PR DESCRIPTION
This PR addresses a problem that is often raised in Typescript as the ChainableInterface does not conform to `Promise<T>`.

It add the missing `Symbol.toStringTag` set to `Promise(Target.name)` (so the Builder would be) `Promise(Builder)`.

I wasn't sure of the signature, for the extend, as `finally` may not be there and it doesn't seem to be polyfilled. 

Was the `Pick<K>` being defensive as `interface.js` does not clone the `Promise` prototype?