### PR TITLE
Prefer `void` as return type on migration generator ts stub

### DIFF
--- a/lib/migrate/stub/ts.stub
+++ b/lib/migrate/stub/ts.stub
@@ -8,7 +8,7 @@ export async function up(knex: Knex): Promise<Knex.SchemaBuilder> {
     });
 }
 <% } else { %>
-export async function up(knex: Knex): Promise<any> {
+export async function up(knex: Knex): Promise<void> {
 }
 <% } %>
 <% if (d.tableName) { %>
@@ -16,6 +16,6 @@ export async function down(knex: Knex): Promise<Knex.SchemaBuilder> {
     return knex.schema.dropTable("<%= d.tableName %>");
 }
 <% } else { %>
-export async function down(knex: Knex): Promise<any> {
+export async function down(knex: Knex): Promise<void> {
 }
 <% } %>

--- a/lib/seed/stub/ts.stub
+++ b/lib/seed/stub/ts.stub
@@ -1,14 +1,13 @@
 import * as Knex from "knex";
 
-export async function seed(knex: Knex): Promise<any> {
+export async function seed(knex: Knex): Promise<void> {
     // Deletes ALL existing entries
-    return knex("table_name").del()
-        .then(() => {
-            // Inserts seed entries
-            return knex("table_name").insert([
-                { id: 1, colName: "rowValue1" },
-                { id: 2, colName: "rowValue2" },
-                { id: 3, colName: "rowValue3" }
-            ]);
-        });
+    await knex("table_name").del();
+
+    // Inserts seed entries
+    await knex("table_name").insert([
+        { id: 1, colName: "rowValue1" },
+        { id: 2, colName: "rowValue2" },
+        { id: 3, colName: "rowValue3" }
+    ]);
 };


### PR DESCRIPTION
The liberal use of `any` is frowned upon by some default `tslint` configurations. That combined with the fact the these functions, as far as I know, don't _need_ to return anything, makes it reasonable to use `void` over `any` for the return type.

If this change is accepted, I could also update docs to reflect that returning on `up` and `down` functions is not necessary, unless I'm missing something!