### PR TITLE
Upgrade package mkdirp and improve it's usage

### DIFF
--- a/lib/migrate/MigrationGenerator.js
+++ b/lib/migrate/MigrationGenerator.js
@@ -1,9 +1,7 @@
-const fs = require('fs');
 const path = require('path');
-const { promisify } = require('util');
-const mkdirp = require('mkdirp');
 const { writeJsFileUsingTemplate } = require('../util/template');
 const { getMergedConfig } = require('./configuration-merger');
+const { ensureDirectoryExists } = require('../util/fs');
 
 class MigrationGenerator {
   constructor(migrationConfig) {
@@ -28,9 +26,7 @@ class MigrationGenerator {
   _ensureFolder() {
     const dirs = this._absoluteConfigDirs();
 
-    const promises = dirs.map((dir) => {
-      return promisify(fs.stat)(dir).catch(() => mkdirp(dir));
-    });
+    const promises = dirs.map(ensureDirectoryExists);
 
     return Promise.all(promises);
   }

--- a/lib/migrate/MigrationGenerator.js
+++ b/lib/migrate/MigrationGenerator.js
@@ -29,7 +29,7 @@ class MigrationGenerator {
     const dirs = this._absoluteConfigDirs();
 
     const promises = dirs.map((dir) => {
-      return promisify(fs.stat)(dir).catch(() => promisify(mkdirp)(dir));
+      return promisify(fs.stat)(dir).catch(() => mkdirp(dir));
     });
 
     return Promise.all(promises);

--- a/lib/seed/Seeder.js
+++ b/lib/seed/Seeder.js
@@ -4,8 +4,8 @@
 const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
-const mkdirp = require('mkdirp');
 const { filter, includes, extend } = require('lodash');
+const { ensureDirectoryExists } = require('../util/fs');
 const { writeJsFileUsingTemplate } = require('../util/template');
 
 // The new seeds we're performing, typically called from the `knex.seed`
@@ -54,11 +54,8 @@ class Seeder {
   // seed config settings.
   async _ensureFolder() {
     const dir = this._absoluteConfigDir();
-    try {
-      await promisify(fs.stat)(dir);
-    } catch (e) {
-      await mkdirp(dir);
-    }
+
+    await ensureDirectoryExists(dir);
   }
 
   // Run seed files, in sequence.

--- a/lib/seed/Seeder.js
+++ b/lib/seed/Seeder.js
@@ -57,7 +57,7 @@ class Seeder {
     try {
       await promisify(fs.stat)(dir);
     } catch (e) {
-      await promisify(mkdirp)(dir);
+      await mkdirp(dir);
     }
   }
 

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const { promisify } = require('util');
+const mkdirp = require('mkdirp');
+
+/**
+ * Ensures the given path exists.
+ *  - If the path already exist, it's fine - it does nothing.
+ *  - If the path doesn't exist, it will create it.
+ *
+ * @param {string} path
+ * @returns {boolean}
+ */
+function ensureDirectoryExists(dir) {
+  return promisify(fs.stat)(dir).catch(() => mkdirp(dir));
+}
+
+module.exports = {
+  ensureDirectoryExists,
+};

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -3,6 +3,14 @@ const { promisify } = require('util');
 const mkdirp = require('mkdirp');
 
 /**
+ * Promisified verion fs.stat() function.
+ *
+ * @param {string} path
+ * @returns {Promise}
+ */
+const stat = promisify(fs.stat);
+
+/**
  * Ensures the given path exists.
  *  - If the path already exist, it's fine - it does nothing.
  *  - If the path doesn't exist, it will create it.
@@ -11,9 +19,10 @@ const mkdirp = require('mkdirp');
  * @returns {Promise}
  */
 function ensureDirectoryExists(dir) {
-  return promisify(fs.stat)(dir).catch(() => mkdirp(dir));
+  return stat(dir).catch(() => mkdirp(dir));
 }
 
 module.exports = {
+  stat,
   ensureDirectoryExists,
 };

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -1,4 +1,6 @@
 const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { promisify } = require('util');
 const mkdirp = require('mkdirp');
 
@@ -9,6 +11,15 @@ const mkdirp = require('mkdirp');
  * @returns {Promise}
  */
 const stat = promisify(fs.stat);
+
+/**
+ * Creates a temporary directory and returns it path.
+ *
+ * @returns {Promise<string>}
+ */
+function createTemp() {
+  return promisify(fs.mkdtemp)(`${os.tmpdir()}${path.sep}`);
+}
 
 /**
  * Ensures the given path exists.
@@ -24,5 +35,6 @@ function ensureDirectoryExists(dir) {
 
 module.exports = {
   stat,
+  createTemp,
   ensureDirectoryExists,
 };

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -3,7 +3,7 @@ const { promisify } = require('util');
 const mkdirp = require('mkdirp');
 
 /**
- * Promisified verion fs.stat() function.
+ * Promisified version of fs.stat() function.
  *
  * @param {string} path
  * @returns {Promise}

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -8,7 +8,7 @@ const mkdirp = require('mkdirp');
  *  - If the path doesn't exist, it will create it.
  *
  * @param {string} path
- * @returns {boolean}
+ * @returns {Promise}
  */
 function ensureDirectoryExists(dir) {
   return promisify(fs.stat)(dir).catch(() => mkdirp(dir));

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "interpret": "^2.0.0",
     "liftoff": "3.1.0",
     "lodash": "^4.17.15",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.3",
     "pg-connection-string": "2.1.0",
     "tarn": "^2.0.0",
     "tildify": "2.0.0",

--- a/test/cli/migrate-make.spec.js
+++ b/test/cli/migrate-make.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const { execCommand } = require('cli-testlab');
 const { expect } = require('chai');
@@ -10,6 +11,7 @@ const {
   expectContentMatchesStub,
   setupFileHelper,
 } = require('./cli-test-utils');
+const { createTemp } = require('../../lib/util/fs');
 
 describe('migrate:make', () => {
   describe('-x option: make migration using a specific extension', () => {
@@ -27,6 +29,39 @@ describe('migrate:make', () => {
 
     before(() => {
       process.env.KNEX_PATH = '../knex.js';
+    });
+
+    it('Create new migration auto-creating migration directory when it does not exist', async () => {
+      const tmpDir = await createTemp();
+      const migrationsDirectory = path.join(tmpDir, 'abc/xyz/temp/migrations');
+      const knexfileContents = `
+        module.exports = {
+          client: 'sqlite3',
+          connection: {
+            filename: __dirname + '/test/jake-util/test.sqlite3',
+          },
+          migrations: {
+            directory: '${migrationsDirectory}',
+          },
+        };`;
+
+      fileHelper.createFile(
+        path.join(process.cwd(), 'knexfile.js'),
+        knexfileContents,
+        { isPathAbsolute: true }
+      );
+
+      await execCommand(
+        `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
+        {
+          expectedOutput: 'Created Migration',
+        }
+      );
+
+      expect(fs.existsSync(migrationsDirectory)).to.equal(true);
+      expect(
+        fileHelper.fileGlobExists(`${migrationsDirectory}/*_somename.js`)
+      ).to.equal(1);
     });
 
     it('Create new migration without knexfile passed or existing in default location', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -33,6 +33,7 @@ process.on('exit', (code) => {
 describe('Util Tests', function() {
   // Unit Tests for utilities.
   require('./unit/query/string');
+  require('./unit/util/fs');
 });
 
 describe('Query Building Tests', function() {

--- a/test/unit/util/fs.js
+++ b/test/unit/util/fs.js
@@ -1,10 +1,12 @@
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
-const { promisify } = require('util');
 
 const { expect } = require('chai');
-const { stat, ensureDirectoryExists } = require('../../../lib/util/fs');
+const {
+  stat,
+  createTemp,
+  ensureDirectoryExists,
+} = require('../../../lib/util/fs');
 
 describe('FS functions', () => {
   describe('stat', () => {
@@ -45,12 +47,3 @@ describe('FS functions', () => {
     });
   });
 });
-
-/**
- * Creates a temporary directory and returns it path.
- *
- * @returns {Promise<string>}
- */
-function createTemp() {
-  return promisify(fs.mkdtemp)(`${os.tmpdir()}${path.sep}`);
-}

--- a/test/unit/util/fs.js
+++ b/test/unit/util/fs.js
@@ -4,9 +4,26 @@ const path = require('path');
 const { promisify } = require('util');
 
 const { expect } = require('chai');
-const { ensureDirectoryExists } = require('../../../lib/util/fs');
+const { stat, ensureDirectoryExists } = require('../../../lib/util/fs');
 
 describe('FS functions', () => {
+  describe('stat', () => {
+    it('should return stats for a given path.', async () => {
+      const directoryThatExists = await createTemp();
+
+      const result = await stat(directoryThatExists);
+
+      expect(result).to.be.an.instanceOf(fs.Stats);
+    });
+
+    it('should throw an error if the path does not exist.', async () => {
+      const directoryThatExists = await createTemp();
+      const unexistingPath = path.join(directoryThatExists, 'abc/xyz/123');
+
+      expect(stat(unexistingPath)).to.eventually.be.rejected;
+    });
+  });
+
   describe('ensureDirectoryExists', () => {
     it('should resolve successfully if the directory already exists.', async () => {
       const directoryThatExists = await createTemp();

--- a/test/unit/util/fs.js
+++ b/test/unit/util/fs.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { promisify } = require('util');
+
+const { expect } = require('chai');
+const { ensureDirectoryExists } = require('../../../lib/util/fs');
+
+describe('FS functions', () => {
+  describe('ensureDirectoryExists', () => {
+    it('should resolve successfully if the directory already exists.', async () => {
+      const directoryThatExists = await createTemp();
+
+      const result = await ensureDirectoryExists(directoryThatExists);
+
+      expect(result).to.be.an.instanceOf(fs.Stats);
+    });
+
+    it('should create a directory (recursively) if it does not exist.', async () => {
+      const directoryThatExists = await createTemp();
+      const newPath = path.join(directoryThatExists, 'abc/xyz/123');
+
+      expect(fs.existsSync(newPath)).to.equal(false);
+
+      await ensureDirectoryExists(newPath);
+
+      expect(fs.existsSync(newPath)).to.equal(true);
+    });
+  });
+});
+
+/**
+ * Creates a temporary directory and returns it path.
+ *
+ * @returns {Promise<string>}
+ */
+function createTemp() {
+  return promisify(fs.mkdtemp)(`${os.tmpdir()}${path.sep}`);
+}


### PR DESCRIPTION
**Changes**
* Upgrade [`mkdirp`](https://www.npmjs.com/package/mkdirp) to `^1.0.3`. Check issue #3740 for details.
* The new version is already Promise-friendly so update the usage a bit to address that.
* De-duplicate `_ensureFolder` logic by extracting the common logic into util function under `lib/util/fs.js`.
* Added tests for the new util function.
* Added CLI tests on the following files to ensure `seed:make` and `migration:make` commands do create directories (recursively) when they do not exist.
  - https://github.com/knex/knex/blob/master/test/cli/migrate-make.spec.js
  - https://github.com/knex/knex/blob/master/test/cli/seed-make.spec.js


Resolves #3740 