### PR TITLE
Add support for AWS Aurora MySQL Data API

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,6 +7,7 @@ const CLIENT_ALIASES = Object.freeze({
 
 const SUPPORTED_CLIENTS = Object.freeze(
   [
+    'aurora-data-mysql',
     'mssql',
     'mysql',
     'mysql2',

--- a/lib/dialects/aurora-data-mysql/index.js
+++ b/lib/dialects/aurora-data-mysql/index.js
@@ -1,0 +1,256 @@
+// AWS Aurora MySQL Data API Client
+// -------
+const Client_MySQL = require('../mysql');
+const Transaction = require('./transaction');
+
+function getAuroraDataValue(value) {
+  if ('blobValue' in value) {
+    return Buffer.from(value.blobValue, 'base64');
+  } else if ('booleanValue' in value) {
+    return value.booleanValue;
+  } else if ('doubleValue' in value) {
+    return value.doubleValue;
+  } else if ('isNull' in value) {
+    return null;
+  } else if ('longValue' in value) {
+    return value.longValue;
+  } else if ('stringValue' in value) {
+    return value.stringValue;
+  } else {
+    const type = Object.keys(value)[0];
+    throw new Error(`Unknown value type '${type}' from row`);
+  }
+}
+
+function hydrateRecord(record, fields) {
+  return record.reduce((row, value, index) => {
+    const field = fields[index];
+
+    value = getAuroraDataValue(value);
+
+    switch (field.typeName) {
+      case 'DECIMAL':
+        value = Number(value);
+        break;
+
+      case 'DATE':
+      case 'DATETIME':
+      case 'TIMESTAMP':
+      case 'YEAR':
+        value = new Date(value + 'Z');
+        break;
+
+      case 'CHAR':
+        if (field.precision === 5) {
+          // ENUM ?
+          break;
+        } else if (field.precision === 13) {
+          // SET ?
+          value = new Set(value.split(','));
+        }
+        break;
+
+      default:
+        break;
+    }
+
+    row[field.name] = value;
+
+    return row;
+  }, {});
+}
+
+class Client_AuroraDataMySQL extends Client_MySQL {
+  transaction() {
+    return new Transaction(this, ...arguments);
+  }
+
+  _driver() {
+    const RDSDataService = require('aws-sdk/clients/rdsdataservice');
+
+    return new RDSDataService(this.config.connection.sdkConfig);
+  }
+
+  acquireRawConnection() {
+    return {
+      client: this.driver,
+      parameters: {
+        // common parameters for Data API requests
+        database: this.config.connection.database,
+        resourceArn: this.config.connection.resourceArn,
+        secretArn: this.config.connection.secretArn,
+      },
+    };
+  }
+
+  destroyRawConnection(connection) {}
+
+  validateConnection(connection) {
+    return true;
+  }
+
+  prepBindings(bindings) {
+    return bindings.map((value, index) => {
+      const name = index.toString();
+
+      switch (typeof value) {
+        case 'undefined':
+          throw new Error('Binding value cannot be `undefined`');
+
+        case 'boolean':
+          return {
+            name,
+            value: {
+              booleanValue: value,
+            },
+          };
+
+        case 'number':
+          if (Number.isInteger(value)) {
+            return {
+              name,
+              value: {
+                longValue: value,
+              },
+            };
+          } else {
+            return {
+              name,
+              typeHint: 'DECIMAL',
+              value: {
+                stringValue: value.toString(),
+              },
+            };
+          }
+
+        case 'string':
+          return {
+            name,
+            value: {
+              stringValue: value,
+            },
+          };
+
+        case 'object':
+          break;
+
+        default:
+          throw new Error(
+            `Unknown binding value type '${typeof value}' for value ${value}`
+          );
+      }
+
+      if (value === null) {
+        return {
+          name,
+          value: {
+            isNull: true,
+          },
+        };
+      }
+
+      if (Buffer.isBuffer(value) || ArrayBuffer.isView(value)) {
+        return {
+          name,
+          value: {
+            blobValue: value,
+          },
+        };
+      }
+
+      if (value instanceof Date) {
+        return {
+          name,
+          typeHint: 'TIMESTAMP',
+          value: {
+            stringValue: value.toISOString().replace('T', ' ').replace('Z', ''),
+          },
+        };
+      }
+
+      if (value instanceof Set) {
+        return {
+          name,
+          value: {
+            stringValue: Array.from(value).join(','),
+          },
+        };
+      }
+
+      throw new Error(
+        `Unknown binding value object of class '${value.constructor.name}' for value ${value}`
+      );
+    });
+  }
+
+  positionBindings(sql) {
+    let questionCount = 0;
+    return sql.replace(/\?/g, function () {
+      return `:${questionCount++}`;
+    });
+  }
+
+  _stream(connection, obj, stream, options) {
+    throw new Error(
+      'Streams are not supported by the aurora-data-mysql dialect'
+    );
+  }
+
+  async _query(connection, obj) {
+    obj.data = await connection.client
+      .executeStatement({
+        ...connection.parameters,
+        includeResultMetadata: true,
+        sql: obj.sql,
+        parameters: obj.bindings,
+      })
+      .promise();
+
+    return obj;
+  }
+
+  processResponse(resp, runner) {
+    if (resp == null) {
+      return;
+    }
+
+    const { method, data } = resp;
+    const {
+      columnMetadata: fields,
+      generatedFields,
+      numberOfRecordsUpdated,
+      records,
+    } = data;
+
+    const rows = records
+      ? records.map((record) => hydrateRecord(record, fields))
+      : [];
+
+    if (resp.output) {
+      return resp.output.call(runner, rows, fields);
+    }
+
+    switch (method) {
+      case 'select':
+      case 'pluck':
+      case 'first': {
+        if (method === 'pluck') {
+          return rows.map(resp.pluck);
+        }
+        return method === 'first' ? rows[0] : rows;
+      }
+      case 'insert':
+        return [getAuroraDataValue(generatedFields[0])];
+      case 'del':
+      case 'update':
+      case 'counter':
+        return numberOfRecordsUpdated;
+      default:
+        return { rows, fields };
+    }
+  }
+}
+
+Client_AuroraDataMySQL.prototype.driverName = 'aurora-data-mysql';
+
+module.exports = Client_AuroraDataMySQL;

--- a/lib/dialects/aurora-data-mysql/transaction.js
+++ b/lib/dialects/aurora-data-mysql/transaction.js
@@ -1,0 +1,99 @@
+const Transaction = require('../../transaction');
+const debug = require('debug')('knex:tx');
+
+class Transaction_AuroraDataMySQL extends Transaction {
+  constructor(client) {
+    if (client.transacting) {
+      throw new Error(
+        'Nested transactions are not supported by the Aurora Data API'
+      );
+    }
+
+    super(...arguments);
+  }
+
+  async begin(conn) {
+    if (conn.parameters.transactionId) {
+      throw new Error(
+        `Attempted to begin a new transaction for connection with existing transaction ${conn.transactionId}`
+      );
+    }
+
+    const { transactionId } = await conn.client
+      .beginTransaction(conn.parameters)
+      .promise();
+    debug(`Transaction begun with id ${transactionId}`);
+
+    conn.parameters.transactionId = transactionId;
+
+    this._resolver();
+  }
+
+  async commit(conn, value) {
+    if (!('transactionId' in conn.parameters)) {
+      throw new Error(
+        'Attempted to commit a transaction when one is not in progress'
+      );
+    }
+
+    const params = conn.parameters;
+    delete params.database;
+
+    const { transactionStatus } = await conn.client
+      .commitTransaction(params)
+      .promise();
+    debug(
+      `Transaction ${conn.parameters.transactionId} commit status: ${transactionStatus}`
+    );
+
+    delete conn.parameters.transactionId;
+
+    this._resolver(value);
+  }
+
+  async rollback(conn, error) {
+    if (!('transactionId' in conn.parameters)) {
+      throw new Error(
+        'Attempted to rollback a transaction when one is not in progress'
+      );
+    }
+
+    const params = conn.parameters;
+    delete params.database;
+
+    const { transactionStatus } = await conn.client
+      .rollbackTransaction(params)
+      .promise();
+    debug(
+      `Transaction ${conn.parameters.transactionId} rollback status: ${transactionStatus}`
+    );
+
+    delete conn.parameters.transactionId;
+
+    if (error === undefined) {
+      if (this.doNotRejectOnRollback) {
+        this._resolver();
+      } else {
+        this._rejecter(
+          new Error(`Transaction rejected with non-error: ${error}`)
+        );
+      }
+    } else {
+      this._rejecter(error);
+    }
+  }
+
+  savepoint(conn) {
+    throw new Error('Savepoints are not supported by the Aurora Data API');
+  }
+
+  release(conn, value) {
+    throw new Error('Savepoints are not supported by the Aurora Data API');
+  }
+
+  rollbackTo(conn, value) {
+    throw new Error('Savepoints are not supported by the Aurora Data API');
+  }
+}
+
+module.exports = Transaction_AuroraDataMySQL;

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "v8flags": "^3.1.3"
   },
   "peerDependencies": {
+    "aws-sdk": "^2.678.0",
     "mssql": "^6.2.0",
     "mysql": "^2.18.1",
     "mysql2": "^2.1.0",


### PR DESCRIPTION
AWS Aurora supports an HTTP Data API that proxies SQL queries as HTTP requests (including transactions!). This PR shows how to create a new dialect to support the Aurora Data Api.

I'm in favor of merging this, but I understand the interest in limiting new dialects built into knex. I'd be fine with maintaining this separately, as suggested in the contributing guidelines, but it's unclear how a complex dialect like this can be instantiated outside of knex itself. I can't think of a way to tell knex to load the `mysql` dialect but with a different implementation and configuration format. Please advise on whether this should be merged into knex or how it could be loaded separately.