### PR TITLE
Extended migration validation to guard against out-of-order migrations

### DIFF
--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -1,10 +1,12 @@
 // Migrator
 // -------
+const difference = require('lodash/difference');
 const differenceWith = require('lodash/differenceWith');
 const get = require('lodash/get');
 const isBoolean = require('lodash/isBoolean');
 const isEmpty = require('lodash/isEmpty');
 const isFunction = require('lodash/isFunction');
+const last = require('lodash/last');
 const max = require('lodash/max');
 const inherits = require('inherits');
 const {
@@ -554,6 +556,23 @@ function validateMigrationList(migrationSource, migrations) {
         ', '
       )}`
     );
+  }
+
+  // Check if there are some migrations which should've already completed
+  const lastCompleted = last(completed);
+  if (!lastCompleted) {
+    return;
+  }
+
+  const allNames = all.map(migrationSource.getMigrationName);
+  const newMigrations = difference(allNames, completed);
+
+  const lastMigrationIndex = allNames.indexOf(lastCompleted);
+  const upcomingMigrations = allNames.slice(lastMigrationIndex + 1);
+  const reordered = difference(newMigrations, upcomingMigrations);
+  if (!isEmpty(reordered)) {
+    const message = `The migration directory is corrupt, the following migrations should have already been run (but didn't): ${reordered.join(', ')}`;
+    throw new Error(message);
   }
 }
 


### PR DESCRIPTION
Currently, the migration list validation errors out if one of the completed migrations is missing. However, it's still possible to add new migrations _before_ the completed ones.

This can produce inconsistent ordering in different databases, for example: 
- Run two migrations, named "1" and "3".
- Add another migration and run it, named "2".
- The resulting order will be "1, 3, 2".
- Rollback all the migrations, and run them again.
- The resulting order this time will be "1, 2, 3" (which would be expected).

To guard against this, there is an extra check to see if there are any migrations that would come before the latest completed one. If there are, an error is produced.