### PR TITLE
Allow string[] type for directory in SeedsConfig

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1944,7 +1944,7 @@ declare namespace Knex {
   }
 
   interface SeedsConfig<V extends {} = any> {
-    directory?: string;
+    directory?: string | string[];
     extension?: string;
     loadExtensions?: readonly string[];
     stub?: string;


### PR DESCRIPTION
I'm pretty sure you can do this, since I had it working for multiple seeds without the typing.