### PR TITLE
Add `null` as valid binding type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -379,6 +379,7 @@ declare namespace Knex {
     | string
     | number
     | boolean
+    | null
     | Date
     | Array<string>
     | Array<number>

--- a/types/test.ts
+++ b/types/test.ts
@@ -201,7 +201,7 @@ const main = async () => {
           [true, false]
       ]
   );
-  
+
   // $ExpectType Article[]
   await knex.raw<Article[]>(
       'select * from articles where authorId = ?',

--- a/types/test.ts
+++ b/types/test.ts
@@ -201,6 +201,12 @@ const main = async () => {
           [true, false]
       ]
   );
+  
+  // $ExpectType Article[]
+  await knex.raw<Article[]>(
+      'select * from articles where authorId = ?',
+      [ null ]
+  );
 
   // $ExpectType User[]
   await knex<User>('user').where('name', ['a', 'b', 'c']);


### PR DESCRIPTION
This change allows `null` into the bindings parameter of `.raw()` to typecheck properly

@lorefnon could you verify if this is the correct way to fix this