### PR TITLE
Fix: Oracle_Transaction#acquireConnection(..) can use config.connection

### DIFF
--- a/lib/dialects/oracledb/transaction.js
+++ b/lib/dialects/oracledb/transaction.js
@@ -53,7 +53,8 @@ module.exports = class Oracle_Transaction extends Transaction {
   async acquireConnection(config, cb) {
     const configConnection = config && config.connection;
 
-    const connection = await this.client.acquireConnection();
+    const connection =
+      configConnection || (await this.client.acquireConnection());
     try {
       connection.__knexTxId = this.txid;
       connection.isTransaction = true;


### PR DESCRIPTION
As noted in #3721 , OracleDB's `Transaction#acquireConnection(..)` implementation was not using `config.connection` when it was passed in.  So, this PR addresses that bug.