### PR TITLE
Add .timeout(ms) to .raw()'s typescript typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1366,6 +1366,7 @@ declare namespace Knex {
   interface Raw<TResult = any>
     extends events.EventEmitter,
       ChainableInterface<ResolveResult<TResult>> {
+    timeout(ms: number, options?: {cancel?: boolean}): Raw<TResult>;
     wrap<TResult2 = TResult>(before: string, after: string): Raw<TResult>;
     toSQL(): Sql;
     queryContext(context: any): Raw<TResult>;


### PR DESCRIPTION
`.timeout(ms)` is [supported for `knex.raw()`](https://github.com/knex/knex/blob/master/lib/raw.js#L46), but it's missing from the TS typings.