### PR TITLE
add migration stub for .cjs extension

### DIFF
--- a/lib/migrate/stub/cjs.stub
+++ b/lib/migrate/stub/cjs.stub
@@ -1,0 +1,15 @@
+
+exports.up = function(knex) {
+  <% if (d.tableName) { %>
+  return knex.schema.createTable("<%= d.tableName %>", function(t) {
+    t.increments();
+    t.timestamp();
+  });
+  <% } %>
+};
+
+exports.down = function(knex) {
+  <% if (d.tableName) { %>
+  return knex.schema.dropTable("<%= d.tableName %>");
+  <% } %>
+};

--- a/test/unit/migrate/migration-list-resolver.js
+++ b/test/unit/migrate/migration-list-resolver.js
@@ -14,6 +14,7 @@ describe('migration-list-resolver', () => {
       migrationSource = new FsMigrations('test/integration/migrate/migration');
       mockFs({
         'test/integration/migrate/migration': {
+          'cjs-migration.cjs': 'cjs migration content',
           'co-migration.co': 'co migation content',
           'coffee-migration.coffee': 'coffee migation content',
           'eg-migration.eg': 'eg migation content',
@@ -34,6 +35,10 @@ describe('migration-list-resolver', () => {
     it('should include all supported extensions by default', () => {
       return migrationListResolver.listAll(migrationSource).then((list) => {
         expect(list).to.eql([
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'cjs-migration.cjs',
+          },
           {
             directory: 'test/integration/migrate/migration',
             file: 'co-migration.co',


### PR DESCRIPTION
When using knex in a node package that has `type:module` in its `package.json` I had to save my knexfile with the commonJS extension; `.cjs`. As a result, when running  
```
knex --knexfile knexfile.cjs migrate:make some-migration-name
```
I get this error
```
Error: ENOENT: no such file or directory, open 'node_modules/knex/lib/migrate/stub/cjs.stub'
```

I was able to resolve the issue by adding a stub to the knex package migrations folder locally. 
This PR shows my changes. It is simply a copy of the js stub. 

Let me know if any changes are required.