### PR TITLE
Support more modes to set the host as a Postgres socket

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "liftoff": "3.1.0",
     "lodash": "^4.17.15",
     "mkdirp": "^1.0.3",
-    "pg-connection-string": "2.1.0",
+    "pg-connection-string": "2.2.0",
     "tarn": "^2.0.0",
     "tildify": "2.0.0",
     "uuid": "^7.0.1",


### PR DESCRIPTION
v2.2.0 of pg-connection-string adds this feature: https://github.com/iceddev/pg-connection-string/pull/34