### PR TITLE
Fix Knex interface types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -322,7 +322,7 @@ interface PgTableOptions {
   only?: boolean;
 }
 
-interface Knex<TRecord extends {} = any, TResult = any[]>
+interface Knex<TRecord extends {} = any, TResult = unknown[]>
   extends Knex.QueryInterface<TRecord, TResult>, events.EventEmitter {
   <TRecord2 = TRecord, TResult2 = DeferredKeySelection<TRecord2, never>[]>(
     tableName?: Knex.TableDescriptor | Knex.AliasDict,
@@ -365,7 +365,7 @@ interface Knex<TRecord extends {} = any, TResult = any[]>
   ref: Knex.RefBuilder;
 }
 
-declare function Knex<TRecord = any, TResult = unknown[]>(
+declare function Knex<TRecord extends {} = any, TResult = unknown[]>(
   config: Knex.Config | string
 ): Knex<TRecord, TResult>;
 


### PR DESCRIPTION
I believe `interface Knex` and `function Knex` should have the same types. (well I don't understand why they should have different types).

This causes some problems with Bookshelf.

Without this PR:

![Screen Shot 2020-04-10 at 15 12 46](https://user-images.githubusercontent.com/643434/78993336-cc5ba100-7b3d-11ea-929f-a32b68b5eddb.png)

<br>

![Screen Shot 2020-04-10 at 15 13 40](https://user-images.githubusercontent.com/643434/78993391-e4cbbb80-7b3d-11ea-97aa-75e88367fd27.png)

With this PR:

![Screen Shot 2020-04-10 at 15 01 18](https://user-images.githubusercontent.com/643434/78993149-548d7680-7b3d-11ea-971a-76a260e19592.png)

I've run `dtslint types` and everything is OK