### PR TITLE
Fix migration source name in rollback all

### DIFF
--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -183,7 +183,9 @@ class Migrator {
           return all
             ? allMigrations
                 .filter((migration) => {
-                  return completedMigrations.includes(migration.file);
+                  return completedMigrations.includes(
+                    this.config.migrationSource.getMigrationName(migration)
+                  );
                 })
                 .reverse()
             : this._getLastBatch(val);

--- a/test/cli/knexfile-test.spec.js
+++ b/test/cli/knexfile-test.spec.js
@@ -199,6 +199,13 @@ module.exports = {
         {
           expectedOutput: 'Batch 1 run: 2 migrations',
         }
+      ).then(() =>
+        execCommand(
+          `node ${KNEX} migrate:rollback --all --knexfile=test/jake-util/knexfile-custom-migration-source/knexfile.js --knexpath=../knex.js`,
+          {
+            expectedOutput: 'Batch 1 rolled back: 2 migrations',
+          }
+        )
       );
     });
 


### PR DESCRIPTION
This looks like it's an oversight, probably not caught because of low custom MigrationSource usage. Until this is merged, the temporary workaround is to make sure your custom `migration` objects have a `file` property that matches their `name`.