### PR TITLE
Avoid lodash typecheks

### DIFF
--- a/lib/dialects/mysql/schema/columncompiler.js
+++ b/lib/dialects/mysql/schema/columncompiler.js
@@ -2,7 +2,7 @@
 // -------
 const inherits = require('inherits');
 const ColumnCompiler = require('../../../schema/columncompiler');
-const isObject = require('../../../util/isObject.js');
+const { isObject } = require('../../../util/is');
 
 function ColumnCompiler_MySQL() {
   ColumnCompiler.apply(this, arguments);

--- a/lib/dialects/mysql/schema/columncompiler.js
+++ b/lib/dialects/mysql/schema/columncompiler.js
@@ -2,8 +2,7 @@
 // -------
 const inherits = require('inherits');
 const ColumnCompiler = require('../../../schema/columncompiler');
-
-const isObject = require('lodash/isObject');
+const isObject = require('../../../util/isObject.js');
 
 function ColumnCompiler_MySQL() {
   ColumnCompiler.apply(this, arguments);

--- a/lib/dialects/oracle/query/compiler.js
+++ b/lib/dialects/oracle/query/compiler.js
@@ -6,7 +6,6 @@ const compact = require('lodash/compact');
 const identity = require('lodash/identity');
 const isEmpty = require('lodash/isEmpty');
 const isPlainObject = require('lodash/isPlainObject');
-const isString = require('lodash/isString');
 const reduce = require('lodash/reduce');
 const QueryCompiler = require('../../../query/compiler');
 const { ReturningHelper } = require('../utils');
@@ -78,7 +77,7 @@ class QueryCompiler_Oracle extends QueryCompiler {
 
     const sql = {};
 
-    if (isString(insertData)) {
+    if (typeof insertData === 'string') {
       return this._addReturningToSqlAndConvert(
         `insert into ${this.tableName} ${insertData}`,
         returning

--- a/lib/dialects/oracle/query/compiler.js
+++ b/lib/dialects/oracle/query/compiler.js
@@ -9,6 +9,7 @@ const isPlainObject = require('lodash/isPlainObject');
 const reduce = require('lodash/reduce');
 const QueryCompiler = require('../../../query/compiler');
 const { ReturningHelper } = require('../utils');
+const { isString } = require('../../../util/is');
 
 const components = [
   'columns',
@@ -77,7 +78,7 @@ class QueryCompiler_Oracle extends QueryCompiler {
 
     const sql = {};
 
-    if (typeof insertData === 'string') {
+    if (isString(insertData)) {
       return this._addReturningToSqlAndConvert(
         `insert into ${this.tableName} ${insertData}`,
         returning

--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -3,7 +3,6 @@
 const each = require('lodash/each');
 const flatten = require('lodash/flatten');
 const isEmpty = require('lodash/isEmpty');
-const isString = require('lodash/isString');
 const map = require('lodash/map');
 const values = require('lodash/values');
 const inherits = require('inherits');
@@ -35,7 +34,7 @@ Client_Oracledb.prototype._driver = function () {
   client.fetchAsString = [];
   if (this.config.fetchAsString && Array.isArray(this.config.fetchAsString)) {
     this.config.fetchAsString.forEach(function (type) {
-      if (!isString(type)) return;
+      if (typeof type !== 'string') return;
       type = type.toUpperCase();
       if (oracledb[type]) {
         if (

--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -14,6 +14,7 @@ const { promisify } = require('util');
 const Transaction = require('./transaction');
 const Client_Oracle = require('../oracle');
 const Oracle_Formatter = require('../oracle/formatter');
+const { isString } = require('../../util/is');
 
 function Client_Oracledb() {
   Client_Oracle.apply(this, arguments);
@@ -34,7 +35,7 @@ Client_Oracledb.prototype._driver = function () {
   client.fetchAsString = [];
   if (this.config.fetchAsString && Array.isArray(this.config.fetchAsString)) {
     this.config.fetchAsString.forEach(function (type) {
-      if (typeof type !== 'string') return;
+      if (!isString(type)) return;
       type = type.toUpperCase();
       if (oracledb[type]) {
         if (

--- a/lib/dialects/oracledb/query/compiler.js
+++ b/lib/dialects/oracledb/query/compiler.js
@@ -2,7 +2,6 @@ const clone = require('lodash/clone');
 const each = require('lodash/each');
 const isEmpty = require('lodash/isEmpty');
 const isPlainObject = require('lodash/isPlainObject');
-const isString = require('lodash/isString');
 const Oracle_Compiler = require('../../oracle/query/compiler');
 const ReturningHelper = require('../utils').ReturningHelper;
 const BlobHelper = require('../utils').BlobHelper;
@@ -52,7 +51,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
 
     const sql = {};
 
-    if (isString(insertData)) {
+    if (typeof insertData === 'string') {
       return this._addReturningToSqlAndConvert(
         'insert into ' + this.tableName + ' ' + insertData,
         outBinding[0],

--- a/lib/dialects/oracledb/query/compiler.js
+++ b/lib/dialects/oracledb/query/compiler.js
@@ -5,6 +5,7 @@ const isPlainObject = require('lodash/isPlainObject');
 const Oracle_Compiler = require('../../oracle/query/compiler');
 const ReturningHelper = require('../utils').ReturningHelper;
 const BlobHelper = require('../utils').BlobHelper;
+const { isString } = require('../../../util/is');
 
 class Oracledb_Compiler extends Oracle_Compiler {
   constructor(client, builder) {
@@ -51,7 +52,7 @@ class Oracledb_Compiler extends Oracle_Compiler {
 
     const sql = {};
 
-    if (typeof insertData === 'string') {
+    if (isString(insertData)) {
       return this._addReturningToSqlAndConvert(
         'insert into ' + this.tableName + ' ' + insertData,
         outBinding[0],

--- a/lib/dialects/oracledb/schema/columncompiler.js
+++ b/lib/dialects/oracledb/schema/columncompiler.js
@@ -1,6 +1,6 @@
 const inherits = require('inherits');
 const ColumnCompiler_Oracle = require('../../oracle/schema/columncompiler');
-const isObject = require('../../../util/isObject.js');
+const { isObject } = require('../../../util/is');
 
 function ColumnCompiler_Oracledb() {
   ColumnCompiler_Oracle.apply(this, arguments);

--- a/lib/dialects/oracledb/schema/columncompiler.js
+++ b/lib/dialects/oracledb/schema/columncompiler.js
@@ -1,7 +1,6 @@
 const inherits = require('inherits');
 const ColumnCompiler_Oracle = require('../../oracle/schema/columncompiler');
-
-const isObject = require('lodash/isObject');
+const isObject = require('../../../util/isObject.js');
 
 function ColumnCompiler_Oracledb() {
   ColumnCompiler_Oracle.apply(this, arguments);

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -11,6 +11,7 @@ const ColumnCompiler = require('./schema/columncompiler');
 const TableCompiler = require('./schema/tablecompiler');
 const SchemaCompiler = require('./schema/compiler');
 const { makeEscape } = require('../../query/string');
+const { isString } = require('../../util/is');
 
 function Client_PG(config) {
   Client.apply(this, arguments);
@@ -169,13 +170,13 @@ Object.assign(Client_PG.prototype, {
 
     if (!path) return Promise.resolve(true);
 
-    if (!Array.isArray(path) && typeof path !== 'string') {
+    if (!Array.isArray(path) && !isString(path)) {
       throw new TypeError(
         `knex: Expected searchPath to be Array/String, got: ${typeof path}`
       );
     }
 
-    if (typeof path === 'string') {
+    if (isString(path)) {
       if (path.includes(',')) {
         const parts = path.split(',');
         const arraySyntax = `[${parts

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -1,7 +1,6 @@
 // PostgreSQL
 // -------
 const extend = require('lodash/extend');
-const isString = require('lodash/isString');
 const map = require('lodash/map');
 const { promisify } = require('util');
 const inherits = require('inherits');
@@ -170,13 +169,13 @@ Object.assign(Client_PG.prototype, {
 
     if (!path) return Promise.resolve(true);
 
-    if (!Array.isArray(path) && !isString(path)) {
+    if (!Array.isArray(path) && typeof path !== 'string') {
       throw new TypeError(
         `knex: Expected searchPath to be Array/String, got: ${typeof path}`
       );
     }
 
-    if (isString(path)) {
+    if (typeof path === 'string') {
       if (path.includes(',')) {
         const parts = path.split(',');
         const arraySyntax = `[${parts

--- a/lib/dialects/postgres/schema/columncompiler.js
+++ b/lib/dialects/postgres/schema/columncompiler.js
@@ -3,7 +3,7 @@
 
 const inherits = require('inherits');
 const ColumnCompiler = require('../../../schema/columncompiler');
-const isObject = require('../../../util/isObject.js');
+const { isObject } = require('../../../util/is');
 
 function ColumnCompiler_PG() {
   ColumnCompiler.apply(this, arguments);

--- a/lib/dialects/postgres/schema/columncompiler.js
+++ b/lib/dialects/postgres/schema/columncompiler.js
@@ -3,7 +3,7 @@
 
 const inherits = require('inherits');
 const ColumnCompiler = require('../../../schema/columncompiler');
-const isObject = require('lodash/isObject');
+const isObject = require('../../../util/isObject.js');
 
 function ColumnCompiler_PG() {
   ColumnCompiler.apply(this, arguments);

--- a/lib/dialects/sqlite3/query/compiler.js
+++ b/lib/dialects/sqlite3/query/compiler.js
@@ -8,6 +8,7 @@ const each = require('lodash/each');
 const identity = require('lodash/identity');
 const isEmpty = require('lodash/isEmpty');
 const reduce = require('lodash/reduce');
+const { isString } = require('../../../util/is');
 
 const emptyStr = constant('');
 
@@ -51,7 +52,7 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
 
     const insertData = this._prepInsert(insertValues);
 
-    if (typeof insertData === 'string') {
+    if (isString(insertData)) {
       return sql + insertData;
     }
 

--- a/lib/dialects/sqlite3/query/compiler.js
+++ b/lib/dialects/sqlite3/query/compiler.js
@@ -7,7 +7,6 @@ const constant = require('lodash/constant');
 const each = require('lodash/each');
 const identity = require('lodash/identity');
 const isEmpty = require('lodash/isEmpty');
-const isString = require('lodash/isString');
 const reduce = require('lodash/reduce');
 
 const emptyStr = constant('');
@@ -52,7 +51,7 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
 
     const insertData = this._prepInsert(insertValues);
 
-    if (isString(insertData)) {
+    if (typeof insertData === 'string') {
       return sql + insertData;
     }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,5 @@
 /* eslint no-console:0 */
 
-const isFunction = require('lodash/isFunction');
 const isPlainObject = require('lodash/isPlainObject');
 const isTypedArray = require('lodash/isTypedArray');
 const { CLIENT_ALIASES } = require('./constants');
@@ -24,7 +23,7 @@ function containsUndefined(mixed) {
 
   if (isTypedArray(mixed)) return false;
 
-  if (mixed && isFunction(mixed.toSQL)) {
+  if (mixed && typeof mixed.toSQL === 'function') {
     //Any QueryBuilder or Raw will automatically be validated during compile.
     return argContainsUndefined;
   }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,6 +3,7 @@
 const isPlainObject = require('lodash/isPlainObject');
 const isTypedArray = require('lodash/isTypedArray');
 const { CLIENT_ALIASES } = require('./constants');
+const { isFunction } = require('./util/is');
 
 // Check if the first argument is an array, otherwise uses all arguments as an
 // array.
@@ -23,7 +24,7 @@ function containsUndefined(mixed) {
 
   if (isTypedArray(mixed)) return false;
 
-  if (mixed && typeof mixed.toSQL === 'function') {
+  if (mixed && isFunction(mixed.toSQL)) {
     //Any QueryBuilder or Raw will automatically be validated during compile.
     return argContainsUndefined;
   }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,8 +2,6 @@
 
 const color = require('colorette');
 const { inspect } = require('util');
-const isFunction = require('lodash/isFunction');
-const isString = require('lodash/isString');
 
 class Logger {
   constructor(config = {}) {
@@ -26,16 +24,16 @@ class Logger {
   }
 
   _log(message, userFn, colorFn) {
-    if (userFn != null && !isFunction(userFn)) {
+    if (userFn != null && typeof userFn !== 'function') {
       throw new TypeError('Extensions to knex logger must be functions!');
     }
 
-    if (isFunction(userFn)) {
+    if (typeof userFn === 'function') {
       userFn(message);
       return;
     }
 
-    if (!isString(message)) {
+    if (typeof message !== 'string') {
       message = inspect(message, {
         depth: this._inspectionDepth,
         colors: this._enableColors,

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,6 +2,7 @@
 
 const color = require('colorette');
 const { inspect } = require('util');
+const { isString, isFunction } = require('./util/is');
 
 class Logger {
   constructor(config = {}) {
@@ -24,16 +25,16 @@ class Logger {
   }
 
   _log(message, userFn, colorFn) {
-    if (userFn != null && typeof userFn !== 'function') {
+    if (userFn != null && !isFunction(userFn)) {
       throw new TypeError('Extensions to knex logger must be functions!');
     }
 
-    if (typeof userFn === 'function') {
+    if (isFunction(userFn)) {
       userFn(message);
       return;
     }
 
-    if (typeof message !== 'string') {
+    if (!isString(message)) {
       message = inspect(message, {
         depth: this._inspectionDepth,
         colors: this._enableColors,

--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -14,6 +14,7 @@ const { getSchemaBuilder } = require('./table-creator');
 const migrationListResolver = require('./migration-list-resolver');
 const MigrationGenerator = require('./MigrationGenerator');
 const { getMergedConfig } = require('./configuration-merger');
+const { isBoolean, isFunction } = require('../util/is');
 
 function LockError(msg) {
   this.name = 'MigrationLocked';
@@ -28,7 +29,7 @@ inherits(LockError, Error);
 class Migrator {
   constructor(knex) {
     // Clone knex instance and remove post-processing that is unnecessary for internal queries from a cloned config
-    if (typeof knex === 'function') {
+    if (isFunction(knex)) {
       if (!knex.isTransaction) {
         this.knex = knex.withUserParams({
           ...knex.userParams,
@@ -474,7 +475,7 @@ class Migrator {
   _useTransaction(migrationContent, allTransactionsDisabled) {
     const singleTransactionValue = get(migrationContent, 'config.transaction');
 
-    return typeof singleTransactionValue === 'boolean'
+    return isBoolean(singleTransactionValue)
       ? singleTransactionValue
       : !allTransactionsDisabled;
   }

--- a/lib/migrate/Migrator.js
+++ b/lib/migrate/Migrator.js
@@ -2,9 +2,7 @@
 // -------
 const differenceWith = require('lodash/differenceWith');
 const get = require('lodash/get');
-const isBoolean = require('lodash/isBoolean');
 const isEmpty = require('lodash/isEmpty');
-const isFunction = require('lodash/isFunction');
 const max = require('lodash/max');
 const inherits = require('inherits');
 const {
@@ -30,7 +28,7 @@ inherits(LockError, Error);
 class Migrator {
   constructor(knex) {
     // Clone knex instance and remove post-processing that is unnecessary for internal queries from a cloned config
-    if (isFunction(knex)) {
+    if (typeof knex === 'function') {
       if (!knex.isTransaction) {
         this.knex = knex.withUserParams({
           ...knex.userParams,
@@ -476,7 +474,7 @@ class Migrator {
   _useTransaction(migrationContent, allTransactionsDisabled) {
     const singleTransactionValue = get(migrationContent, 'config.transaction');
 
-    return isBoolean(singleTransactionValue)
+    return typeof singleTransactionValue === 'boolean'
       ? singleTransactionValue
       : !allTransactionsDisabled;
   }

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -17,7 +17,7 @@ const reject = require('lodash/reject');
 const tail = require('lodash/tail');
 const toArray = require('lodash/toArray');
 const saveAsyncStack = require('../util/save-async-stack');
-const isObject = require('../util/isObject.js');
+const { isBoolean, isNumber, isObject, isString } = require('../util/is');
 
 const { lockMode, waitMode } = require('./constants');
 
@@ -91,7 +91,7 @@ assign(Builder.prototype, {
   },
 
   timeout(ms, { cancel } = {}) {
-    if (typeof ms === 'number' && ms > 0) {
+    if (isNumber(ms) && ms > 0) {
       this._timeout = ms;
       if (cancel) {
         this.client.assertCanCancelQuery();
@@ -598,7 +598,7 @@ assign(Builder.prototype, {
           value: columnInfo['column'],
           direction: columnInfo['order'],
         });
-      } else if (typeof columnInfo === 'string') {
+      } else if (isString(columnInfo)) {
         this._statements.push({
           grouping: 'order',
           type: 'orderByBasic',
@@ -623,7 +623,7 @@ assign(Builder.prototype, {
   _union(clause, args) {
     let callbacks = args[0];
     let wrap = args[1];
-    if (args.length === 1 || (args.length === 2 && typeof wrap === 'boolean')) {
+    if (args.length === 1 || (args.length === 2 && isBoolean(wrap))) {
       if (!Array.isArray(callbacks)) {
         callbacks = [callbacks];
       }
@@ -638,7 +638,7 @@ assign(Builder.prototype, {
     } else {
       callbacks = toArray(args).slice(0, args.length - 1);
       wrap = args[args.length - 1];
-      if (typeof wrap !== 'boolean') {
+      if (!isBoolean(wrap)) {
         callbacks.push(wrap);
         wrap = false;
       }
@@ -659,10 +659,7 @@ assign(Builder.prototype, {
 
   // Adds an intersect statement to the query
   intersect(callbacks, wrap) {
-    if (
-      arguments.length === 1 ||
-      (arguments.length === 2 && typeof wrap === 'boolean')
-    ) {
+    if (arguments.length === 1 || (arguments.length === 2 && isBoolean(wrap))) {
       if (!Array.isArray(callbacks)) {
         callbacks = [callbacks];
       }
@@ -677,7 +674,7 @@ assign(Builder.prototype, {
     } else {
       callbacks = toArray(arguments).slice(0, arguments.length - 1);
       wrap = arguments[arguments.length - 1];
-      if (typeof wrap !== 'boolean') {
+      if (!isBoolean(wrap)) {
         callbacks.push(wrap);
         wrap = false;
       }
@@ -1054,7 +1051,7 @@ assign(Builder.prototype, {
     let ret;
     const obj = this._single.update || {};
     this._method = 'update';
-    if (typeof values === 'string') {
+    if (isString(values)) {
       obj[values] = returning;
       if (arguments.length > 2) {
         ret = arguments[2];

--- a/lib/query/builder.js
+++ b/lib/query/builder.js
@@ -10,18 +10,14 @@ const JoinClause = require('./joinclause');
 const assign = require('lodash/assign');
 const clone = require('lodash/clone');
 const each = require('lodash/each');
-const isBoolean = require('lodash/isBoolean');
 const isEmpty = require('lodash/isEmpty');
-const isFunction = require('lodash/isFunction');
-const isNumber = require('lodash/isNumber');
-const isObject = require('lodash/isObject');
 const isPlainObject = require('lodash/isPlainObject');
-const isString = require('lodash/isString');
 const last = require('lodash/last');
 const reject = require('lodash/reject');
 const tail = require('lodash/tail');
 const toArray = require('lodash/toArray');
 const saveAsyncStack = require('../util/save-async-stack');
+const isObject = require('../util/isObject.js');
 
 const { lockMode, waitMode } = require('./constants');
 
@@ -95,7 +91,7 @@ assign(Builder.prototype, {
   },
 
   timeout(ms, { cancel } = {}) {
-    if (isNumber(ms) && ms > 0) {
+    if (typeof ms === 'number' && ms > 0) {
       this._timeout = ms;
       if (cancel) {
         this.client.assertCanCancelQuery();
@@ -346,7 +342,7 @@ assign(Builder.prototype, {
   orWhere() {
     this._bool('or');
     const obj = arguments[0];
-    if (isObject(obj) && !isFunction(obj) && !(obj instanceof Raw)) {
+    if (isObject(obj) && !(obj instanceof Raw)) {
       return this.whereWrapped(function () {
         for (const key in obj) {
           this.andWhere(key, obj[key]);
@@ -359,7 +355,7 @@ assign(Builder.prototype, {
   orWhereColumn() {
     this._bool('or');
     const obj = arguments[0];
-    if (isObject(obj) && !isFunction(obj) && !(obj instanceof Raw)) {
+    if (isObject(obj) && !(obj instanceof Raw)) {
       return this.whereWrapped(function () {
         for (const key in obj) {
           this.andWhereColumn(key, '=', obj[key]);
@@ -602,7 +598,7 @@ assign(Builder.prototype, {
           value: columnInfo['column'],
           direction: columnInfo['order'],
         });
-      } else if (isString(columnInfo)) {
+      } else if (typeof columnInfo === 'string') {
         this._statements.push({
           grouping: 'order',
           type: 'orderByBasic',
@@ -627,7 +623,7 @@ assign(Builder.prototype, {
   _union(clause, args) {
     let callbacks = args[0];
     let wrap = args[1];
-    if (args.length === 1 || (args.length === 2 && isBoolean(wrap))) {
+    if (args.length === 1 || (args.length === 2 && typeof wrap === 'boolean')) {
       if (!Array.isArray(callbacks)) {
         callbacks = [callbacks];
       }
@@ -642,7 +638,7 @@ assign(Builder.prototype, {
     } else {
       callbacks = toArray(args).slice(0, args.length - 1);
       wrap = args[args.length - 1];
-      if (!isBoolean(wrap)) {
+      if (typeof wrap !== 'boolean') {
         callbacks.push(wrap);
         wrap = false;
       }
@@ -663,7 +659,10 @@ assign(Builder.prototype, {
 
   // Adds an intersect statement to the query
   intersect(callbacks, wrap) {
-    if (arguments.length === 1 || (arguments.length === 2 && isBoolean(wrap))) {
+    if (
+      arguments.length === 1 ||
+      (arguments.length === 2 && typeof wrap === 'boolean')
+    ) {
       if (!Array.isArray(callbacks)) {
         callbacks = [callbacks];
       }
@@ -678,7 +677,7 @@ assign(Builder.prototype, {
     } else {
       callbacks = toArray(arguments).slice(0, arguments.length - 1);
       wrap = arguments[arguments.length - 1];
-      if (!isBoolean(wrap)) {
+      if (typeof wrap !== 'boolean') {
         callbacks.push(wrap);
         wrap = false;
       }
@@ -714,7 +713,7 @@ assign(Builder.prototype, {
   orHaving: function orHaving() {
     this._bool('or');
     const obj = arguments[0];
-    if (isObject(obj) && !isFunction(obj) && !(obj instanceof Raw)) {
+    if (isObject(obj) && !(obj instanceof Raw)) {
       return this.havingWrapped(function () {
         for (const key in obj) {
           this.andHaving(key, obj[key]);
@@ -1055,7 +1054,7 @@ assign(Builder.prototype, {
     let ret;
     const obj = this._single.update || {};
     this._method = 'update';
-    if (isString(values)) {
+    if (typeof values === 'string') {
       obj[values] = returning;
       if (arguments.length > 2) {
         ret = arguments[2];

--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -12,8 +12,6 @@ const compact = require('lodash/compact');
 const groupBy = require('lodash/groupBy');
 const has = require('lodash/has');
 const isEmpty = require('lodash/isEmpty');
-const isString = require('lodash/isString');
-const isUndefined = require('lodash/isUndefined');
 const map = require('lodash/map');
 const omitBy = require('lodash/omitBy');
 const reduce = require('lodash/reduce');
@@ -82,7 +80,7 @@ class QueryCompiler {
       },
     });
 
-    if (isString(val)) {
+    if (typeof val === 'string') {
       query.sql = val;
     } else {
       assign(query, val);
@@ -802,7 +800,7 @@ class QueryCompiler {
       data[column] = this.client.raw(`?? ${symbol} ?`, [column, value]);
     }
 
-    data = omitBy(data, isUndefined);
+    data = omitBy(data, (item) => typeof item === 'undefined');
 
     const vals = [];
     const columns = Object.keys(data);

--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -16,6 +16,7 @@ const map = require('lodash/map');
 const omitBy = require('lodash/omitBy');
 const reduce = require('lodash/reduce');
 const uuid = require('uuid');
+const { isString, isUndefined } = require('../util/is');
 
 const debugBindings = debug('knex:bindings');
 
@@ -80,7 +81,7 @@ class QueryCompiler {
       },
     });
 
-    if (typeof val === 'string') {
+    if (isString(val)) {
       query.sql = val;
     } else {
       assign(query, val);
@@ -800,7 +801,7 @@ class QueryCompiler {
       data[column] = this.client.raw(`?? ${symbol} ?`, [column, value]);
     }
 
-    data = omitBy(data, (item) => typeof item === 'undefined');
+    data = omitBy(data, isUndefined);
 
     const vals = [];
     const columns = Object.keys(data);

--- a/lib/raw.js
+++ b/lib/raw.js
@@ -10,7 +10,7 @@ const isPlainObject = require('lodash/isPlainObject');
 const reduce = require('lodash/reduce');
 const saveAsyncStack = require('./util/save-async-stack');
 const uuid = require('uuid');
-const isObject = require('./util/isObject.js');
+const { isNumber, isObject } = require('./util/is');
 
 const debugBindings = debug('knex:bindings');
 
@@ -43,7 +43,7 @@ assign(Raw.prototype, {
   },
 
   timeout(ms, { cancel } = {}) {
-    if (typeof ms === 'number' && ms > 0) {
+    if (isNumber(ms) && ms > 0) {
       this._timeout = ms;
       if (cancel) {
         this.client.assertCanCancelQuery();

--- a/lib/raw.js
+++ b/lib/raw.js
@@ -6,12 +6,11 @@ const { EventEmitter } = require('events');
 const debug = require('debug');
 
 const assign = require('lodash/assign');
-const isNumber = require('lodash/isNumber');
-const isObject = require('lodash/isObject');
 const isPlainObject = require('lodash/isPlainObject');
 const reduce = require('lodash/reduce');
 const saveAsyncStack = require('./util/save-async-stack');
 const uuid = require('uuid');
+const isObject = require('./util/isObject.js');
 
 const debugBindings = debug('knex:bindings');
 
@@ -44,7 +43,7 @@ assign(Raw.prototype, {
   },
 
   timeout(ms, { cancel } = {}) {
-    if (isNumber(ms) && ms > 0) {
+    if (typeof ms === 'number' && ms > 0) {
       this._timeout = ms;
       if (cancel) {
         this.client.assertCanCancelQuery();

--- a/lib/schema/columncompiler.js
+++ b/lib/schema/columncompiler.js
@@ -7,8 +7,8 @@ const helpers = require('./helpers');
 const groupBy = require('lodash/groupBy');
 const first = require('lodash/first');
 const has = require('lodash/has');
-const isObject = require('lodash/isObject');
 const tail = require('lodash/tail');
+const isObject = require('../util/isObject.js');
 
 function ColumnCompiler(client, tableCompiler, columnBuilder) {
   this.client = client;

--- a/lib/schema/columncompiler.js
+++ b/lib/schema/columncompiler.js
@@ -8,7 +8,7 @@ const groupBy = require('lodash/groupBy');
 const first = require('lodash/first');
 const has = require('lodash/has');
 const tail = require('lodash/tail');
-const isObject = require('../util/isObject.js');
+const { isObject } = require('../util/is');
 
 function ColumnCompiler(client, tableCompiler, columnBuilder) {
   this.client = client;

--- a/lib/schema/helpers.js
+++ b/lib/schema/helpers.js
@@ -1,11 +1,10 @@
-const isString = require('lodash/isString');
 const tail = require('lodash/tail');
 
 // Push a new query onto the compiled "sequence" stack,
 // creating a new formatter, returning the compiler.
 function pushQuery(query) {
   if (!query) return;
-  if (isString(query)) {
+  if (typeof query === 'string') {
     query = { sql: query };
   }
   if (!query.bindings) {
@@ -33,7 +32,7 @@ function pushAdditional(fn) {
 // creating a new formatter, returning the compiler.
 function unshiftQuery(query) {
   if (!query) return;
-  if (isString(query)) {
+  if (typeof query === 'string') {
     query = { sql: query };
   }
   if (!query.bindings) {

--- a/lib/schema/helpers.js
+++ b/lib/schema/helpers.js
@@ -1,10 +1,11 @@
 const tail = require('lodash/tail');
+const { isString } = require('../util/is');
 
 // Push a new query onto the compiled "sequence" stack,
 // creating a new formatter, returning the compiler.
 function pushQuery(query) {
   if (!query) return;
-  if (typeof query === 'string') {
+  if (isString(query)) {
     query = { sql: query };
   }
   if (!query.bindings) {
@@ -32,7 +33,7 @@ function pushAdditional(fn) {
 // creating a new formatter, returning the compiler.
 function unshiftQuery(query) {
   if (!query) return;
-  if (typeof query === 'string') {
+  if (isString(query)) {
     query = { sql: query };
   }
   if (!query.bindings) {

--- a/lib/schema/tablebuilder.js
+++ b/lib/schema/tablebuilder.js
@@ -8,8 +8,6 @@
 // ------
 const each = require('lodash/each');
 const extend = require('lodash/extend');
-const isFunction = require('lodash/isFunction');
-const isString = require('lodash/isString');
 const toArray = require('lodash/toArray');
 const helpers = require('../helpers');
 
@@ -22,7 +20,7 @@ function TableBuilder(client, method, tableName, fn) {
   this._statements = [];
   this._single = {};
 
-  if (!isFunction(this._fn)) {
+  if (typeof this._fn !== 'function') {
     throw new TypeError(
       'A callback function must be supplied to calls against `.createTable` ' +
         'and `.table`'
@@ -211,7 +209,7 @@ TableBuilder.prototype.foreign = function (column, keyName) {
   let returnObj = {
     references(tableColumn) {
       let pieces;
-      if (isString(tableColumn)) {
+      if (typeof tableColumn === 'string') {
         pieces = tableColumn.split('.');
       }
       if (!pieces || pieces.length === 1) {

--- a/lib/schema/tablebuilder.js
+++ b/lib/schema/tablebuilder.js
@@ -10,6 +10,7 @@ const each = require('lodash/each');
 const extend = require('lodash/extend');
 const toArray = require('lodash/toArray');
 const helpers = require('../helpers');
+const { isString, isFunction } = require('../util/is');
 
 function TableBuilder(client, method, tableName, fn) {
   this.client = client;
@@ -20,7 +21,7 @@ function TableBuilder(client, method, tableName, fn) {
   this._statements = [];
   this._single = {};
 
-  if (typeof this._fn !== 'function') {
+  if (!isFunction(this._fn)) {
     throw new TypeError(
       'A callback function must be supplied to calls against `.createTable` ' +
         'and `.table`'
@@ -209,7 +210,7 @@ TableBuilder.prototype.foreign = function (column, keyName) {
   let returnObj = {
     references(tableColumn) {
       let pieces;
-      if (typeof tableColumn === 'string') {
+      if (isString(tableColumn)) {
         pieces = tableColumn.split('.');
       }
       if (!pieces || pieces.length === 1) {

--- a/lib/util/batchInsert.js
+++ b/lib/util/batchInsert.js
@@ -1,6 +1,5 @@
 const chunk = require('lodash/chunk');
 const flatten = require('lodash/flatten');
-const isNumber = require('lodash/isNumber');
 const delay = require('./delay');
 
 module.exports = function batchInsert(
@@ -21,7 +20,7 @@ module.exports = function batchInsert(
 
   return Object.assign(
     Promise.resolve().then(async () => {
-      if (!isNumber(chunkSize) || chunkSize < 1) {
+      if (typeof chunkSize !== 'number' || chunkSize < 1) {
         throw new TypeError(`Invalid chunkSize: ${chunkSize}`);
       }
 

--- a/lib/util/batchInsert.js
+++ b/lib/util/batchInsert.js
@@ -1,6 +1,7 @@
 const chunk = require('lodash/chunk');
 const flatten = require('lodash/flatten');
 const delay = require('./delay');
+const { isNumber } = require('./is');
 
 module.exports = function batchInsert(
   client,
@@ -20,7 +21,7 @@ module.exports = function batchInsert(
 
   return Object.assign(
     Promise.resolve().then(async () => {
-      if (typeof chunkSize !== 'number' || chunkSize < 1) {
+      if (!isNumber(chunkSize) || chunkSize < 1) {
         throw new TypeError(`Invalid chunkSize: ${chunkSize}`);
       }
 

--- a/lib/util/is.js
+++ b/lib/util/is.js
@@ -1,0 +1,23 @@
+exports.isString = function isString(value) {
+  return typeof value === 'string';
+};
+
+exports.isNumber = function isNumber(value) {
+  return typeof value === 'number';
+};
+
+exports.isBoolean = function isBoolean(value) {
+  return typeof value === 'boolean';
+};
+
+exports.isUndefined = function isUndefined(value) {
+  return typeof value === 'undefined';
+};
+
+exports.isObject = function isObject(value) {
+  return typeof value === 'object' && value !== null;
+};
+
+exports.isFunction = function isFunction(value) {
+  return typeof value === 'function';
+};

--- a/lib/util/isObject.js
+++ b/lib/util/isObject.js
@@ -1,3 +1,0 @@
-module.exports = function isObject(value) {
-  return typeof value === 'object' && value !== null;
-};

--- a/lib/util/isObject.js
+++ b/lib/util/isObject.js
@@ -1,0 +1,3 @@
+module.exports = function isObject(value) {
+  return typeof value === 'object' && value !== null;
+};

--- a/test/integration/logger.js
+++ b/test/integration/logger.js
@@ -2,6 +2,7 @@
 
 const { expect } = require('chai');
 const _ = require('lodash');
+const isObject = require('../../lib/util/isObject.js');
 
 const { TEST_TIMESTAMP } = require('../util/constants');
 
@@ -91,7 +92,7 @@ module.exports = function (knex) {
   }
 
   function stripDates(resp) {
-    if (!_.isObject(resp[0])) return resp;
+    if (!isObject(resp[0])) return resp;
     return _.map(resp, function (val) {
       return _.reduce(
         val,

--- a/test/integration/logger.js
+++ b/test/integration/logger.js
@@ -2,7 +2,7 @@
 
 const { expect } = require('chai');
 const _ = require('lodash');
-const isObject = require('../../lib/util/isObject.js');
+const { isObject } = require('../../lib/util/is');
 
 const { TEST_TIMESTAMP } = require('../util/constants');
 

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -3,7 +3,7 @@
 const { expect } = require('chai');
 
 const _ = require('lodash');
-const isObject = require('../../../lib/util/isObject.js');
+const { isString, isObject } = require('../../../lib/util/is');
 
 const wrapIdentifier = (value, wrap) => {
   return wrap(value ? value.toUpperCase() : value);
@@ -558,7 +558,7 @@ module.exports = (knex) => {
             if (knex.client.driverName === 'pg') {
               expect(result.metadata).to.eql(defaultMetadata);
               expect(result.details).to.eql(defaultDetails);
-            } else if (typeof result.metadata === 'string') {
+            } else if (isString(result.metadata)) {
               expect(JSON.parse(result.metadata)).to.eql(defaultMetadata);
             } else {
               expect(result.metadata).to.eql(defaultMetadata);

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -3,6 +3,7 @@
 const { expect } = require('chai');
 
 const _ = require('lodash');
+const isObject = require('../../../lib/util/isObject.js');
 
 const wrapIdentifier = (value, wrap) => {
   return wrap(value ? value.toUpperCase() : value);
@@ -22,7 +23,7 @@ const postProcessResponse = (response) => {
   if (Array.isArray(response)) {
     return response.map(mapObject);
   } else {
-    if (_.isObject(response)) {
+    if (isObject(response)) {
       return mapObject(response);
     }
     return response;
@@ -557,7 +558,7 @@ module.exports = (knex) => {
             if (knex.client.driverName === 'pg') {
               expect(result.metadata).to.eql(defaultMetadata);
               expect(result.details).to.eql(defaultDetails);
-            } else if (_.isString(result.metadata)) {
+            } else if (typeof result.metadata === 'string') {
               expect(JSON.parse(result.metadata)).to.eql(defaultMetadata);
             } else {
               expect(result.metadata).to.eql(defaultMetadata);

--- a/test/unit/dialects/postgres.js
+++ b/test/unit/dialects/postgres.js
@@ -11,7 +11,7 @@ describe('Postgres Unit Tests', function () {
     const fakeConnection = {
       query: (...args) => {
         const cb = args.find((arg) => {
-          return _.isFunction(arg);
+          return typeof arg === 'function';
         });
         cb();
       },

--- a/test/unit/dialects/postgres.js
+++ b/test/unit/dialects/postgres.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const pgDialect = require('../../../lib/dialects/postgres/index.js');
 const pg = require('pg');
 const _ = require('lodash');
+const { isFunction } = require('../../../lib/util/is');
 
 describe('Postgres Unit Tests', function () {
   let checkVersionStub, querySpy;
@@ -11,7 +12,7 @@ describe('Postgres Unit Tests', function () {
     const fakeConnection = {
       query: (...args) => {
         const cb = args.find((arg) => {
-          return typeof arg === 'function';
+          return isFunction(arg);
         });
         cb();
       },


### PR DESCRIPTION
Lodash is quite big project. Even with direct imports it loads [tons](https://github.com/knex/knex/pull/3804) of
code and still bloats node_modules. This is a problem especially since lodash
mostly used as a polyfill for modern js features.

In this diff I attempted to reduce lodash usage by replacing type checks
with `typeof` operator which might be sufficient.

Also replaced lodash/isObject with custom simplified utility which does not
consider functions as objects and allows to simplify code in one place.