### PR TITLE
#3807: Fix inference of generated seed/migration extension from knexfile extension

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -27,12 +27,6 @@ async function openKnexfile(configPath) {
   if (typeof config === 'function') {
     config = await config();
   }
-
-  // FYI: By default, the extension for the migration files is inferred
-  //      from the knexfile's extension. So, the following lines are in
-  //      place for backwards compatibility purposes.
-  config.ext = config.ext || path.extname(configPath).replace('.', '');
-
   return config;
 }
 
@@ -55,7 +49,7 @@ async function initKnex(env, opts) {
     ? await openKnexfile(env.configPath)
     : mkConfigObj(opts);
 
-  const resolvedConfig = resolveEnvironmentConfig(opts, env.configuration);
+  const resolvedConfig = resolveEnvironmentConfig(opts, env.configuration, env.configPath);
   const knex = require(env.modulePath);
   return knex(resolvedConfig);
 }
@@ -240,7 +234,6 @@ function invoke(env) {
           if (log.length === 0) {
             success(color.cyan('Already at the base migration'));
           }
-
           success(
             color.green(
               `Batch ${batchNo} rolled back the following migrations:\n${log.join(

--- a/bin/utils/cli-config-utils.js
+++ b/bin/utils/cli-config-utils.js
@@ -30,7 +30,7 @@ function mkConfigObj(opts) {
   };
 }
 
-function resolveEnvironmentConfig(opts, allConfigs) {
+function resolveEnvironmentConfig(opts, allConfigs, configFilePath) {
   const environment = opts.env || process.env.NODE_ENV || 'development';
   const result = allConfigs[environment] || allConfigs;
 
@@ -45,6 +45,12 @@ function resolveEnvironmentConfig(opts, allConfigs) {
 
   if (argv.debug !== undefined) {
     result.debug = argv.debug;
+  }
+
+  // It is safe to assume that unless explicitly specified, we would want
+  // migrations, seeds etc. to be generated with same extension
+  if (configFilePath) {
+    result.ext = result.ext || path.extname(configFilePath).replace('.', '');
   }
 
   return result;
@@ -77,7 +83,7 @@ function checkLocalModule(env) {
 }
 
 function getMigrationExtension(env, opts) {
-  const config = resolveEnvironmentConfig(opts, env.configuration);
+  const config = resolveEnvironmentConfig(opts, env.configuration, env.configPath);
 
   let ext = DEFAULT_EXT;
   if (argv.x) {
@@ -91,7 +97,7 @@ function getMigrationExtension(env, opts) {
 }
 
 function getSeedExtension(env, opts) {
-  const config = resolveEnvironmentConfig(opts, env.configuration);
+  const config = resolveEnvironmentConfig(opts, env.configuration, env.configPath);
 
   let ext = DEFAULT_EXT;
   if (argv.x) {

--- a/test/cli/migrate-make.spec.js
+++ b/test/cli/migrate-make.spec.js
@@ -138,10 +138,11 @@ module.exports = {
 
     it('Create new migration with default ts knexfile', async () => {
       fileHelper.registerGlobForCleanup(
-        'test/jake-util/knexfile_migrations/*_somename.ts'
+        'test/jake-util/knexfile_migrations/*_somename1.ts'
       );
+      const filePath = path.join(process.cwd(), '/knexfile.ts');
       fileHelper.createFile(
-        process.cwd() + '/knexfile.ts',
+        filePath,
         `
 module.exports = {
   client: 'sqlite3',
@@ -156,14 +157,49 @@ module.exports = {
         { isPathAbsolute: true }
       );
       await execCommand(
-        `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
+        `node ${KNEX} migrate:make somename1 --knexpath=../knex.js`,
         {
           expectedOutput: 'Created Migration',
         }
       );
 
       const fileCount = fileHelper.fileGlobExists(
-        'test/jake-util/knexfile_migrations/*_somename.ts'
+        'test/jake-util/knexfile_migrations/*_somename1.ts'
+      );
+      expect(fileCount).to.equal(1);
+    });
+
+    it('Create new migration with default ts knexfile when knexfile has per-env configurations', async () => {
+      fileHelper.registerGlobForCleanup(
+        'test/jake-util/knexfile_migrations/*_somename2.ts'
+      );
+      const filePath = path.join(process.cwd(), '/knexfile.ts');
+      fileHelper.createFile(
+        filePath,
+        `
+module.exports = {
+  development: {
+    client: 'sqlite3',
+    connection: {
+      filename: __dirname + '/test/jake-util/test.sqlite3',
+    },
+    migrations: {
+      directory: __dirname + '/test/jake-util/knexfile_migrations',
+    }
+  }
+};    
+    `,
+        { isPathAbsolute: true }
+      );
+      await execCommand(
+        `node ${KNEX} migrate:make somename2 --knexpath=../knex.js`,
+        {
+          expectedOutput: 'Created Migration',
+        }
+      );
+
+      const fileCount = fileHelper.fileGlobExists(
+        'test/jake-util/knexfile_migrations/*_somename2.ts'
       );
       expect(fileCount).to.equal(1);
     });


### PR DESCRIPTION
Current implementation doesn't work when knexfile has multiple env-specific configuration sections.
