### PR TITLE
Make the migrationSource / FsMigrations warning quieter

### DIFF
--- a/lib/migrate/configuration-merger.js
+++ b/lib/migrate/configuration-merger.js
@@ -30,6 +30,7 @@ function getMergedConfig(config, currentConfig, logger = defaultLogger) {
     config &&
     // If user specifies any FS related config,
     // clear existing FsMigrations migrationSource
+    mergedConfig.migrationSource != null &&
     (config.directory ||
       config.sortDirsSeparately !== undefined ||
       config.loadExtensions)


### PR DESCRIPTION
The warning that was added in #3839 is noisier than necessary; see #3921. It should suffice to warn only if the migrationSource is actually modified.