### PR TITLE
Ensure that semicolon is not appended to statements that already end with a semicolon

### DIFF
--- a/lib/interface.js
+++ b/lib/interface.js
@@ -11,7 +11,7 @@ module.exports = function (Target) {
       .map((statement) => {
         return this.client._formatQuery(statement.sql, statement.bindings, tz);
       })
-      .join(';\n');
+      .reduce((a, c) => a.concat(a.endsWith(';') ? '\n' : ';\n', c));
   };
 
   // Create a new instance of the `Runner`, passing in the current object.

--- a/test/unit/schema/oracle.js
+++ b/test/unit/schema/oracle.js
@@ -963,4 +963,12 @@ describe('Oracle SchemaBuilder', function () {
       expect(spy.thirdCall.args).to.deep.equal(['users', 'table context']);
     });
   });
+
+  it('test converting a sql wrapped with catch to string, #4045', function () {
+    tableSql = client.schemaBuilder().dropTableIfExists('book');
+
+    expect(tableSql.toQuery()).to.equal(
+      'begin execute immediate \'drop table "book"\'; exception when others then if sqlcode != -942 then raise; end if; end;\nbegin execute immediate \'drop sequence "book_seq"\'; exception when others then if sqlcode != -2289 then raise; end if; end;'
+    );
+  });
 });

--- a/test/unit/schema/oracledb.js
+++ b/test/unit/schema/oracledb.js
@@ -963,4 +963,12 @@ describe('OracleDb SchemaBuilder', function () {
       expect(spy.thirdCall.args).to.deep.equal(['users', 'table context']);
     });
   });
+
+  it('test converting a sql wrapped with catch to string, #4045', function () {
+    tableSql = client.schemaBuilder().dropTableIfExists('book');
+
+    expect(tableSql.toQuery()).to.equal(
+      'begin execute immediate \'drop table "book"\'; exception when others then if sqlcode != -942 then raise; end if; end;\nbegin execute immediate \'drop sequence "book_seq"\'; exception when others then if sqlcode != -2289 then raise; end if; end;'
+    );
+  });
 });


### PR DESCRIPTION
This solves #4045:

`toQuery()` & `toSql()` are returning duplicate semicolons for queries that pass through the method `wrapSqlWithCatch()`

Example: 

```
var knex = require('knex')({
    client: 'oracledb',
    connection: {
        host: '127.0.0.1',
        user: 'your_database_user',
        password: 'your_database_password',
        database: 'myapp_test'
    }
});

var builder = knex.schema.dropTableIfExists('book');

console.log(builder.toQuery())
```
outputs: 
```
begin execute immediate 'drop table "book"'; exception when others then if sqlcode != -942 then raise; end if; end;;
begin execute immediate 'drop sequence "book_seq"'; exception when others then if sqlcode != -2289 then raise; end if; end;
```
