### PR TITLE
Warn if whereNot is used with 'in' or 'between'

### DIFF
--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -371,6 +371,13 @@ assign(Builder.prototype, {
 
   // Adds an `not where` clause to the query.
   whereNot() {
+    if (arguments.length >= 2) {
+      if (arguments[1] === 'in' || arguments[1] === 'between') {
+        this.client.logger.warn(
+          'whereNot is not suitable for "in" and "between" type subqueries. You should use "not in" and "not between" instead.'
+        );
+      }
+    }
     return this._not(true).where.apply(this, arguments);
   },
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -952,6 +952,34 @@ describe('QueryBuilder', () => {
     );
   });
 
+  it('where not should throw warning when used with "in" or "between"', function () {
+    try {
+      clientsWithCustomLoggerForTestWarnings.pg
+        .queryBuilder()
+        .select('*')
+        .from('users')
+        .whereNot('id', 'in', [1, 2, 3]);
+      throw new Error('Should not reach this point');
+    } catch (error) {
+      expect(error.message).to.equal(
+        'whereNot is not suitable for "in" and "between" type subqueries. You should use "not in" and "not between" instead.'
+      );
+    }
+
+    try {
+      clientsWithCustomLoggerForTestWarnings.pg
+        .queryBuilder()
+        .select('*')
+        .from('users')
+        .whereNot('id', 'between', [1, 3]);
+      throw new Error('Should not reach this point');
+    } catch (error) {
+      expect(error.message).to.equal(
+        'whereNot is not suitable for "in" and "between" type subqueries. You should use "not in" and "not between" instead.'
+      );
+    }
+  });
+
   it('where bool', () => {
     testquery(qb().select('*').from('users').where(true), {
       mysql: 'select * from `users` where 1 = 1',


### PR DESCRIPTION
Today I was confused by the fact that `whereNot('col', 'in', [ values ])` is not valid and does fail silently. I struggled with this for quite some time before finding this part of the documentation:

> CAVEAT: WhereNot is not suitable for "in" and "between" type subqueries. You should use "not in" and "not between" instead.

If I understand correctly, it's never allowed to call `whereNot()` with "in" or "between". This PR logs the warning from the documentation, helping developers to avoid this error.