### PR TITLE
support postProcessResponse for streams (#3870)

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,7 +1,7 @@
 const { KnexTimeoutError } = require('./util/timeout');
 const { timeout } = require('./util/timeout');
 
-let PassThrough;
+let Transform;
 
 // The "Runner" constructor takes a "builder" (query, schema, or raw)
 // and runs through each of the query statements, calling any additional
@@ -73,12 +73,19 @@ Object.assign(Runner.prototype, {
     // Determines whether we emit an error or throw here.
     const hasHandler = typeof handler === 'function';
 
-    // Lazy-load the "PassThrough" dependency.
-    PassThrough = PassThrough || require('stream').PassThrough;
+    // Lazy-load the "Transform" dependency.
+    Transform = Transform || require('stream').Transform;
 
     const runner = this;
-    const stream = new PassThrough({ objectMode: true });
+    const queryContext = this.builder.queryContext();
 
+    const stream = new Transform({
+      objectMode: true,
+      transform: (chunk, _, callback) => {
+        callback(null, this.client.postProcessResponse(chunk, queryContext));
+      },
+    });
+    
     let hasConnection = false;
     const promise = this.ensureConnection(function (connection) {
       hasConnection = true;

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -84,6 +84,35 @@ module.exports = function (knex) {
             expect(res.queryContext).to.equal('the context');
           });
       });
+
+      it('should process response done through a stream', (done) => {
+        const stream = knex('accounts').limit(1).stream();
+        stream.on('data', (res) => {
+          expect(res.callCount).to.equal(1);
+        });
+        stream.on('finish', () => done());
+      });
+
+      it('should process response for each row done through a stream', (done) => {
+        const stream = knex('accounts').limit(5).stream();
+        let count = 0;
+        stream.on('data', () => count++);
+        stream.on('finish', () => {
+          expect(count).to.equal(5);
+          done();
+        });
+      });
+
+      it('should pass query context for responses through a stream', (done) => {
+        const stream = knex('accounts')
+          .queryContext('the context')
+          .limit(1)
+          .stream();
+        stream.on('data', (res) => {
+          expect(res.queryContext).to.equal('the context');
+        });
+        stream.on('finish', () => done());
+      });
     });
 
     describe('columnInfo with wrapIdentifier and postProcessResponse', () => {

--- a/test/integration/builder/additional.js
+++ b/test/integration/builder/additional.js
@@ -86,11 +86,32 @@ module.exports = function (knex) {
       });
 
       it('should process response done through a stream', (done) => {
+        let response;
         const stream = knex('accounts').limit(1).stream();
+        
         stream.on('data', (res) => {
-          expect(res.callCount).to.equal(1);
+          response = res;
         });
-        stream.on('finish', () => done());
+        stream.on('finish', () => {
+          expect(response.callCount).to.equal(1);
+          done();
+        });
+      });
+
+      it('should pass query context for responses through a stream', (done) => {
+        let response;
+        const stream = knex('accounts')
+          .queryContext('the context')
+          .limit(1)
+          .stream();
+
+        stream.on('data', (res) => {
+          response = res;
+        });
+        stream.on('finish', () => {
+          expect(response.queryContext).to.equal('the context');
+          done();
+        });
       });
 
       it('should process response for each row done through a stream', (done) => {
@@ -103,16 +124,6 @@ module.exports = function (knex) {
         });
       });
 
-      it('should pass query context for responses through a stream', (done) => {
-        const stream = knex('accounts')
-          .queryContext('the context')
-          .limit(1)
-          .stream();
-        stream.on('data', (res) => {
-          expect(res.queryContext).to.equal('the context');
-        });
-        stream.on('finish', () => done());
-      });
     });
 
     describe('columnInfo with wrapIdentifier and postProcessResponse', () => {


### PR DESCRIPTION
#3870 

When using `query.stream()` the postProcessResponse method is not called.

Example:

```js
const knex = require('./knex');
const { PassThrough } = require('stream');

async function main() {
  const db = knex({
    client: 'pg',
    connection: 'postgres://localhost:5432/db',
    postProcessResponse: (result, queryContext) => {
      console.log('postProcessResponse', result, queryContext); // only called once, for the "normal" query
      return result;
    },
  });

  // normal promise - works
  await db('a_table').select('*').limit(3);

  // stream - doesn't work
  const stream = db('a_table').select('*').limit(3).stream();
  stream.pipe(new PassThrough({ objectMode: true }));
  await new Promise(resolve => stream.on("finish", () => resolve()));
}

main()
  .then(() => {
    console.log('✅');
    process.exit(0);
  })
  .catch((err) => {
    console.error(err);
    console.log('❌');
    process.exit(1);
  });

```