### PR TITLE
Fix for issue 3914

### DIFF
--- a/lib/dialects/oracle/utils.js
+++ b/lib/dialects/oracle/utils.js
@@ -1,6 +1,6 @@
 function generateCombinedName(logger, postfix, name, subNames) {
   const crypto = require('crypto');
-  const limit = 30;
+  const limit = 128;
   if (!Array.isArray(subNames)) subNames = subNames ? [subNames] : [];
   const table = name.replace(/\.|-/g, '_');
   const subNamesPart = subNames.join('_');

--- a/test/unit/dialects/oracledb.js
+++ b/test/unit/dialects/oracledb.js
@@ -144,6 +144,42 @@ describe('OracleDb parameters', function () {
   });
 });
 
+describe('OracleDb combined name tests', function () {
+  const Logger = require('../../../lib/logger');
+  const logger = new Logger();
+  const postfix = 'seq';
+  const name = 'test';
+
+  it('Should not base64 encode a string below 128 characters', function () {
+    const utils = require('../../../lib/dialects/oracle/utils');
+    expect(
+      utils.generateCombinedName(logger, postfix, name, [
+        'supercalifragilistic',
+        'expialadocious',
+        'antidisestablishmentarianism',
+        'submandibular',
+        'Pseudopseudohypoparathyroidism',
+      ])
+    ).to.equal(
+      'test_supercalifragilistic_expialadocious_antidisestablishmentarianism_submandibular_pseudopseudohypoparathyroidism_seq'
+    );
+  });
+
+  it('Should base64 encode a string above 128 character', function () {
+    const utils = require('../../../lib/dialects/oracle/utils');
+    expect(
+      utils.generateCombinedName(logger, postfix, name, [
+        'supercalifragilistic',
+        'expialadocious',
+        'antidisestablishmentarianism',
+        'submandibular',
+        'Pseudopseudohypoparathyroidism',
+        'Floccinaucinihilipilification',
+      ])
+    ).to.equal('rqo6pEjFfE9VOIX39GKFdPvNPrE');
+  });
+});
+
 describe('OracleDb unit tests', function () {
   let knexClient;
 


### PR DESCRIPTION
Fix for https://github.com/knex/knex/issues/3914

Added unit tests for generateCombinedName

This broke these two tests
```
  1) Query Building Tests
       Oracle SchemaBuilder
         allows dropping a unique compound index with too long generated name:
  2) Query Building Tests
       OracleDb SchemaBuilder
         allows dropping a unique compound index with too long generated name:
```

Let me know how to proceed to remediate those issues in the way that matches the pattern you have laid out in other places.

Thanks!