### PR TITLE
Fix getMergedConfig calls to include client logger

### DIFF
--- a/lib/migrate/MigrationGenerator.js
+++ b/lib/migrate/MigrationGenerator.js
@@ -4,13 +4,13 @@ const { getMergedConfig } = require('./configuration-merger');
 const { ensureDirectoryExists } = require('../util/fs');
 
 class MigrationGenerator {
-  constructor(migrationConfig) {
-    this.config = getMergedConfig(migrationConfig);
+  constructor(migrationConfig, logger) {
+    this.config = getMergedConfig(migrationConfig, undefined, logger);
   }
 
   // Creates a new migration, with a given name.
-  async make(name, config) {
-    this.config = getMergedConfig(config, this.config);
+  async make(name, config, logger) {
+    this.config = getMergedConfig(config, this.config, logger);
     if (!name) {
       return Promise.reject(
         new Error('A name must be specified for the generated migration')

--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -45,9 +45,13 @@ class Migrator {
 
     this.config = getMergedConfig(
       this.knex.client.config.migrations,
+      undefined,
       this.knex.client.logger
     );
-    this.generator = new MigrationGenerator(this.knex.client.config.migrations);
+    this.generator = new MigrationGenerator(
+      this.knex.client.config.migrations,
+      this.knex.client.logger
+    );
     this._activeMigration = {
       fileName: null,
     };
@@ -302,7 +306,7 @@ class Migrator {
   // Creates a new migration, with a given name.
   make(name, config) {
     this.config = getMergedConfig(config, this.config, this.knex.client.logger);
-    return this.generator.make(name, this.config);
+    return this.generator.make(name, this.config, this.knex.client.logger);
   }
 
   _disableProcessing() {


### PR DESCRIPTION
This fixes issues with logging that were introduced in this PR (https://github.com/knex/knex/pull/3839).

This fixes the following issue that I logged: https://github.com/knex/knex/issues/3919 