### PR TITLE
Reduce size of lodash in bundle

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -20,7 +20,9 @@ const { EventEmitter } = require('events');
 const { promisify } = require('util');
 
 const { makeEscape } = require('./query/string');
-const { uniqueId, cloneDeep, defaults } = require('lodash');
+const cloneDeep = require('lodash/cloneDeep');
+const defaults = require('lodash/defaults');
+const uniqueId = require('lodash/uniqueId');
 
 const Logger = require('./logger');
 const { KnexTimeoutError } = require('./util/timeout');

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,5 +1,3 @@
-const { keys } = require('lodash');
-
 // The client names we'll allow in the `{name: lib}` pairing.
 const CLIENT_ALIASES = Object.freeze({
   pg: 'postgres',
@@ -16,7 +14,7 @@ const SUPPORTED_CLIENTS = Object.freeze(
     'postgres',
     'redshift',
     'sqlite3',
-  ].concat(keys(CLIENT_ALIASES))
+  ].concat(Object.keys(CLIENT_ALIASES))
 );
 
 const POOL_CONFIG_OPTIONS = Object.freeze([

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -1,6 +1,8 @@
 // MSSQL Client
 // -------
-const { map, flatten, values } = require('lodash');
+const flatten = require('lodash/flatten');
+const map = require('lodash/map');
+const values = require('lodash/values');
 const inherits = require('inherits');
 
 const Client = require('../../client');

--- a/lib/dialects/mssql/query/compiler.js
+++ b/lib/dialects/mssql/query/compiler.js
@@ -2,7 +2,9 @@
 // ------
 const QueryCompiler = require('../../../query/compiler');
 
-const { isEmpty, compact, identity } = require('lodash');
+const compact = require('lodash/compact');
+const identity = require('lodash/identity');
+const isEmpty = require('lodash/isEmpty');
 
 const components = [
   'columns',

--- a/lib/dialects/mssql/transaction.js
+++ b/lib/dialects/mssql/transaction.js
@@ -1,5 +1,4 @@
 const Transaction = require('../../transaction');
-const { isUndefined } = require('lodash');
 const debug = require('debug')('knex:tx');
 
 module.exports = class Transaction_MSSQL extends Transaction {
@@ -29,7 +28,7 @@ module.exports = class Transaction_MSSQL extends Transaction {
     return conn.tx_.rollback().then(
       () => {
         let err = error;
-        if (isUndefined(error)) {
+        if (error === undefined) {
           if (this.doNotRejectOnRollback) {
             this._resolver();
             return;

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -1,7 +1,8 @@
 // MySQL Client
 // -------
 const inherits = require('inherits');
-const { map, defer } = require('lodash');
+const defer = require('lodash/defer');
+const map = require('lodash/map');
 const { promisify } = require('util');
 const Client = require('../../client');
 

--- a/lib/dialects/mysql/query/compiler.js
+++ b/lib/dialects/mysql/query/compiler.js
@@ -2,7 +2,7 @@
 // ------
 const QueryCompiler = require('../../../query/compiler');
 
-const { identity } = require('lodash');
+const identity = require('lodash/identity');
 
 class QueryCompiler_MySQL extends QueryCompiler {
   constructor(client, builder) {
@@ -68,7 +68,7 @@ class QueryCompiler_MySQL extends QueryCompiler {
         'select * from information_schema.columns where table_name = ? and table_schema = ?',
       bindings: [table, this.client.database()],
       output(resp) {
-        const out = resp.reduce(function (columns, val) {
+        const out = resp.reduce(function(columns, val) {
           columns[val.COLUMN_NAME] = {
             defaultValue: val.COLUMN_DEFAULT,
             type: val.DATA_TYPE,

--- a/lib/dialects/mysql/schema/columncompiler.js
+++ b/lib/dialects/mysql/schema/columncompiler.js
@@ -3,7 +3,7 @@
 const inherits = require('inherits');
 const ColumnCompiler = require('../../../schema/columncompiler');
 
-const { isObject } = require('lodash');
+const isObject = require('lodash/isObject');
 
 function ColumnCompiler_MySQL() {
   ColumnCompiler.apply(this, arguments);

--- a/lib/dialects/mysql/schema/compiler.js
+++ b/lib/dialects/mysql/schema/compiler.js
@@ -3,7 +3,7 @@
 const inherits = require('inherits');
 const SchemaCompiler = require('../../../schema/compiler');
 
-const { some } = require('lodash');
+const some = require('lodash/some');
 
 function SchemaCompiler_MySQL(client, builder) {
   SchemaCompiler.call(this, client, builder);

--- a/lib/dialects/mysql/transaction.js
+++ b/lib/dialects/mysql/transaction.js
@@ -1,6 +1,5 @@
 const Transaction = require('../../transaction');
 const Debug = require('debug');
-const { isUndefined } = require('lodash');
 
 const debug = Debug('knex:tx');
 
@@ -28,7 +27,7 @@ Object.assign(Transaction_MySQL.prototype, {
       .then(function(res) {
         if (status === 1) t._resolver(value);
         if (status === 2) {
-          if (isUndefined(value)) {
+          if (value === undefined) {
             if (t.doNotRejectOnRollback && /^ROLLBACK\b/i.test(sql)) {
               t._resolver();
               return;

--- a/lib/dialects/mysql2/transaction.js
+++ b/lib/dialects/mysql2/transaction.js
@@ -1,8 +1,6 @@
 const Transaction = require('../../transaction');
 const debug = require('debug')('knex:tx');
 
-const { isUndefined } = require('lodash');
-
 class Transaction_MySQL2 extends Transaction {}
 
 Object.assign(Transaction_MySQL2.prototype, {
@@ -27,7 +25,7 @@ Object.assign(Transaction_MySQL2.prototype, {
       .then(function(res) {
         if (status === 1) t._resolver(value);
         if (status === 2) {
-          if (isUndefined(value)) {
+          if (value === undefined) {
             if (t.doNotRejectOnRollback && /^ROLLBACK\b/i.test(sql)) {
               t._resolver();
               return;

--- a/lib/dialects/oracle/query/compiler.js
+++ b/lib/dialects/oracle/query/compiler.js
@@ -6,7 +6,6 @@ const {
   isPlainObject,
   isEmpty,
   isString,
-  map,
   reduce,
   compact,
   identity,
@@ -102,52 +101,56 @@ class QueryCompiler_Oracle extends QueryCompiler {
 
     sql.sql =
       'begin ' +
-      map(insertData.values, (value) => {
-        let returningHelper;
-        const parameterizedValues = !insertDefaultsOnly
-          ? this.formatter.parameterize(value, this.client.valueForUndefined)
-          : '';
-        const returningValues = Array.isArray(returning)
-          ? returning
-          : [returning];
-        let subSql = `insert into ${this.tableName} `;
+      insertData.values
+        .map((value) => {
+          let returningHelper;
+          const parameterizedValues = !insertDefaultsOnly
+            ? this.formatter.parameterize(value, this.client.valueForUndefined)
+            : '';
+          const returningValues = Array.isArray(returning)
+            ? returning
+            : [returning];
+          let subSql = `insert into ${this.tableName} `;
 
-        if (returning) {
-          returningHelper = new ReturningHelper(returningValues.join(':'));
-          sql.outParams = (sql.outParams || []).concat(returningHelper);
-        }
+          if (returning) {
+            returningHelper = new ReturningHelper(returningValues.join(':'));
+            sql.outParams = (sql.outParams || []).concat(returningHelper);
+          }
 
-        if (insertDefaultsOnly) {
-          // no columns given so only the default value
-          subSql += `(${this.formatter.wrap(
-            this.single.returning
-          )}) values (default)`;
-        } else {
-          subSql += `(${this.formatter.columnize(
-            insertData.columns
-          )}) values (${parameterizedValues})`;
-        }
-        subSql += returning
-          ? ` returning ROWID into ${this.formatter.parameter(returningHelper)}`
-          : '';
+          if (insertDefaultsOnly) {
+            // no columns given so only the default value
+            subSql += `(${this.formatter.wrap(
+              this.single.returning
+            )}) values (default)`;
+          } else {
+            subSql += `(${this.formatter.columnize(
+              insertData.columns
+            )}) values (${parameterizedValues})`;
+          }
+          subSql += returning
+            ? ` returning ROWID into ${this.formatter.parameter(
+                returningHelper
+              )}`
+            : '';
 
-        // pre bind position because subSql is an execute immediate parameter
-        // later position binding will only convert the ? params
+          // pre bind position because subSql is an execute immediate parameter
+          // later position binding will only convert the ? params
 
-        subSql = this.formatter.client.positionBindings(subSql);
+          subSql = this.formatter.client.positionBindings(subSql);
 
-        const parameterizedValuesWithoutDefault = parameterizedValues
-          .replace('DEFAULT, ', '')
-          .replace(', DEFAULT', '');
-        return (
-          `execute immediate '${subSql.replace(/'/g, "''")}` +
-          (parameterizedValuesWithoutDefault || returning ? "' using " : '') +
-          parameterizedValuesWithoutDefault +
-          (parameterizedValuesWithoutDefault && returning ? ', ' : '') +
-          (returning ? 'out ?' : '') +
-          ';'
-        );
-      }).join(' ') +
+          const parameterizedValuesWithoutDefault = parameterizedValues
+            .replace('DEFAULT, ', '')
+            .replace(', DEFAULT', '');
+          return (
+            `execute immediate '${subSql.replace(/'/g, "''")}` +
+            (parameterizedValuesWithoutDefault || returning ? "' using " : '') +
+            parameterizedValuesWithoutDefault +
+            (parameterizedValuesWithoutDefault && returning ? ', ' : '') +
+            (returning ? 'out ?' : '') +
+            ';'
+          );
+        })
+        .join(' ') +
       'end;';
 
     if (returning) {
@@ -252,7 +255,7 @@ class QueryCompiler_Oracle extends QueryCompiler {
 
   select() {
     let query = this.with();
-    const statements = map(components, (component) => {
+    const statements = components.map((component) => {
       return this[component]();
     });
     query += compact(statements).join(' ');

--- a/lib/dialects/oracle/query/compiler.js
+++ b/lib/dialects/oracle/query/compiler.js
@@ -2,14 +2,12 @@
 
 // Oracle Query Builder & Compiler
 // ------
-const {
-  isPlainObject,
-  isEmpty,
-  isString,
-  reduce,
-  compact,
-  identity,
-} = require('lodash');
+const compact = require('lodash/compact');
+const identity = require('lodash/identity');
+const isEmpty = require('lodash/isEmpty');
+const isPlainObject = require('lodash/isPlainObject');
+const isString = require('lodash/isString');
+const reduce = require('lodash/reduce');
 const QueryCompiler = require('../../../query/compiler');
 const { ReturningHelper } = require('../utils');
 

--- a/lib/dialects/oracle/schema/columnbuilder.js
+++ b/lib/dialects/oracle/schema/columnbuilder.js
@@ -1,7 +1,7 @@
 const inherits = require('inherits');
 const ColumnBuilder = require('../../../schema/columnbuilder');
 
-const { toArray } = require('lodash');
+const toArray = require('lodash/toArray');
 
 function ColumnBuilder_Oracle() {
   ColumnBuilder.apply(this, arguments);

--- a/lib/dialects/oracle/schema/columncompiler.js
+++ b/lib/dialects/oracle/schema/columncompiler.js
@@ -1,4 +1,4 @@
-const { uniq, map } = require('lodash');
+const { uniq } = require('lodash');
 const inherits = require('inherits');
 const Raw = require('../../../raw');
 const ColumnCompiler = require('../../../schema/columncompiler');
@@ -128,7 +128,7 @@ Object.assign(ColumnCompiler_Oracle.prototype, {
     } else if (value instanceof Raw) {
       value = value.toQuery();
     } else if (Array.isArray(value)) {
-      value = map(value, (v) => `'${v}'`).join(', ');
+      value = value.map((v) => `'${v}'`).join(', ');
     } else {
       value = `'${value}'`;
     }

--- a/lib/dialects/oracle/schema/columncompiler.js
+++ b/lib/dialects/oracle/schema/columncompiler.js
@@ -1,4 +1,4 @@
-const { uniq } = require('lodash');
+const uniq = require('lodash/uniq');
 const inherits = require('inherits');
 const Raw = require('../../../raw');
 const ColumnCompiler = require('../../../schema/columncompiler');

--- a/lib/dialects/oracle/schema/tablecompiler.js
+++ b/lib/dialects/oracle/schema/tablecompiler.js
@@ -6,8 +6,6 @@ const TableCompiler = require('../../../schema/tablecompiler');
 const helpers = require('../../../helpers');
 const Trigger = require('./trigger');
 
-const { map } = require('lodash');
-
 // Table Compiler
 // ------
 
@@ -21,7 +19,7 @@ Object.assign(TableCompiler_Oracle.prototype, {
     if (columns.sql.length > 0) {
       prefix = prefix || this.addColumnsPrefix;
 
-      const columnSql = map(columns.sql, (column) => column);
+      const columnSql = columns.sql;
       const alter = this.lowerCase ? 'alter table ' : 'ALTER TABLE ';
 
       let sql = `${alter}${this.tableName()} ${prefix}`;

--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -28,7 +28,7 @@ Client_Oracledb.prototype._driver = function() {
   const client = this;
   const oracledb = require('oracledb');
   client.fetchAsString = [];
-  if (this.config.fetchAsString && _.isArray(this.config.fetchAsString)) {
+  if (this.config.fetchAsString && Array.isArray(this.config.fetchAsString)) {
     this.config.fetchAsString.forEach(function(type) {
       if (!_.isString(type)) return;
       type = type.toUpperCase();
@@ -100,7 +100,7 @@ Client_Oracledb.prototype.acquireRawConnection = function() {
       oracleDbConfig.prefetchRows = client.connectionSettings.prefetchRowCount;
     }
 
-    if (!_.isUndefined(client.connectionSettings.stmtCacheSize)) {
+    if (client.connectionSettings.stmtCacheSize !== undefined) {
       oracleDbConfig.stmtCacheSize = client.connectionSettings.stmtCacheSize;
     }
 
@@ -402,7 +402,7 @@ Client_Oracledb.prototype.processResponse = function(obj, runner) {
           return _.flatten(_.map(response, _.values));
         }
         return response;
-      } else if (!_.isUndefined(obj.rowsAffected)) {
+      } else if (obj.rowsAffected !== undefined) {
         return obj.rowsAffected;
       } else {
         return 1;

--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -1,6 +1,11 @@
 // Oracledb Client
 // -------
-const _ = require('lodash');
+const each = require('lodash/each');
+const flatten = require('lodash/flatten');
+const isEmpty = require('lodash/isEmpty');
+const isString = require('lodash/isString');
+const map = require('lodash/map');
+const values = require('lodash/values');
 const inherits = require('inherits');
 const QueryCompiler = require('./query/compiler');
 const ColumnCompiler = require('./schema/columncompiler');
@@ -30,7 +35,7 @@ Client_Oracledb.prototype._driver = function() {
   client.fetchAsString = [];
   if (this.config.fetchAsString && Array.isArray(this.config.fetchAsString)) {
     this.config.fetchAsString.forEach(function(type) {
-      if (!_.isString(type)) return;
+      if (!isString(type)) return;
       type = type.toUpperCase();
       if (oracledb[type]) {
         if (
@@ -64,7 +69,7 @@ Client_Oracledb.prototype.transaction = function() {
 };
 
 Client_Oracledb.prototype.prepBindings = function(bindings) {
-  return _.map(bindings, (value) => {
+  return map(bindings, (value) => {
     if (value instanceof BlobHelper && this.driver) {
       return { type: this.driver.BLOB, dir: this.driver.BIND_OUT };
       // Returning helper always use ROWID as string
@@ -262,7 +267,7 @@ Client_Oracledb.prototype._query = function(connection, obj) {
     .executeAsync(obj.sql, obj.bindings, options)
     .then(async function(response) {
       // Flatten outBinds
-      let outBinds = _.flatten(response.outBinds);
+      let outBinds = flatten(response.outBinds);
       obj.response = response.rows || [];
       obj.rowsAffected = response.rows
         ? response.rows.rowsAffected
@@ -287,7 +292,7 @@ Client_Oracledb.prototype._query = function(connection, obj) {
 
         for (let i = 0; i < modifiedRowsCount; i++) {
           updatedObjOutBinding.push(obj.outBinding[0]);
-          _.each(obj.outBinding[0], updateOutBinds(i));
+          each(obj.outBinding[0], updateOutBinds(i));
         }
         outBinds = updatedOutBinds;
         obj.outBinding = updatedObjOutBinding;
@@ -390,16 +395,16 @@ Client_Oracledb.prototype.processResponse = function(obj, runner) {
     case 'pluck':
     case 'first':
       if (obj.method === 'pluck') {
-        response = _.map(response, obj.pluck);
+        response = map(response, obj.pluck);
       }
       return obj.method === 'first' ? response[0] : response;
     case 'insert':
     case 'del':
     case 'update':
     case 'counter':
-      if (obj.returning && !_.isEmpty(obj.returning)) {
+      if (obj.returning && !isEmpty(obj.returning)) {
         if (obj.returning.length === 1 && obj.returning[0] !== '*') {
-          return _.flatten(_.map(response, _.values));
+          return flatten(map(response, values));
         }
         return response;
       } else if (obj.rowsAffected !== undefined) {

--- a/lib/dialects/oracledb/query/compiler.js
+++ b/lib/dialects/oracledb/query/compiler.js
@@ -27,10 +27,10 @@ class Oracledb_Compiler extends Oracle_Compiler {
     ) {
       return this._addReturningToSqlAndConvert(
         'insert into ' +
-        this.tableName +
-        ' (' +
-        this.formatter.wrap(this.single.returning) +
-        ') values (default)',
+          this.tableName +
+          ' (' +
+          this.formatter.wrap(this.single.returning) +
+          ') values (default)',
         outBinding[0],
         this.tableName,
         returning
@@ -60,12 +60,12 @@ class Oracledb_Compiler extends Oracle_Compiler {
     if (insertData.values.length === 1) {
       return this._addReturningToSqlAndConvert(
         'insert into ' +
-        this.tableName +
-        ' (' +
-        this.formatter.columnize(insertData.columns) +
-        ') values (' +
-        this.formatter.parameterize(insertData.values[0]) +
-        ')',
+          this.tableName +
+          ' (' +
+          this.formatter.columnize(insertData.columns) +
+          ') values (' +
+          this.formatter.parameterize(insertData.values[0]) +
+          ')',
         outBinding[0],
         this.tableName,
         returning
@@ -76,104 +76,106 @@ class Oracledb_Compiler extends Oracle_Compiler {
     sql.returning = returning;
     sql.sql =
       'begin ' +
-      _.map(insertData.values, function (value, index) {
-        const parameterizedValues = !insertDefaultsOnly
-          ? self.formatter.parameterize(value, self.client.valueForUndefined)
-          : '';
-        let subSql = 'insert into ' + self.tableName;
+      insertData.values
+        .map(function(value, index) {
+          const parameterizedValues = !insertDefaultsOnly
+            ? self.formatter.parameterize(value, self.client.valueForUndefined)
+            : '';
+          let subSql = 'insert into ' + self.tableName;
 
-        if (insertDefaultsOnly) {
-          // No columns given so only the default value
-          subSql +=
-            ' (' +
-            self.formatter.wrap(self.single.returning) +
-            ') values (default)';
-        } else {
-          subSql +=
-            ' (' +
-            self.formatter.columnize(insertData.columns) +
-            ') values (' +
-            parameterizedValues +
-            ')';
-        }
-
-        let returningClause = '';
-        let intoClause = '';
-        // ToDo review if this code is still needed or could be dropped
-        // eslint-disable-next-line no-unused-vars
-        let usingClause = '';
-        let outClause = '';
-
-        _.each(value, function (val) {
-          if (!(val instanceof BlobHelper)) {
-            usingClause += ' ?,';
+          if (insertDefaultsOnly) {
+            // No columns given so only the default value
+            subSql +=
+              ' (' +
+              self.formatter.wrap(self.single.returning) +
+              ') values (default)';
+          } else {
+            subSql +=
+              ' (' +
+              self.formatter.columnize(insertData.columns) +
+              ') values (' +
+              parameterizedValues +
+              ')';
           }
-        });
-        usingClause = usingClause.slice(0, -1);
 
-        // Build returning and into clauses
-        _.each(outBinding[index], function (ret) {
-          const columnName = ret.columnName || ret;
-          returningClause += self.formatter.wrap(columnName) + ',';
-          intoClause += ' ?,';
-          outClause += ' out ?,';
+          let returningClause = '';
+          let intoClause = '';
+          // ToDo review if this code is still needed or could be dropped
+          // eslint-disable-next-line no-unused-vars
+          let usingClause = '';
+          let outClause = '';
 
-          // Add Helpers to bindings
-          if (ret instanceof BlobHelper) {
-            return self.formatter.bindings.push(ret);
+          _.each(value, function(val) {
+            if (!(val instanceof BlobHelper)) {
+              usingClause += ' ?,';
+            }
+          });
+          usingClause = usingClause.slice(0, -1);
+
+          // Build returning and into clauses
+          outBinding[index].forEach(function(ret) {
+            const columnName = ret.columnName || ret;
+            returningClause += self.formatter.wrap(columnName) + ',';
+            intoClause += ' ?,';
+            outClause += ' out ?,';
+
+            // Add Helpers to bindings
+            if (ret instanceof BlobHelper) {
+              return self.formatter.bindings.push(ret);
+            }
+            self.formatter.bindings.push(new ReturningHelper(columnName));
+          });
+
+          // Strip last comma
+          returningClause = returningClause.slice(0, -1);
+          intoClause = intoClause.slice(0, -1);
+          outClause = outClause.slice(0, -1);
+
+          if (returningClause && intoClause) {
+            subSql += ' returning ' + returningClause + ' into' + intoClause;
           }
-          self.formatter.bindings.push(new ReturningHelper(columnName));
-        });
 
-        // Strip last comma
-        returningClause = returningClause.slice(0, -1);
-        intoClause = intoClause.slice(0, -1);
-        outClause = outClause.slice(0, -1);
-
-        if (returningClause && intoClause) {
-          subSql += ' returning ' + returningClause + ' into' + intoClause;
-        }
-
-        // Pre bind position because subSql is an execute immediate parameter
-        // later position binding will only convert the ? params
-        subSql = self.formatter.client.positionBindings(subSql);
-        const parameterizedValuesWithoutDefaultAndBlob = parameterizedValues
-          .replace('DEFAULT, ', '')
-          .replace(', DEFAULT', '')
-          .replace('EMPTY_BLOB(), ', '')
-          .replace(', EMPTY_BLOB()', '');
-        return (
-          "execute immediate '" +
-          subSql.replace(/'/g, "''") +
-          (parameterizedValuesWithoutDefaultAndBlob || value
-            ? "' using "
-            : '') +
-          parameterizedValuesWithoutDefaultAndBlob +
-          (parameterizedValuesWithoutDefaultAndBlob && outClause ? ',' : '') +
-          outClause +
-          ';'
-        );
-      }).join(' ') +
+          // Pre bind position because subSql is an execute immediate parameter
+          // later position binding will only convert the ? params
+          subSql = self.formatter.client.positionBindings(subSql);
+          const parameterizedValuesWithoutDefaultAndBlob = parameterizedValues
+            .replace('DEFAULT, ', '')
+            .replace(', DEFAULT', '')
+            .replace('EMPTY_BLOB(), ', '')
+            .replace(', EMPTY_BLOB()', '');
+          return (
+            "execute immediate '" +
+            subSql.replace(/'/g, "''") +
+            (parameterizedValuesWithoutDefaultAndBlob || value
+              ? "' using "
+              : '') +
+            parameterizedValuesWithoutDefaultAndBlob +
+            (parameterizedValuesWithoutDefaultAndBlob && outClause ? ',' : '') +
+            outClause +
+            ';'
+          );
+        })
+        .join(' ') +
       'end;';
 
     sql.outBinding = outBinding;
     if (returning[0] === '*') {
       // Generate select statement with special order by
       // to keep the order because 'in (..)' may change the order
-      sql.returningSql = function () {
+      sql.returningSql = function() {
         return (
           'select * from ' +
           self.tableName +
           ' where ROWID in (' +
           this.outBinding
-            .map(function (v, i) {
+            .map(function(v, i) {
               return ':' + (i + 1);
             })
             .join(', ') +
           ')' +
           ' order by case ROWID ' +
           this.outBinding
-            .map(function (v, i) {
+            .map(function(v, i) {
               return 'when CHARTOROWID(:' + (i + 1) + ') then ' + i;
             })
             .join(' ') +
@@ -185,12 +187,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
     return sql;
   }
 
-  _addReturningToSqlAndConvert(
-    sql,
-    outBinding,
-    tableName,
-    returning
-  ) {
+  _addReturningToSqlAndConvert(sql, outBinding, tableName, returning) {
     const self = this;
     const res = {
       sql: sql,
@@ -205,7 +202,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
     let returningClause = '';
     let intoClause = '';
     // Build returning and into clauses
-    _.each(returningValues, function (ret) {
+    returningValues.forEach(function(ret) {
       const columnName = ret.columnName || ret;
       returningClause += self.formatter.wrap(columnName) + ',';
       intoClause += '?,';
@@ -226,7 +223,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
     }
     res.outBinding = [outBinding];
     if (returning[0] === '*') {
-      res.returningSql = function () {
+      res.returningSql = function() {
         return 'select * from ' + self.tableName + ' where ROWID = :1';
       };
     }
@@ -249,13 +246,13 @@ class Oracledb_Compiler extends Oracle_Compiler {
 
     const outBinding = [];
     // Handle Buffer value as Blob
-    _.each(params, function (values, index) {
+    _.each(params, function(values, index) {
       if (returning[0] === '*') {
         outBinding[index] = ['ROWID'];
       } else {
         outBinding[index] = _.clone(returning);
       }
-      _.each(values, function (value, key) {
+      _.each(values, function(value, key) {
         if (value instanceof Buffer) {
           values[key] = new BlobHelper(key, value);
 
@@ -267,7 +264,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
           }
           outBinding[index].push(values[key]);
         }
-        if (_.isUndefined(value)) {
+        if (value === undefined) {
           delete params[index][key];
         }
       });
@@ -299,8 +296,8 @@ class Oracledb_Compiler extends Oracle_Compiler {
     }
 
     // Build returning and into clauses
-    _.each(outBinding, function (out) {
-      _.each(out, function (ret) {
+    outBinding.forEach(function(out) {
+      out.forEach(function(ret) {
         const columnName = ret.columnName || ret;
         returningClause += self.formatter.wrap(columnName) + ',';
         intoClause += ' ?,';
@@ -328,7 +325,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
       sql.sql += ' returning ' + returningClause + ' into' + intoClause;
     }
     if (returning[0] === '*') {
-      sql.returningSql = function () {
+      sql.returningSql = function() {
         let sql = 'select * from ' + self.tableName;
         const modifiedRowsCount = this.rowsAffected.length || this.rowsAffected;
         let returningSqlIn = ' where ROWID in (';

--- a/lib/dialects/oracledb/query/compiler.js
+++ b/lib/dialects/oracledb/query/compiler.js
@@ -1,4 +1,8 @@
-const _ = require('lodash');
+const clone = require('lodash/clone');
+const each = require('lodash/each');
+const isEmpty = require('lodash/isEmpty');
+const isPlainObject = require('lodash/isPlainObject');
+const isString = require('lodash/isString');
 const Oracle_Compiler = require('../../oracle/query/compiler');
 const ReturningHelper = require('../utils').ReturningHelper;
 const BlobHelper = require('../utils').BlobHelper;
@@ -23,7 +27,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
     if (
       Array.isArray(insertValues) &&
       insertValues.length === 1 &&
-      _.isEmpty(insertValues[0])
+      isEmpty(insertValues[0])
     ) {
       return this._addReturningToSqlAndConvert(
         'insert into ' +
@@ -38,7 +42,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
     }
 
     if (
-      _.isEmpty(this.single.insert) &&
+      isEmpty(this.single.insert) &&
       typeof this.single.insert !== 'function'
     ) {
       return '';
@@ -48,7 +52,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
 
     const sql = {};
 
-    if (_.isString(insertData)) {
+    if (isString(insertData)) {
       return this._addReturningToSqlAndConvert(
         'insert into ' + this.tableName + ' ' + insertData,
         outBinding[0],
@@ -105,7 +109,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
           let usingClause = '';
           let outClause = '';
 
-          _.each(value, function(val) {
+          each(value, function(val) {
             if (!(val instanceof BlobHelper)) {
               usingClause += ' ?,';
             }
@@ -236,7 +240,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
     const result = {};
     let params = paramValues || [];
     let returning = paramReturning || [];
-    if (!Array.isArray(params) && _.isPlainObject(paramValues)) {
+    if (!Array.isArray(params) && isPlainObject(paramValues)) {
       params = [params];
     }
     // Always wrap returning argument in array
@@ -246,13 +250,13 @@ class Oracledb_Compiler extends Oracle_Compiler {
 
     const outBinding = [];
     // Handle Buffer value as Blob
-    _.each(params, function(values, index) {
+    each(params, function(values, index) {
       if (returning[0] === '*') {
         outBinding[index] = ['ROWID'];
       } else {
-        outBinding[index] = _.clone(returning);
+        outBinding[index] = clone(returning);
       }
-      _.each(values, function(value, key) {
+      each(values, function(value, key) {
         if (value instanceof Buffer) {
           values[key] = new BlobHelper(key, value);
 
@@ -291,7 +295,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
     let returningClause = '';
     let intoClause = '';
 
-    if (_.isEmpty(updates) && typeof this.single.update !== 'function') {
+    if (isEmpty(updates) && typeof this.single.update !== 'function') {
       return '';
     }
 
@@ -321,7 +325,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
       ' set ' +
       updates.join(', ') +
       (where ? ' ' + where : '');
-    if (outBinding.length && !_.isEmpty(outBinding[0])) {
+    if (outBinding.length && !isEmpty(outBinding[0])) {
       sql.sql += ' returning ' + returningClause + ' into' + intoClause;
     }
     if (returning[0] === '*') {

--- a/lib/dialects/oracledb/schema/columncompiler.js
+++ b/lib/dialects/oracledb/schema/columncompiler.js
@@ -1,7 +1,7 @@
 const inherits = require('inherits');
 const ColumnCompiler_Oracle = require('../../oracle/schema/columncompiler');
 
-const { isObject } = require('lodash');
+const isObject = require('lodash/isObject');
 
 function ColumnCompiler_Oracledb() {
   ColumnCompiler_Oracle.apply(this, arguments);

--- a/lib/dialects/oracledb/transaction.js
+++ b/lib/dialects/oracledb/transaction.js
@@ -1,5 +1,3 @@
-const { isUndefined } = require('lodash');
-
 const Transaction = require('../../transaction');
 const { timeout, KnexTimeoutError } = require('../../util/timeout');
 const debugTx = require('debug')('knex:tx');
@@ -35,7 +33,7 @@ module.exports = class Oracle_Transaction extends Transaction {
         this._rejecter(e);
       })
       .then(() => {
-        if (isUndefined(err)) {
+        if (err === undefined) {
           if (this.doNotRejectOnRollback) {
             this._resolver();
             return;

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -1,6 +1,8 @@
 // PostgreSQL
 // -------
-const { map, extend, isString } = require('lodash');
+const extend = require('lodash/extend');
+const isString = require('lodash/isString');
+const map = require('lodash/map');
 const { promisify } = require('util');
 const inherits = require('inherits');
 const Client = require('../../client');

--- a/lib/dialects/postgres/query/compiler.js
+++ b/lib/dialects/postgres/query/compiler.js
@@ -2,7 +2,8 @@
 // ------
 const QueryCompiler = require('../../../query/compiler');
 
-const { reduce, identity } = require('lodash');
+const identity = require('lodash/identity');
+const reduce = require('lodash/reduce');
 
 class QueryCompiler_PG extends QueryCompiler {
   constructor(client, builder) {
@@ -16,7 +17,6 @@ class QueryCompiler_PG extends QueryCompiler {
   }
 
   // is used if the an array with multiple empty values supplied
-  
 
   // Compiles an `insert` query, allowing for multiple
   // inserts using a single query statement.

--- a/lib/dialects/postgres/schema/columncompiler.js
+++ b/lib/dialects/postgres/schema/columncompiler.js
@@ -3,7 +3,7 @@
 
 const inherits = require('inherits');
 const ColumnCompiler = require('../../../schema/columncompiler');
-const { isObject } = require('lodash');
+const isObject = require('lodash/isObject');
 
 function ColumnCompiler_PG() {
   ColumnCompiler.apply(this, arguments);

--- a/lib/dialects/postgres/schema/tablecompiler.js
+++ b/lib/dialects/postgres/schema/tablecompiler.js
@@ -6,7 +6,7 @@
 const inherits = require('inherits');
 const TableCompiler = require('../../../schema/tablecompiler');
 
-const { has } = require('lodash');
+const has = require('lodash/has');
 
 function TableCompiler_PG() {
   TableCompiler.apply(this, arguments);

--- a/lib/dialects/redshift/index.js
+++ b/lib/dialects/redshift/index.js
@@ -2,7 +2,7 @@
 // -------
 const inherits = require('inherits');
 const Client_PG = require('../postgres');
-const { map } = require('lodash');
+const map = require('lodash/map');
 
 const Transaction = require('./transaction');
 const QueryCompiler = require('./query/compiler');

--- a/lib/dialects/redshift/query/compiler.js
+++ b/lib/dialects/redshift/query/compiler.js
@@ -3,10 +3,10 @@
 const QueryCompiler = require('../../../query/compiler');
 const QueryCompiler_PG = require('../../postgres/query/compiler');
 
-const { reduce, identity } = require('lodash');
+const identity = require('lodash/identity');
+const reduce = require('lodash/reduce');
 
 class QueryCompiler_Redshift extends QueryCompiler_PG {
-
   constructor(client, builder) {
     super(client, builder);
   }

--- a/lib/dialects/redshift/schema/tablecompiler.js
+++ b/lib/dialects/redshift/schema/tablecompiler.js
@@ -4,7 +4,7 @@
 // -------
 
 const inherits = require('inherits');
-const { has } = require('lodash');
+const has = require('lodash/has');
 const TableCompiler_PG = require('../../postgres/schema/tablecompiler');
 
 function TableCompiler_Redshift() {

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -1,7 +1,7 @@
 // SQLite3
 // -------
 const inherits = require('inherits');
-const { isUndefined, map, defaults } = require('lodash');
+const { map, defaults } = require('lodash');
 const { promisify } = require('util');
 
 const Client = require('../../client');
@@ -15,7 +15,7 @@ const SQLite3_Formatter = require('./formatter');
 
 function Client_SQLite3(config) {
   Client.call(this, config);
-  if (isUndefined(config.useNullAsDefault)) {
+  if (config.useNullAsDefault === undefined) {
     this.logger.warn(
       'sqlite does not support inserting default values. Set the ' +
         '`useNullAsDefault` flag to hide this warning. ' +

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -1,7 +1,8 @@
 // SQLite3
 // -------
 const inherits = require('inherits');
-const { map, defaults } = require('lodash');
+const defaults = require('lodash/defaults');
+const map = require('lodash/map');
 const { promisify } = require('util');
 
 const Client = require('../../client');

--- a/lib/dialects/sqlite3/query/compiler.js
+++ b/lib/dialects/sqlite3/query/compiler.js
@@ -3,14 +3,12 @@
 const QueryCompiler = require('../../../query/compiler');
 
 const noop = require('../../../util/noop');
-const {
-  constant,
-  each,
-  isEmpty,
-  isString,
-  reduce,
-  identity,
-} = require('lodash');
+const constant = require('lodash/constant');
+const each = require('lodash/each');
+const identity = require('lodash/identity');
+const isEmpty = require('lodash/isEmpty');
+const isString = require('lodash/isString');
+const reduce = require('lodash/reduce');
 
 const emptyStr = constant('');
 

--- a/lib/dialects/sqlite3/query/compiler.js
+++ b/lib/dialects/sqlite3/query/compiler.js
@@ -2,12 +2,12 @@
 
 const QueryCompiler = require('../../../query/compiler');
 
+const noop = require('../../../util/noop');
 const {
   constant,
   each,
   isEmpty,
   isString,
-  noop,
   reduce,
   identity,
 } = require('lodash');

--- a/lib/dialects/sqlite3/query/compiler.js
+++ b/lib/dialects/sqlite3/query/compiler.js
@@ -15,7 +15,6 @@ const {
 const emptyStr = constant('');
 
 class QueryCompiler_SQLite3 extends QueryCompiler {
-
   constructor(client, builder) {
     super(client, builder);
 
@@ -67,13 +66,13 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
 
     // backwards compatible error
     if (this.client.valueForUndefined !== null) {
-      each(insertData.values, (bindings) => {
+      insertData.values.forEach((bindings) => {
         each(bindings, (binding) => {
           if (binding === undefined)
             throw new TypeError(
               '`sqlite` does not support inserting default values. Specify ' +
-              'values explicitly or use the `useNullAsDefault` config flag. ' +
-              '(see docs http://knexjs.org/#Builder-insert).'
+                'values explicitly or use the `useNullAsDefault` config flag. ' +
+                '(see docs http://knexjs.org/#Builder-insert).'
             );
         });
       });
@@ -135,7 +134,7 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
         const maxLengthRegex = /.*\((\d+)\)/;
         const out = reduce(
           resp,
-          function (columns, val) {
+          function(columns, val) {
             let { type } = val;
             let maxLength = type.match(maxLengthRegex);
             if (maxLength) {
@@ -168,6 +167,5 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
     )}`;
   }
 }
-
 
 module.exports = QueryCompiler_SQLite3;

--- a/lib/dialects/sqlite3/schema/compiler.js
+++ b/lib/dialects/sqlite3/schema/compiler.js
@@ -3,7 +3,7 @@
 const inherits = require('inherits');
 const SchemaCompiler = require('../../../schema/compiler');
 
-const { some } = require('lodash');
+const some = require('lodash/some');
 
 // Schema Compiler
 // -------

--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -4,18 +4,16 @@
 // columns and changing datatypes.
 // -------
 
-const {
-  assign,
-  uniqueId,
-  find,
-  identity,
-  omit,
-  invert,
-  fromPairs,
-  negate,
-  isEmpty,
-  chunk,
-} = require('lodash');
+const assign = require('lodash/assign');
+const chunk = require('lodash/chunk');
+const find = require('lodash/find');
+const fromPairs = require('lodash/fromPairs');
+const identity = require('lodash/identity');
+const invert = require('lodash/invert');
+const isEmpty = require('lodash/isEmpty');
+const negate = require('lodash/negate');
+const omit = require('lodash/omit');
+const uniqueId = require('lodash/uniqueId');
 
 // So altering the schema in SQLite3 is a major pain.
 // We have our own object to deal with the renaming and altering the types

--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -9,11 +9,9 @@ const {
   uniqueId,
   find,
   identity,
-  map,
   omit,
   invert,
   fromPairs,
-  some,
   negate,
   isEmpty,
   chunk,
@@ -103,7 +101,7 @@ assign(SQLite3_DDL.prototype, {
       await this.trx
         .queryBuilder()
         .table(target)
-        .insert(map(batch, iterator));
+        .insert(batch.map(iterator));
     }
   },
 
@@ -174,7 +172,7 @@ assign(SQLite3_DDL.prototype, {
       }
 
       const doesMatchFromIdentifier = (target) =>
-        some(fromMatchCandidates, (c) => target.match(c));
+        fromMatchCandidates.some((c) => target.match(c));
 
       const replaceFromIdentifier = (target) =>
         fromMatchCandidates.reduce(

--- a/lib/dialects/sqlite3/schema/tablecompiler.js
+++ b/lib/dialects/sqlite3/schema/tablecompiler.js
@@ -1,7 +1,8 @@
 const inherits = require('inherits');
 const TableCompiler = require('../../../schema/tablecompiler');
 
-const { filter, values } = require('lodash');
+const filter = require('lodash/filter');
+const values = require('lodash/values');
 
 // Table Compiler
 // -------

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,6 +1,6 @@
 const QueryBuilder = require('./query/builder');
 const Raw = require('./raw');
-const { transform } = require('lodash');
+const transform = require('lodash/transform');
 
 // Valid values for the `order by` clause generation.
 const orderBys = ['asc', 'desc'];

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,12 +1,6 @@
 /* eslint no-console:0 */
 
-const {
-  isFunction,
-  isUndefined,
-  isPlainObject,
-  isArray,
-  isTypedArray,
-} = require('lodash');
+const { isFunction, isPlainObject, isTypedArray } = require('lodash');
 const { CLIENT_ALIASES } = require('./constants');
 
 // Check if the first argument is an array, otherwise uses all arguments as an
@@ -33,7 +27,7 @@ function containsUndefined(mixed) {
     return argContainsUndefined;
   }
 
-  if (isArray(mixed)) {
+  if (Array.isArray(mixed)) {
     for (let i = 0; i < mixed.length; i++) {
       if (argContainsUndefined) break;
       argContainsUndefined = containsUndefined(mixed[i]);
@@ -45,7 +39,7 @@ function containsUndefined(mixed) {
       }
     });
   } else {
-    argContainsUndefined = isUndefined(mixed);
+    argContainsUndefined = mixed === undefined;
   }
 
   return argContainsUndefined;
@@ -77,7 +71,7 @@ function addQueryContext(Target) {
   // Stores or returns (if called with no arguments) context passed to
   // wrapIdentifier and postProcessResponse hooks
   Target.prototype.queryContext = function(context) {
-    if (isUndefined(context)) {
+    if (context === undefined) {
       return this._queryContext;
     }
     this._queryContext = context;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,8 @@
 /* eslint no-console:0 */
 
-const { isFunction, isPlainObject, isTypedArray } = require('lodash');
+const isFunction = require('lodash/isFunction');
+const isPlainObject = require('lodash/isPlainObject');
+const isTypedArray = require('lodash/isTypedArray');
 const { CLIENT_ALIASES } = require('./constants');
 
 // Check if the first argument is an array, otherwise uses all arguments as an

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -1,4 +1,4 @@
-const { isEmpty, map, clone } = require('lodash');
+const { isEmpty, clone } = require('lodash');
 const { callbackify } = require('util');
 const finallyMixin = require('./util/finally-mixin');
 
@@ -6,9 +6,11 @@ module.exports = function(Target) {
   Target.prototype.toQuery = function(tz) {
     let data = this.toSQL(this._method, tz);
     if (!Array.isArray(data)) data = [data];
-    return map(data, (statement) => {
-      return this.client._formatQuery(statement.sql, statement.bindings, tz);
-    }).join(';\n');
+    return data
+      .map((statement) => {
+        return this.client._formatQuery(statement.sql, statement.bindings, tz);
+      })
+      .join(';\n');
   };
 
   // Create a new instance of the `Runner`, passing in the current object.

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -1,4 +1,5 @@
-const { isEmpty, clone } = require('lodash');
+const clone = require('lodash/clone');
+const isEmpty = require('lodash/isEmpty');
 const { callbackify } = require('util');
 const finallyMixin = require('./util/finally-mixin');
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,7 +2,8 @@
 
 const color = require('colorette');
 const { inspect } = require('util');
-const { isFunction, isString } = require('lodash');
+const isFunction = require('lodash/isFunction');
+const isString = require('lodash/isString');
 
 class Logger {
   constructor(config) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,7 +2,7 @@
 
 const color = require('colorette');
 const { inspect } = require('util');
-const { isFunction, isNil, isString } = require('lodash');
+const { isFunction, isString } = require('lodash');
 
 class Logger {
   constructor(config) {
@@ -25,7 +25,7 @@ class Logger {
   }
 
   _log(message, userFn, colorFn) {
-    if (!isNil(userFn) && !isFunction(userFn)) {
+    if (userFn != null && !isFunction(userFn)) {
       throw new TypeError('Extensions to knex logger must be functions!');
     }
 
@@ -64,7 +64,7 @@ class Logger {
 }
 
 function resolveIsEnabledColors(enableColorsParam) {
-  if (!isNil(enableColorsParam)) {
+  if (enableColorsParam != null) {
     return enableColorsParam;
   }
 

--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -1,13 +1,11 @@
 // Migrator
 // -------
-const {
-  differenceWith,
-  get,
-  isFunction,
-  isBoolean,
-  isEmpty,
-  max,
-} = require('lodash');
+const differenceWith = require('lodash/differenceWith');
+const get = require('lodash/get');
+const isBoolean = require('lodash/isBoolean');
+const isEmpty = require('lodash/isEmpty');
+const isFunction = require('lodash/isFunction');
+const max = require('lodash/max');
 const inherits = require('inherits');
 const {
   getLockTableName,

--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -2,13 +2,10 @@
 // -------
 const {
   differenceWith,
-  each,
-  filter,
   get,
   isFunction,
   isBoolean,
   isEmpty,
-  isUndefined,
   max,
 } = require('lodash');
 const inherits = require('inherits');
@@ -78,14 +75,12 @@ class Migrator {
 
         const transactionForAll =
           !this.config.disableTransactions &&
-          isEmpty(
-            filter(migrations, (migration) => {
-              const migrationContents = this.config.migrationSource.getMigration(
-                migration
-              );
-              return !this._useTransaction(migrationContents);
-            })
-          );
+          !migrations.some((migration) => {
+            const migrationContents = this.config.migrationSource.getMigration(
+              migration
+            );
+            return !this._useTransaction(migrationContents);
+          });
 
         if (transactionForAll) {
           return this.knex.transaction((trx) => {
@@ -141,15 +136,10 @@ class Migrator {
 
         const transactionForAll =
           !this.config.disableTransactions &&
-          isEmpty(
-            filter(migrationsToRun, (migration) => {
-              const migrationContents = this.config.migrationSource.getMigration(
-                migration
-              );
-
-              return !this._useTransaction(migrationContents);
-            })
-          );
+          (!migrationToRun ||
+            this._useTransaction(
+              this.config.migrationSource.getMigration(migrationToRun)
+            ));
 
         if (transactionForAll) {
           return this.knex.transaction((trx) => {
@@ -261,7 +251,7 @@ class Migrator {
       .listCompleted(this.config.tableName, this.config.schemaName, this.knex)
       .then((completed) => {
         const val = max(completed.map((value) => value.split('_')[0]));
-        return isUndefined(val) ? 'none' : val;
+        return val === undefined ? 'none' : val;
       });
   }
 
@@ -487,7 +477,7 @@ class Migrator {
     const { tableName, schemaName, disableTransactions } = this.config;
     let current = Promise.resolve();
     const log = [];
-    each(migrations, (migration) => {
+    migrations.forEach((migration) => {
       const name = this.config.migrationSource.getMigrationName(migration);
       this._activeMigration.fileName = name;
       const migrationContent = this.config.migrationSource.getMigration(

--- a/lib/migrate/sources/fs-migrations.js
+++ b/lib/migrate/sources/fs-migrations.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { sortBy, filter } = require('lodash');
+const { sortBy } = require('lodash');
 
 const { readdir } = require('../../util/fs');
 
@@ -83,7 +83,7 @@ class FsMigrations {
 }
 
 function filterMigrations(migrationSource, migrations, loadExtensions) {
-  return filter(migrations, (migration) => {
+  return migrations.filter((migration) => {
     const migrationName = migrationSource.getMigrationName(migration);
     const extension = path.extname(migrationName);
     return loadExtensions.includes(extension);

--- a/lib/migrate/sources/fs-migrations.js
+++ b/lib/migrate/sources/fs-migrations.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { sortBy } = require('lodash');
+const sortBy = require('lodash/sortBy');
 
 const { readdir } = require('../../util/fs');
 

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -14,15 +14,12 @@ const {
   isBoolean,
   isEmpty,
   isFunction,
-  isNil,
   isNumber,
   isObject,
   isString,
-  isUndefined,
   tail,
   toArray,
   reject,
-  includes,
   last,
   isPlainObject,
 } = require('lodash');
@@ -86,13 +83,13 @@ assign(Builder.prototype, {
     cloned._debug = this._debug;
 
     // `_option` is assigned by the `Interface` mixin.
-    if (!isUndefined(this._options)) {
+    if (this._options !== undefined) {
       cloned._options = clone(this._options);
     }
-    if (!isUndefined(this._queryContext)) {
+    if (this._queryContext !== undefined) {
       cloned._queryContext = clone(this._queryContext);
     }
-    if (!isUndefined(this._connection)) {
+    if (this._connection !== undefined) {
       cloned._connection = this._connection;
     }
 
@@ -870,7 +867,7 @@ assign(Builder.prototype, {
 
   // Only allow a single "offset" to be set for the current query.
   offset(value) {
-    if (isNil(value) || value instanceof Raw || value instanceof Builder) {
+    if (value == null || value instanceof Raw || value instanceof Builder) {
       // Builder for backward compatibility
       this._single.offset = value;
     } else {
@@ -1254,12 +1251,12 @@ assign(Builder.prototype, {
 
   // Helper function that checks if the builder will emit a select query
   _isSelectQuery() {
-    return includes(['pluck', 'first', 'select'], this._method);
+    return ['pluck', 'first', 'select'].includes(this._method);
   },
 
   // Helper function that checks if the query has a lock mode set
   _hasLockMode() {
-    return includes([lockMode.forShare, lockMode.forUpdate], this._single.lock);
+    return [lockMode.forShare, lockMode.forUpdate].includes(this._single.lock);
   },
 });
 

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -7,22 +7,20 @@ const { EventEmitter } = require('events');
 const Raw = require('../raw');
 const helpers = require('../helpers');
 const JoinClause = require('./joinclause');
-const {
-  assign,
-  clone,
-  each,
-  isBoolean,
-  isEmpty,
-  isFunction,
-  isNumber,
-  isObject,
-  isString,
-  tail,
-  toArray,
-  reject,
-  last,
-  isPlainObject,
-} = require('lodash');
+const assign = require('lodash/assign');
+const clone = require('lodash/clone');
+const each = require('lodash/each');
+const isBoolean = require('lodash/isBoolean');
+const isEmpty = require('lodash/isEmpty');
+const isFunction = require('lodash/isFunction');
+const isNumber = require('lodash/isNumber');
+const isObject = require('lodash/isObject');
+const isPlainObject = require('lodash/isPlainObject');
+const isString = require('lodash/isString');
+const last = require('lodash/last');
+const reject = require('lodash/reject');
+const tail = require('lodash/tail');
+const toArray = require('lodash/toArray');
 const saveAsyncStack = require('../util/save-async-stack');
 
 const { lockMode, waitMode } = require('./constants');

--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -6,19 +6,17 @@ const QueryBuilder = require('./builder');
 const JoinClause = require('./joinclause');
 const debug = require('debug');
 
-const {
-  assign,
-  bind,
-  compact,
-  groupBy,
-  isEmpty,
-  isString,
-  isUndefined,
-  map,
-  omitBy,
-  reduce,
-  has,
-} = require('lodash');
+const assign = require('lodash/assign');
+const bind = require('lodash/bind');
+const compact = require('lodash/compact');
+const groupBy = require('lodash/groupBy');
+const has = require('lodash/has');
+const isEmpty = require('lodash/isEmpty');
+const isString = require('lodash/isString');
+const isUndefined = require('lodash/isUndefined');
+const map = require('lodash/map');
+const omitBy = require('lodash/omitBy');
+const reduce = require('lodash/reduce');
 const uuid = require('uuid');
 
 const debugBindings = debug('knex:bindings');

--- a/lib/raw.js
+++ b/lib/raw.js
@@ -5,7 +5,11 @@ const helpers = require('./helpers');
 const { EventEmitter } = require('events');
 const debug = require('debug');
 
-const { assign, reduce, isObject, isPlainObject, isNumber } = require('lodash');
+const assign = require('lodash/assign');
+const isNumber = require('lodash/isNumber');
+const isObject = require('lodash/isObject');
+const isPlainObject = require('lodash/isPlainObject');
+const reduce = require('lodash/reduce');
 const saveAsyncStack = require('./util/save-async-stack');
 const uuid = require('uuid');
 

--- a/lib/raw.js
+++ b/lib/raw.js
@@ -5,14 +5,7 @@ const helpers = require('./helpers');
 const { EventEmitter } = require('events');
 const debug = require('debug');
 
-const {
-  assign,
-  reduce,
-  isPlainObject,
-  isObject,
-  isUndefined,
-  isNumber,
-} = require('lodash');
+const { assign, reduce, isObject, isPlainObject, isNumber } = require('lodash');
 const saveAsyncStack = require('./util/save-async-stack');
 const uuid = require('uuid');
 
@@ -39,7 +32,7 @@ assign(Raw.prototype, {
   set(sql, bindings) {
     this.sql = sql;
     this.bindings =
-      (isObject(bindings) && !bindings.toSQL) || isUndefined(bindings)
+      (isObject(bindings) && !bindings.toSQL) || bindings === undefined
         ? bindings
         : [bindings];
 
@@ -82,7 +75,7 @@ assign(Raw.prototype, {
       obj = {
         method: 'raw',
         sql: this.sql,
-        bindings: isUndefined(this.bindings) ? [] : [this.bindings],
+        bindings: this.bindings === undefined ? [] : [this.bindings],
       };
     }
 

--- a/lib/schema/builder.js
+++ b/lib/schema/builder.js
@@ -1,6 +1,6 @@
 const inherits = require('inherits');
 const { EventEmitter } = require('events');
-const { each, toArray } = require('lodash');
+const { toArray } = require('lodash');
 const { addQueryContext } = require('../helpers');
 const saveAsyncStack = require('../util/save-async-stack');
 
@@ -22,49 +22,46 @@ inherits(SchemaBuilder, EventEmitter);
 
 // Each of the schema builder methods just add to the
 // "_sequence" array for consistency.
-each(
-  [
-    'createTable',
-    'createTableIfNotExists',
-    'createSchema',
-    'createSchemaIfNotExists',
-    'dropSchema',
-    'dropSchemaIfExists',
-    'createExtension',
-    'createExtensionIfNotExists',
-    'dropExtension',
-    'dropExtensionIfExists',
-    'table',
-    'alterTable',
-    'hasTable',
-    'hasColumn',
-    'dropTable',
-    'renameTable',
-    'dropTableIfExists',
-    'raw',
-  ],
-  function(method) {
-    SchemaBuilder.prototype[method] = function() {
-      if (method === 'createTableIfNotExists') {
-        this.client.logger.warn(
-          [
-            'Use async .hasTable to check if table exists and then use plain .createTable. Since ',
-            '.createTableIfNotExists actually just generates plain "CREATE TABLE IF NOT EXIST..." ',
-            'query it will not work correctly if there are any alter table queries generated for ',
-            'columns afterwards. To not break old migrations this function is left untouched for now',
-            ', but it should not be used when writing new code and it is removed from documentation.',
-          ].join('')
-        );
-      }
-      if (method === 'table') method = 'alterTable';
-      this._sequence.push({
-        method,
-        args: toArray(arguments),
-      });
-      return this;
-    };
-  }
-);
+[
+  'createTable',
+  'createTableIfNotExists',
+  'createSchema',
+  'createSchemaIfNotExists',
+  'dropSchema',
+  'dropSchemaIfExists',
+  'createExtension',
+  'createExtensionIfNotExists',
+  'dropExtension',
+  'dropExtensionIfExists',
+  'table',
+  'alterTable',
+  'hasTable',
+  'hasColumn',
+  'dropTable',
+  'renameTable',
+  'dropTableIfExists',
+  'raw',
+].forEach(function(method) {
+  SchemaBuilder.prototype[method] = function() {
+    if (method === 'createTableIfNotExists') {
+      this.client.logger.warn(
+        [
+          'Use async .hasTable to check if table exists and then use plain .createTable. Since ',
+          '.createTableIfNotExists actually just generates plain "CREATE TABLE IF NOT EXIST..." ',
+          'query it will not work correctly if there are any alter table queries generated for ',
+          'columns afterwards. To not break old migrations this function is left untouched for now',
+          ', but it should not be used when writing new code and it is removed from documentation.',
+        ].join('')
+      );
+    }
+    if (method === 'table') method = 'alterTable';
+    this._sequence.push({
+      method,
+      args: toArray(arguments),
+    });
+    return this;
+  };
+});
 
 require('../interface')(SchemaBuilder);
 addQueryContext(SchemaBuilder);

--- a/lib/schema/builder.js
+++ b/lib/schema/builder.js
@@ -1,6 +1,6 @@
 const inherits = require('inherits');
 const { EventEmitter } = require('events');
-const { toArray } = require('lodash');
+const toArray = require('lodash/toArray');
 const { addQueryContext } = require('../helpers');
 const saveAsyncStack = require('../util/save-async-stack');
 

--- a/lib/schema/columnbuilder.js
+++ b/lib/schema/columnbuilder.js
@@ -1,4 +1,4 @@
-const { extend, each, toArray } = require('lodash');
+const { extend, toArray } = require('lodash');
 const { addQueryContext } = require('../helpers');
 
 // The chainable interface off the original "column" method.
@@ -40,7 +40,7 @@ const aliasMethod = {
 
 // If we call any of the modifiers (index or otherwise) on the chainable, we pretend
 // as though we're calling `table.method(column)` directly.
-each(modifiers, function(method) {
+modifiers.forEach(function(method) {
   const key = aliasMethod[method] || method;
   ColumnBuilder.prototype[method] = function() {
     this._modifiers[key] = toArray(arguments);
@@ -54,7 +54,7 @@ ColumnBuilder.prototype.notNull = ColumnBuilder.prototype.notNullable = function
   return this.nullable(false);
 };
 
-each(['index', 'primary', 'unique'], function(method) {
+['index', 'primary', 'unique'].forEach(function(method) {
   ColumnBuilder.prototype[method] = function() {
     if (this._type.toLowerCase().indexOf('increments') === -1) {
       this._tableBuilder[method].apply(

--- a/lib/schema/columnbuilder.js
+++ b/lib/schema/columnbuilder.js
@@ -1,4 +1,5 @@
-const { extend, toArray } = require('lodash');
+const extend = require('lodash/extend');
+const toArray = require('lodash/toArray');
 const { addQueryContext } = require('../helpers');
 
 // The chainable interface off the original "column" method.

--- a/lib/schema/columncompiler.js
+++ b/lib/schema/columncompiler.js
@@ -4,7 +4,11 @@
 // -------
 const Raw = require('../raw');
 const helpers = require('./helpers');
-const { groupBy, first, tail, has, isObject } = require('lodash');
+const groupBy = require('lodash/groupBy');
+const first = require('lodash/first');
+const has = require('lodash/has');
+const isObject = require('lodash/isObject');
+const tail = require('lodash/tail');
 
 function ColumnCompiler(client, tableCompiler, columnBuilder) {
   this.client = client;

--- a/lib/schema/compiler.js
+++ b/lib/schema/compiler.js
@@ -1,7 +1,5 @@
 const { pushQuery, pushAdditional, unshiftQuery } = require('./helpers');
 
-const { isUndefined } = require('lodash');
-
 // The "SchemaCompiler" takes all of the query statements which have been
 // gathered in the "SchemaBuilder" and turns them into an array of
 // properly formatted / bound query strings.
@@ -83,7 +81,7 @@ function buildTable(type) {
 
     // pass queryContext down to tableBuilder but do not overwrite it if already set
     const queryContext = this.builder.queryContext();
-    if (!isUndefined(queryContext) && isUndefined(builder.queryContext())) {
+    if (queryContext !== undefined && builder.queryContext() === undefined) {
       builder.queryContext(queryContext);
     }
 

--- a/lib/schema/helpers.js
+++ b/lib/schema/helpers.js
@@ -1,4 +1,5 @@
-const { isString, tail } = require('lodash');
+const isString = require('lodash/isString');
+const tail = require('lodash/tail');
 
 // Push a new query onto the compiled "sequence" stack,
 // creating a new formatter, returning the compiler.

--- a/lib/schema/tablebuilder.js
+++ b/lib/schema/tablebuilder.js
@@ -74,7 +74,7 @@ const specialMethods = {
   postgresql: ['inherits'],
 };
 each(specialMethods, function(methods, dialect) {
-  each(methods, function(method) {
+  methods.forEach(function(method) {
     TableBuilder.prototype[method] = function(value) {
       if (this.client.dialect !== dialect) {
         throw new Error(

--- a/lib/schema/tablebuilder.js
+++ b/lib/schema/tablebuilder.js
@@ -6,7 +6,11 @@
 // method, pushing everything we want to do onto the "allStatements" array,
 // which is then compiled into sql.
 // ------
-const { extend, each, toArray, isString, isFunction } = require('lodash');
+const each = require('lodash/each');
+const extend = require('lodash/extend');
+const isFunction = require('lodash/isFunction');
+const isString = require('lodash/isString');
+const toArray = require('lodash/toArray');
 const helpers = require('../helpers');
 
 function TableBuilder(client, method, tableName, fn) {

--- a/lib/schema/tablecompiler.js
+++ b/lib/schema/tablecompiler.js
@@ -4,17 +4,7 @@
 // -------
 const { pushAdditional, pushQuery, unshiftQuery } = require('./helpers');
 const helpers = require('../helpers');
-const {
-  groupBy,
-  reduce,
-  map,
-  first,
-  tail,
-  isEmpty,
-  indexOf,
-  isArray,
-  isUndefined,
-} = require('lodash');
+const { groupBy, tail, isEmpty, indexOf } = require('lodash');
 
 function TableCompiler(client, tableBuilder) {
   this.client = client;
@@ -139,9 +129,9 @@ TableCompiler.prototype.foreign = function(foreignData) {
 
 // Get all of the column sql & bindings individually for building the table queries.
 TableCompiler.prototype.getColumnTypes = (columns) =>
-  reduce(
-    map(columns, first),
-    function(memo, column) {
+  columns.reduce(
+    function(memo, columnSQL) {
+      const column = columnSQL[0];
       memo.sql.push(column.sql);
       memo.bindings.concat(column.bindings);
       return memo;
@@ -151,14 +141,11 @@ TableCompiler.prototype.getColumnTypes = (columns) =>
 
 // Adds all of the additional queries from the "column"
 TableCompiler.prototype.columnQueries = function(columns) {
-  const queries = reduce(
-    map(columns, tail),
-    function(memo, column) {
-      if (!isEmpty(column)) return memo.concat(column);
-      return memo;
-    },
-    []
-  );
+  const queries = columns.reduce(function(memo, columnSQL) {
+    const column = tail(columnSQL);
+    if (!isEmpty(column)) return memo.concat(column);
+    return memo;
+  }, []);
   for (const q of queries) {
     this.pushQuery(q);
   }
@@ -172,7 +159,7 @@ TableCompiler.prototype.addColumns = function(columns, prefix) {
   prefix = prefix || this.addColumnsPrefix;
 
   if (columns.sql.length > 0) {
-    const columnSql = map(columns.sql, (column) => {
+    const columnSql = columns.sql.map((column) => {
       return prefix + column;
     });
     this.pushQuery({
@@ -207,8 +194,8 @@ TableCompiler.prototype.getColumns = function(method) {
     .map((column) => {
       // pass queryContext down to columnBuilder but do not overwrite it if already set
       if (
-        !isUndefined(queryContext) &&
-        isUndefined(column.builder.queryContext())
+        queryContext !== undefined &&
+        column.builder.queryContext() === undefined
       ) {
         column.builder.queryContext(queryContext);
       }
@@ -276,7 +263,7 @@ TableCompiler.prototype.dropUnique = TableCompiler.prototype.dropForeign = funct
 TableCompiler.prototype.dropColumnPrefix = 'drop column ';
 TableCompiler.prototype.dropColumn = function() {
   const columns = helpers.normalizeArr.apply(null, arguments);
-  const drops = map(isArray(columns) ? columns : [columns], (column) => {
+  const drops = (Array.isArray(columns) ? columns : [columns]).map((column) => {
     return this.dropColumnPrefix + this.formatter.wrap(column);
   });
   this.pushQuery(
@@ -291,7 +278,7 @@ TableCompiler.prototype.dropColumn = function() {
 // convention of the table name, followed by the columns, followed by an
 // index type, such as primary or index, which makes the index unique.
 TableCompiler.prototype._indexCommand = function(type, tableName, columns) {
-  if (!isArray(columns)) columns = columns ? [columns] : [];
+  if (!Array.isArray(columns)) columns = columns ? [columns] : [];
   const table = tableName.replace(/\.|-/g, '_');
   const indexName = (
     table +

--- a/lib/schema/tablecompiler.js
+++ b/lib/schema/tablecompiler.js
@@ -4,7 +4,10 @@
 // -------
 const { pushAdditional, pushQuery, unshiftQuery } = require('./helpers');
 const helpers = require('../helpers');
-const { groupBy, tail, isEmpty, indexOf } = require('lodash');
+const groupBy = require('lodash/groupBy');
+const indexOf = require('lodash/indexOf');
+const isEmpty = require('lodash/isEmpty');
+const tail = require('lodash/tail');
 
 function TableCompiler(client, tableBuilder) {
   this.client = client;

--- a/lib/seed/Seeder.js
+++ b/lib/seed/Seeder.js
@@ -2,7 +2,7 @@
 // -------
 
 const path = require('path');
-const { filter, includes, extend } = require('lodash');
+const { includes, extend } = require('lodash');
 const { readdir, ensureDirectoryExists } = require('../util/fs');
 const { writeJsFileUsingTemplate } = require('../util/template');
 
@@ -41,10 +41,12 @@ class Seeder {
     this.config = this.setConfig(config);
     const loadExtensions = this.config.loadExtensions;
     return readdir(this._absoluteConfigDir()).then((seeds) =>
-      filter(seeds, (value) => {
-        const extension = path.extname(value);
-        return includes(loadExtensions, extension);
-      }).sort()
+      seeds
+        .filter((value) => {
+          const extension = path.extname(value);
+          return includes(loadExtensions, extension);
+        })
+        .sort()
     );
   }
 

--- a/lib/seed/Seeder.js
+++ b/lib/seed/Seeder.js
@@ -2,7 +2,8 @@
 // -------
 
 const path = require('path');
-const { includes, extend } = require('lodash');
+const extend = require('lodash/extend');
+const includes = require('lodash/includes');
 const { readdir, ensureDirectoryExists } = require('../util/fs');
 const { writeJsFileUsingTemplate } = require('../util/template');
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -10,7 +10,7 @@ const finallyMixin = require('./util/finally-mixin');
 
 const debug = Debug('knex:tx');
 
-const { uniqueId } = require('lodash');
+const uniqueId = require('lodash/uniqueId');
 
 // FYI: This is defined as a function instead of a constant so that
 //      each Transactor can have its own copy of the default config.

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -10,7 +10,7 @@ const finallyMixin = require('./util/finally-mixin');
 
 const debug = Debug('knex:tx');
 
-const { uniqueId, isUndefined } = require('lodash');
+const { uniqueId } = require('lodash');
 
 // FYI: This is defined as a function instead of a constant so that
 //      each Transactor can have its own copy of the default config.
@@ -131,7 +131,7 @@ class Transaction extends EventEmitter {
           this._resolver(value);
         }
         if (status === 2) {
-          if (isUndefined(value)) {
+          if (value === undefined) {
             if (this.doNotRejectOnRollback && /^ROLLBACK\b/i.test(sql)) {
               this._resolver();
               return;
@@ -259,7 +259,7 @@ function makeTransactor(trx, connection, trxClient) {
   transactor.context.transaction = function(container, options) {
     if (!options) {
       options = { doNotRejectOnRollback: true };
-    } else if (isUndefined(options.doNotRejectOnRollback)) {
+    } else if (options.doNotRejectOnRollback === undefined) {
       options.doNotRejectOnRollback = true;
     }
 

--- a/lib/util/batchInsert.js
+++ b/lib/util/batchInsert.js
@@ -1,4 +1,6 @@
-const { isNumber, chunk, flatten } = require('lodash');
+const chunk = require('lodash/chunk');
+const flatten = require('lodash/flatten');
+const isNumber = require('lodash/isNumber');
 const delay = require('./delay');
 
 module.exports = function batchInsert(

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -4,7 +4,7 @@ const { Migrator } = require('../migrate/Migrator');
 const Seeder = require('../seed/Seeder');
 const FunctionHelper = require('../functionhelper');
 const QueryInterface = require('../query/methods');
-const { merge } = require('lodash');
+const merge = require('lodash/merge');
 const batchInsert = require('./batchInsert');
 
 // Javascript does not officially support "callable objects".  Instead,

--- a/lib/util/make-knex.js
+++ b/lib/util/make-knex.js
@@ -4,7 +4,7 @@ const { Migrator } = require('../migrate/Migrator');
 const Seeder = require('../seed/Seeder');
 const FunctionHelper = require('../functionhelper');
 const QueryInterface = require('../query/methods');
-const { merge, isUndefined } = require('lodash');
+const { merge } = require('lodash');
 const batchInsert = require('./batchInsert');
 
 // Javascript does not officially support "callable objects".  Instead,
@@ -125,7 +125,7 @@ function initContext(knexFn) {
     transaction(container, _config) {
       const config = Object.assign({}, _config);
       config.userParams = this.userParams || {};
-      if (isUndefined(config.doNotRejectOnRollback)) {
+      if (config.doNotRejectOnRollback === undefined) {
         // Backwards-compatibility: default value changes depending upon
         // whether or not a `container` was provided.
         config.doNotRejectOnRollback = !container;

--- a/lib/util/template.js
+++ b/lib/util/template.js
@@ -1,4 +1,4 @@
-const { template } = require('lodash');
+const template = require('lodash/template');
 
 const { readFile, writeFile } = require('./fs');
 


### PR DESCRIPTION
When rolling up the current master plus pg, the resulting bundle is 961KB, of which more than half consists of just lodash. This PR removes unnecessary usage of lodash and changes the remaining requires so that only the necessary parts are loaded. The size of the same bundle is down 660KB, so roughly half of lodash is left out.