### PR TITLE
Add support for .cjs files by default

### DIFF
--- a/lib/migrate/sources/fs-migrations.js
+++ b/lib/migrate/sources/fs-migrations.js
@@ -9,6 +9,7 @@ const DEFAULT_LOAD_EXTENSIONS = Object.freeze([
   '.eg',
   '.iced',
   '.js',
+  '.cjs',
   '.litcoffee',
   '.ls',
   '.ts',


### PR DESCRIPTION
This PR should solve the problem which I get after specified `"type": "module"` on the `package.json`. Since `--esm` flag doesn't work on node.js 14.0, the only way to use migration CLI with module packages is to specify all files as `.cjs`. But thay are doesn't supported by default, and there is no documented way to add it to the available list, but I was find one.

