### PR TITLE
Minor improvements on the usage of fs utilities - unify all the fs functions into the same util/fs to simplify things

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,8 +7,6 @@ const tildify = require('tildify');
 const commander = require('commander');
 const color = require('colorette');
 const argv = require('getopts')(process.argv.slice(2));
-const fs = require('fs');
-const { promisify } = require('util');
 const cliPkg = require('../package');
 const {
   mkConfigObj,
@@ -20,13 +18,9 @@ const {
   getSeedExtension,
   getStubPath,
 } = require('./utils/cli-config-utils');
+const { readFile, writeFile } = require('./../lib/util/fs');
 
 const { listMigrations } = require('./utils/migrationsLister');
-
-const fsPromised = {
-  readFile: promisify(fs.readFile),
-  writeFile: promisify(fs.writeFile),
-};
 
 function openKnexfile(configPath) {
   const config = require(configPath);
@@ -118,15 +112,14 @@ function invoke(env) {
       }
       checkLocalModule(env);
       const stubPath = `./knexfile.${type}`;
-      pending = fsPromised
-        .readFile(
-          path.dirname(env.modulePath) +
-            '/lib/migrate/stub/knexfile-' +
-            type +
-            '.stub'
-        )
+      pending = readFile(
+        path.dirname(env.modulePath) +
+          '/lib/migrate/stub/knexfile-' +
+          type +
+          '.stub'
+      )
         .then((code) => {
-          return fsPromised.writeFile(stubPath, code);
+          return writeFile(stubPath, code);
         })
         .then(() => {
           success(color.green(`Created ${stubPath}`));

--- a/lib/migrate/sources/fs-migrations.js
+++ b/lib/migrate/sources/fs-migrations.js
@@ -1,9 +1,7 @@
-const fs = require('fs');
 const path = require('path');
-const { promisify } = require('util');
 const { sortBy, filter } = require('lodash');
 
-const readDirAsync = promisify(fs.readdir);
+const { readdir } = require('../../util/fs');
 
 const DEFAULT_LOAD_EXTENSIONS = Object.freeze([
   '.co',
@@ -35,7 +33,7 @@ class FsMigrations {
     // Get a list of files in all specified migration directories
     const readMigrationsPromises = this.migrationsPaths.map((configDir) => {
       const absoluteDir = path.resolve(process.cwd(), configDir);
-      return readDirAsync(absoluteDir).then((files) => ({
+      return readdir(absoluteDir).then((files) => ({
         files,
         configDir,
         absoluteDir,

--- a/lib/seed/Seeder.js
+++ b/lib/seed/Seeder.js
@@ -1,11 +1,9 @@
 // Seeder
 // -------
 
-const fs = require('fs');
 const path = require('path');
-const { promisify } = require('util');
 const { filter, includes, extend } = require('lodash');
-const { ensureDirectoryExists } = require('../util/fs');
+const { readdir, ensureDirectoryExists } = require('../util/fs');
 const { writeJsFileUsingTemplate } = require('../util/template');
 
 // The new seeds we're performing, typically called from the `knex.seed`
@@ -42,7 +40,7 @@ class Seeder {
   async _listAll(config) {
     this.config = this.setConfig(config);
     const loadExtensions = this.config.loadExtensions;
-    return promisify(fs.readdir)(this._absoluteConfigDir()).then((seeds) =>
+    return readdir(this._absoluteConfigDir()).then((seeds) =>
       filter(seeds, (value) => {
         const extension = path.extname(value);
         return includes(loadExtensions, extension);

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -13,6 +13,23 @@ const mkdirp = require('mkdirp');
 const stat = promisify(fs.stat);
 
 /**
+ * Promisified version of fs.readFile() function.
+ *
+ * @param {string} path
+ * @returns {Promise<any>}
+ */
+const readFile = promisify(fs.readFile);
+
+/**
+ * Promisified version of fs.writeFile() function.
+ *
+ * @param {string} path
+ * @param {data} data
+ * @returns {Promise<any>}
+ */
+const writeFile = promisify(fs.writeFile);
+
+/**
  * Creates a temporary directory and returns it path.
  *
  * @returns {Promise<string>}
@@ -35,6 +52,8 @@ function ensureDirectoryExists(dir) {
 
 module.exports = {
   stat,
+  readFile,
+  writeFile,
   createTemp,
   ensureDirectoryExists,
 };

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -14,18 +14,11 @@ const stat = promisify(fs.stat);
 
 /**
  * Promisified version of fs.readFile() function.
- *
- * @param {string} path
- * @returns {Promise<any>}
  */
 const readFile = promisify(fs.readFile);
 
 /**
  * Promisified version of fs.writeFile() function.
- *
- * @param {string} path
- * @param {data} data
- * @returns {Promise<any>}
  */
 const writeFile = promisify(fs.writeFile);
 

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -4,24 +4,10 @@ const path = require('path');
 const { promisify } = require('util');
 const mkdirp = require('mkdirp');
 
-/**
- * Promisified version of fs.stat() function.
- *
- * @param {string} path
- * @returns {Promise}
- */
+// Promisify common fs functions.
 const stat = promisify(fs.stat);
-
-/**
- * Promisified version of fs.readFile() function.
- */
 const readFile = promisify(fs.readFile);
-
-/**
- * Promisified version of fs.writeFile() function.
- */
 const writeFile = promisify(fs.writeFile);
-
 const readdir = promisify(fs.readdir);
 
 /**

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -22,6 +22,8 @@ const readFile = promisify(fs.readFile);
  */
 const writeFile = promisify(fs.writeFile);
 
+const readdir = promisify(fs.readdir);
+
 /**
  * Creates a temporary directory and returns it path.
  *
@@ -45,6 +47,7 @@ function ensureDirectoryExists(dir) {
 
 module.exports = {
   stat,
+  readdir,
   readFile,
   writeFile,
   createTemp,

--- a/lib/util/template.js
+++ b/lib/util/template.js
@@ -1,6 +1,6 @@
 const { template } = require('lodash');
-const { promisify } = require('util');
-const fs = require('fs');
+
+const { readFile, writeFile } = require('./fs');
 
 /**
  * Light wrapper over lodash templates making it safer to be used with javascript source code.
@@ -15,9 +15,6 @@ const jsSourceTemplate = (content, options) =>
     interpolate: /<%=([\s\S]+?)%>/g,
     ...options,
   });
-
-const readFile = promisify(fs.readFile, { context: fs });
-const writeFile = promisify(fs.writeFile, { context: fs });
 
 /**
  * Compile the contents of specified (javascript) file as a lodash template

--- a/test/unit/util/fs.js
+++ b/test/unit/util/fs.js
@@ -30,12 +30,12 @@ describe('FS functions', () => {
   });
 
   describe('readFile', async () => {
-    const tmpPath = await createTemp();
-    const filePath = path.join(tmpPath, `${Date.now()}1.txt`);
-
-    fs.writeFileSync(filePath, 'Hello World!');
-
     it('should be able to read from the given file path.', async () => {
+      const tmpPath = await createTemp();
+      const filePath = path.join(tmpPath, `${Date.now()}1.txt`);
+
+      fs.writeFileSync(filePath, 'Hello World!');
+
       const contents = await readFile(filePath);
 
       expect(contents.toString()).to.equal('Hello World!');
@@ -43,10 +43,10 @@ describe('FS functions', () => {
   });
 
   describe('writeFile', async () => {
-    const tmpPath = await createTemp();
-    const filePath = path.join(tmpPath, `${Date.now()}2.txt`);
-
     it('should be able to write to the given file path.', async () => {
+      const tmpPath = await createTemp();
+      const filePath = path.join(tmpPath, `${Date.now()}2.txt`);
+
       await writeFile(filePath, 'Foo Bar');
 
       expect(fs.readFileSync(filePath).toString()).to.equal('Foo Bar');

--- a/test/unit/util/fs.js
+++ b/test/unit/util/fs.js
@@ -4,6 +4,8 @@ const path = require('path');
 const { expect } = require('chai');
 const {
   stat,
+  readFile,
+  writeFile,
   createTemp,
   ensureDirectoryExists,
 } = require('../../../lib/util/fs');
@@ -23,6 +25,30 @@ describe('FS functions', () => {
       const unexistingPath = path.join(directoryThatExists, 'abc/xyz/123');
 
       expect(stat(unexistingPath)).to.eventually.be.rejected;
+    });
+  });
+
+  describe('readFile', async () => {
+    const tmpPath = await createTemp();
+    const filePath = path.join(tmpPath, `${Date.now()}1.txt`);
+
+    fs.writeFileSync(filePath, 'Hello World!');
+
+    it('should be able to read from the given file path.', async () => {
+      const contents = await readFile(filePath);
+
+      expect(contents.toString()).to.equal('Hello World!');
+    });
+  });
+
+  describe('writeFile', async () => {
+    const tmpPath = await createTemp();
+    const filePath = path.join(tmpPath, `${Date.now()}2.txt`);
+
+    it('should be able to write to the given file path.', async () => {
+      await writeFile(filePath, 'Foo Bar');
+
+      expect(fs.readFileSync(filePath).toString()).to.equal('Foo Bar');
     });
   });
 

--- a/test/unit/util/fs.js
+++ b/test/unit/util/fs.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { expect } = require('chai');
 const {
   stat,
+  readdir,
   readFile,
   writeFile,
   createTemp,
@@ -49,6 +50,27 @@ describe('FS functions', () => {
       await writeFile(filePath, 'Foo Bar');
 
       expect(fs.readFileSync(filePath).toString()).to.equal('Foo Bar');
+    });
+  });
+
+  describe('readdir', async () => {
+    it('should read a directory and return a list of files under it.', async () => {
+      const directory = await createTemp();
+
+      // Create files under the directory.
+      fs.writeFileSync(path.join(directory, 'testfile1.txt'), 'testfile1');
+      fs.writeFileSync(path.join(directory, 'testfile2.txt'), 'testfile2');
+      fs.writeFileSync(path.join(directory, 'testfile3.txt'), 'testfile3');
+      fs.writeFileSync(path.join(directory, 'testfile4.txt'), 'testfile4');
+
+      const result = await readdir(directory);
+
+      expect(result).to.deep.equal([
+        'testfile1.txt',
+        'testfile2.txt',
+        'testfile3.txt',
+        'testfile4.txt',
+      ]);
     });
   });
 


### PR DESCRIPTION
- Move all the promisified declarations of fs functions such as `readFile`, `writeFile` and `readdir` to `util/fs.js` module. This also deduplicates the usage a bit.
- Update usages and import them from the same module. 
- Add few tests - just for a quick validation of the module's exports


