### PR TITLE
Replace mkdirp with recursive flag

### DIFF
--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -2,13 +2,13 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { promisify } = require('util');
-const mkdirp = require('mkdirp');
 
 // Promisify common fs functions.
 const stat = promisify(fs.stat);
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 const readdir = promisify(fs.readdir);
+const mkdir = promisify(fs.mkdir);
 
 /**
  * Creates a temporary directory and returns it path.
@@ -28,7 +28,7 @@ function createTemp() {
  * @returns {Promise}
  */
 function ensureDirectoryExists(dir) {
-  return stat(dir).catch(() => mkdirp(dir));
+  return stat(dir).catch(() => mkdir(dir, { recursive: true }));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "interpret": "^2.2.0",
     "liftoff": "3.1.0",
     "lodash": "^4.17.20",
-    "mkdirp": "^1.0.4",
     "pg-connection-string": "2.3.0",
     "tarn": "^3.0.0",
     "tildify": "2.0.0",


### PR DESCRIPTION
Ref https://nodejs.org/docs/latest/api/fs.html#fs_fs_mkdir_path_options_callback

In node 10 mkdir got new flag to support mkdirp like functionality.