### PR TITLE
add delayedThen/delayedCatch methods

### DIFF
--- a/lib/interface.js
+++ b/lib/interface.js
@@ -11,8 +11,22 @@ module.exports = function(Target) {
     }).join(';\n');
   };
 
+  Target.prototype.delayThen = function() {
+    this.interceptors = this.interceptors || [];
+    this.interceptors.push(['then', arguments]);
+    return this;
+  };
+
+  Target.prototype.delayCatch = function() {
+    this.interceptors = this.interceptors || [];
+    this.interceptors.push(['catch', arguments]);
+    return this;
+  };
+
   // Create a new instance of the `Runner`, passing in the current object.
   Target.prototype.then = function(/* onFulfilled, onRejected */) {
+    this.interceptors = this.interceptors || [];
+    this.interceptors.push(['then', arguments]);
     let result = this.client.runner(this).run();
 
     if (this.client.config.asyncStackTraces) {
@@ -26,7 +40,11 @@ module.exports = function(Target) {
       });
     }
 
-    return result.then.apply(result, arguments);
+    for(const interceptor of this.interceptors) {
+      result = result[interceptor[0]].apply(result, interceptor[1]);
+    }
+
+    return result;
   };
 
   // Add additional "options" to the builder. Typically used for client specific

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -12,21 +12,18 @@ module.exports = function(Target) {
   };
 
   Target.prototype.delayThen = function() {
-    this.interceptors = this.interceptors || [];
-    this.interceptors.push(['then', arguments]);
+    this._interceptors.push(['then', arguments]);
     return this;
   };
 
   Target.prototype.delayCatch = function() {
-    this.interceptors = this.interceptors || [];
-    this.interceptors.push(['catch', arguments]);
+    this._interceptors.push(['catch', arguments]);
     return this;
   };
 
   // Create a new instance of the `Runner`, passing in the current object.
   Target.prototype.then = function(/* onFulfilled, onRejected */) {
-    this.interceptors = this.interceptors || [];
-    this.interceptors.push(['then', arguments]);
+    this._interceptors.push(['then', arguments]);
     let result = this.client.runner(this).run();
 
     if (this.client.config.asyncStackTraces) {
@@ -40,7 +37,7 @@ module.exports = function(Target) {
       });
     }
 
-    for(const interceptor of this.interceptors) {
+    for(const interceptor of this._interceptors) {
       result = result[interceptor[0]].apply(result, interceptor[1]);
     }
 

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -47,6 +47,7 @@ function Builder(client) {
   this._boolFlag = 'and';
   this._notFlag = false;
   this._asColumnFlag = false;
+  this._interceptors = [];
 }
 
 inherits(Builder, EventEmitter);

--- a/lib/raw.js
+++ b/lib/raw.js
@@ -23,6 +23,7 @@ function Raw(client) {
 
   this.sql = '';
   this.bindings = [];
+  this._interceptors = [];
 
   // Todo: Deprecate
   this._wrappedBefore = undefined;

--- a/lib/schema/builder.js
+++ b/lib/schema/builder.js
@@ -11,6 +11,7 @@ const saveAsyncStack = require('../util/save-async-stack');
 function SchemaBuilder(client) {
   this.client = client;
   this._sequence = [];
+  this._interceptors = [];
 
   if (client.config) {
     this._debug = client.config.debug;


### PR DESCRIPTION
Im building a lightweight framework around knex. 

delayedThens and delayedCatches (im not sure if there is a more correct name) allow me to declaratively handle postprocessing of responses for finds, inserts, updates, etc that are unique to those queries, while still allowing the developer to be in control of when execution happens AND can continue to modify the querybuilder outside of my framework seamlessly.

Question 1: is this something of interest?
Question 2: if so then where should i add tests? Under unit, integration, both?