### PR TITLE
Add migrate:unlock command, truncate on forceFreeMigrationsLock

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -58,7 +58,6 @@ function invoke(env) {
   env.modulePath = env.modulePath || env.knexpath || process.env.KNEX_PATH;
 
   const filetypes = ['js', 'coffee', 'ts', 'eg', 'ls'];
-  let pending = null;
 
   const cliVersion = [
     color.blue('Knex CLI version:'),
@@ -110,7 +109,7 @@ function invoke(env) {
       }
       checkLocalModule(env);
       const stubPath = `./knexfile.${type}`;
-      pending = readFile(
+      readFile(
         path.dirname(env.modulePath) +
           '/lib/migrate/stub/knexfile-' +
           type +
@@ -148,7 +147,7 @@ function invoke(env) {
         configOverrides.stub = stub;
       }
 
-      pending = instance.migrate
+      instance.migrate
         .make(name, configOverrides)
         .then((name) => {
           success(color.green(`Created Migration: ${name}`));
@@ -161,7 +160,7 @@ function invoke(env) {
     .description('        Run all migrations that have not yet been run.')
     .option('--verbose', 'verbose')
     .action(() => {
-      pending = initKnex(env, commander.opts())
+      initKnex(env, commander.opts())
         .then((instance) => instance.migrate.latest())
         .then(([batchNo, log]) => {
           if (log.length === 0) {
@@ -181,7 +180,7 @@ function invoke(env) {
       '        Run the next or the specified migration that has not yet been run.'
     )
     .action((name) => {
-      pending = initKnex(env, commander.opts())
+      initKnex(env, commander.opts())
         .then((instance) => instance.migrate.up({ name }))
         .then(([batchNo, log]) => {
           if (log.length === 0) {
@@ -207,7 +206,7 @@ function invoke(env) {
     .action((cmd) => {
       const { all } = cmd;
 
-      pending = initKnex(env, commander.opts())
+      initKnex(env, commander.opts())
         .then((instance) => instance.migrate.rollback(null, all))
         .then(([batchNo, log]) => {
           if (log.length === 0) {
@@ -228,7 +227,7 @@ function invoke(env) {
       '        Undo the last or the specified migration that was already run.'
     )
     .action((name) => {
-      pending = initKnex(env, commander.opts())
+      initKnex(env, commander.opts())
         .then((instance) => instance.migrate.down({ name }))
         .then(([batchNo, log]) => {
           if (log.length === 0) {
@@ -249,7 +248,7 @@ function invoke(env) {
     .command('migrate:currentVersion')
     .description('        View the current version for the migration.')
     .action(() => {
-      pending = initKnex(env, commander.opts())
+      initKnex(env, commander.opts())
         .then((instance) => instance.migrate.currentVersion())
         .then((version) => {
           success(color.green('Current Version: ') + color.blue(version));
@@ -262,7 +261,7 @@ function invoke(env) {
     .alias('migrate:status')
     .description('        List all migrations files with status.')
     .action(() => {
-      pending = initKnex(env, commander.opts())
+      initKnex(env, commander.opts())
         .then((instance) => {
           return instance.migrate.list();
         })
@@ -278,8 +277,8 @@ function invoke(env) {
       '        Forcibly unlocks the migrations lock table.'
     )
     .action(() => {
-      pending = initKnex(env, commander.opts())
-        .migrate.forceFreeMigrationsLock()
+      initKnex(env, commander.opts())
+        .then((instance) => instance.migrate.forceFreeMigrationsLock())
         .then(() => {
           success(
             color.green(
@@ -312,7 +311,7 @@ function invoke(env) {
         configOverrides.stub = stub;
       }
 
-      pending = instance.seed
+      instance.seed
         .make(name, configOverrides)
         .then((name) => {
           success(color.green(`Created seed file: ${name}`));
@@ -326,7 +325,7 @@ function invoke(env) {
     .option('--verbose', 'verbose')
     .option('--specific', 'run specific seed file')
     .action(() => {
-      pending = initKnex(env, commander.opts())
+      initKnex(env, commander.opts())
         .then((instance) => instance.seed.run({ specific: argv.specific }))
         .then(([log]) => {
           if (log.length === 0) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -273,6 +273,24 @@ function invoke(env) {
     });
 
   commander
+    .command('migrate:unlock')
+    .description(
+      '        Forcibly unlocks the migrations lock table.'
+    )
+    .action(() => {
+      pending = initKnex(env, commander.opts())
+        .migrate.forceFreeMigrationsLock()
+        .then(() => {
+          success(
+            color.green(
+              `Succesfully unlocked the migrations lock table`
+            )
+          );
+        })
+        .catch(exit);
+    });
+
+  commander
     .command('seed:make <name>')
     .description('        Create a named seed file.')
     .option(

--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -9,7 +9,6 @@ const max = require('lodash/max');
 const inherits = require('inherits');
 const {
   getLockTableName,
-  getLockTableNameWithSchema,
   getTable,
   getTableName,
 } = require('./table-resolver');

--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -278,10 +278,18 @@ class Migrator {
   forceFreeMigrationsLock(config) {
     this.config = getMergedConfig(config, this.config);
 
-    const lockTable = getLockTableName(this.config.tableName);
+    const lockTableName = getLockTableName(this.config.tableName);
+
     return getSchemaBuilder(this.knex, this.config.schemaName)
       .hasTable(lockTable)
-      .then((exist) => exist && this._freeLock());
+      .then((exist) => {
+        if (exist) {
+          await getTable(this.knex, lockTableName, this.config.schemaName).del();
+          await getTable(this.knex, lockTableName, this.config.schemaName).insert({
+            is_locked: 0,
+          });
+        }
+      });
   }
 
   // Creates a new migration, with a given name.

--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -384,12 +384,7 @@ class Migrator {
             );
             this.knex.client.logger.warn(
               'If you are sure migrations are not running you can release the ' +
-                'lock manually by deleting all the rows = require(migrations lock ' +
-                'table: ' +
-                getLockTableNameWithSchema(
-                  this.config.tableName,
-                  this.config.schemaName
-                )
+                'lock manually by running \'knex migrate:unlock\''
             );
           } else {
             if (this._activeMigration.fileName) {

--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -275,21 +275,22 @@ class Migrator {
     return [completed, newMigrations];
   }
 
-  forceFreeMigrationsLock(config) {
+  async forceFreeMigrationsLock(config) {
     this.config = getMergedConfig(config, this.config);
-
-    const lockTableName = getLockTableName(this.config.tableName);
-
-    return getSchemaBuilder(this.knex, this.config.schemaName)
-      .hasTable(lockTable)
-      .then((exist) => {
-        if (exist) {
-          await getTable(this.knex, lockTableName, this.config.schemaName).del();
-          await getTable(this.knex, lockTableName, this.config.schemaName).insert({
-            is_locked: 0,
-          });
-        }
+    const {
+      schemaName,
+      tableName,
+    } = this.config;
+    const lockTableName = getLockTableName(tableName);
+    const { knex } = this;
+    const getLockTable = () => getTable(knex, lockTableName, schemaName);
+    const tableExists = await getSchemaBuilder(knex, schemaName).hasTable(lockTableName);
+    if (tableExists) {
+      await getLockTable().del();
+      await getLockTable().insert({
+        is_locked: 0,
       });
+    }
   }
 
   // Creates a new migration, with a given name.

--- a/test/cli/migrate-unlock.spec.js
+++ b/test/cli/migrate-unlock.spec.js
@@ -8,39 +8,54 @@ const { getRootDir } = require('./cli-test-utils');
 const KNEX = path.normalize(__dirname + '/../../bin/cli.js');
 
 describe('migrate:unlock', () => {
-    before(() => {
-        process.env.KNEX_PATH = '../knex.js';
-    });
 
     const rootDir = getRootDir();
     const dbPath = path.resolve(rootDir, 'db');
+    let db;
 
-    it('should restore lock table to one row with is_locked=0', async () => {
-        
-        const db = await new sqlite3.Database(dbPath);
+    before(async () => {
+        process.env.KNEX_PATH = '../knex.js';
+        db = await new sqlite3.Database(dbPath);
+    });
+
+    after(async () => {
+        db.close();
+    });
+
+    async function verifyMigrationsUnlocked() {
+        const rows = await new Promise((resolve, reject) => {
+            db.all('SELECT * FROM knex_migrations_lock', {}, (err, rows) => {
+                err ? reject(err) : resolve(rows);
+            });
+        });
+        expect(rows.length).to.equal(1);
+        expect(rows[0].is_locked).to.equal(0);
+    }
+
+    function runUnlockCommand() {
+        return execCommand(`node ${KNEX} migrate:unlock \
+            --client=sqlite3 --connection=${dbPath} \
+            --migrations-directory=${rootDir}/migrations test_unlock`);
+    }
+
+    it('should create row in lock table if none exists', async () => {
+        // Purge the lock table to ensure none exists
+        await new Promise((resolve, reject) => {
+            db.run('DELETE FROM knex_migrations_lock', (err) => err ? reject(err) : resolve());
+        });
+        await runUnlockCommand();
+        await verifyMigrationsUnlocked();
+    });
+
+    it('should restore lock table to one row with is_locked=0 if multiple rows exist', async () => {
         // Seed multiple rows into the lock table
         await new Promise((resolve, reject) => {
             db.run('INSERT INTO knex_migrations_lock(is_locked) VALUES (?),(?),(?)', [1, 0, 1], (err) => {
                 err ? reject(err) : resolve();
             });
         });
-        await execCommand(`node ${KNEX} migrate:unlock \
-            --client=sqlite3 --connection=${dbPath} \
-            --migrations-directory=${rootDir}/migrations \
-            create_rule_table`);
-
-        const rows = await new Promise((resolve, reject) => {
-            db.all('SELECT * FROM knex_migrations_lock', {}, (err, rows) => {
-                if (err) {
-                    reject(err);
-                }
-                resolve(rows);
-            });
-        });
-        expect(rows.length).to.equal(1);
-        expect(rows[0].is_locked).to.equal(0);
-        db.close();
-
+        await runUnlockCommand();
+        await verifyMigrationsUnlocked();
     });
 
 });

--- a/test/cli/migrate-unlock.spec.js
+++ b/test/cli/migrate-unlock.spec.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const path = require('path');
+const sqlite3 = require('sqlite3');
+const { expect } = require('chai');
+const { execCommand } = require('cli-testlab');
+const { getRootDir } = require('./cli-test-utils');
+const KNEX = path.normalize(__dirname + '/../../bin/cli.js');
+
+describe('migrate:unlock', () => {
+    before(() => {
+        process.env.KNEX_PATH = '../knex.js';
+    });
+
+    const rootDir = getRootDir();
+    const dbPath = path.resolve(rootDir, 'db');
+
+    it('should restore lock table to one row with is_locked=0', async () => {
+        
+        const db = await new sqlite3.Database(dbPath);
+        // Seed multiple rows into the lock table
+        await new Promise((resolve, reject) => {
+            db.run('INSERT INTO knex_migrations_lock(is_locked) VALUES (?),(?),(?)', [1, 0, 1], (err) => {
+                err ? reject(err) : resolve();
+            });
+        });
+        await execCommand(`node ${KNEX} migrate:unlock \
+            --client=sqlite3 --connection=${dbPath} \
+            --migrations-directory=${rootDir}/migrations \
+            create_rule_table`);
+
+        const rows = await new Promise((resolve, reject) => {
+            db.all('SELECT * FROM knex_migrations_lock', {}, (err, rows) => {
+                if (err) {
+                    reject(err);
+                }
+                resolve(rows);
+            });
+        });
+        expect(rows.length).to.equal(1);
+        expect(rows[0].is_locked).to.equal(0);
+        db.close();
+
+    });
+
+});

--- a/test/jake/jakelib/migrate-test.js
+++ b/test/jake/jakelib/migrate-test.js
@@ -717,40 +717,6 @@ test('migrate runs "esm" modules', (temp) => {
   });
 });
 
-test('migrate:unlock restores lock table to one row with is_locked=0', (temp) => {
-  const db = new sqlite3.Database(`${temp}/db`);
-  // Seed multiple rows into the lock table
-  return new Promise((resolve, reject) =>
-    db.run('INSERT INTO knex_migrations_lock(is_locked) VALUES (?),(?),(?)', [1, 0, 1], (err) => {
-      err ? reject(err) : resolve();
-    })
-  )
-    .then(() => {
-      return assertExec(
-        `node ${KNEX} migrate:unlock \
-      --client=sqlite3 \
-      --connection=${temp}/db \
-      --migrations-directory=${temp}/migrations`
-        )
-    })
-    .then(({ stdout }) => {
-      assert.include(
-        stdout,
-        `Succesfully unlocked the migrations lock table`
-      );
-      return new Promise((resolve, reject) => {
-        db.all('SELECT * FROM knex_migrations_lock', (err, rows) => {
-          assert.deepEqual(rows, [
-            {
-              "is_locked": 0,
-            },
-          ]);
-          err ? reject(err) : resolve();
-        });
-      });
-    });
-});
-
 module.exports = {
   taskList,
 };


### PR DESCRIPTION
# Changes
- Adds new `migrate:unlock` command to CLI which invokes `knex.migrations.forceFreeMigrationsLock()`, to provide for a CLI-based way of forcibly resetting the `knex_migrations_lock` table in the event that it gets into a bad state.
- Adjusts the behavior of `forceFreeMigrationsLock` to truncate the `knex_migrations_lock` table to ensure that there is only 1 row in the event that multiple rows have been inserted into that table, in which case [migrations will fail](https://github.com/knex/knex/blob/master/lib/migrate/Migrator.js#L299-L310)