### PR TITLE
Update README to reflect correct handling of native map function

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,12 @@ knex.schema
       .select('users.user_name as user', 'accounts.account_name as account')
   )
 
-  // .map over the results
-  .map(row => {
-    console.log(row)
-  })
+  // map over the results
+  .then(rows =>
+    rows.map(row => {
+      console.log(row)
+    })
+  )
 
   // Finally, add a .catch handler for the promise chain
   .catch(e => {


### PR DESCRIPTION
There is an example in the README which presents `.map` as exposed with the knex library.

This had previously been valid when bluebird functions were leaked in the library and documentation.

Further described in https://github.com/knex/knex/issues/3704#issuecomment-595782683