### PR TITLE
Allow to globally define table/record mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,8 @@
     "CHANGELOG.md",
     "scripts/*",
     "types/index.d.ts",
-    "types/result.d.ts"
+    "types/result.d.ts",
+    "types/tables.d.ts"
   ],
   "license": "MIT",
   "tonicExampleFilename": "scripts/runkit-example.js",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,6 +13,8 @@ import events = require('events');
 import stream = require('stream');
 import ResultTypes = require('./result');
 
+import { Tables } from './tables';
+
 import { ConnectionOptions } from "tls";
 
 // # Generic type-level utilities
@@ -325,6 +327,14 @@ interface PgTableOptions {
 
 interface Knex<TRecord extends {} = any, TResult = unknown[]>
   extends Knex.QueryInterface<TRecord, TResult>, events.EventEmitter {
+  <
+    TTable extends keyof Tables,
+    TRecord2 = Tables[TTable],
+    TResult2 = DeferredKeySelection<TRecord2, never>[]
+  >(
+    tableName: TTable,
+    options?: TableOptions
+  ): Knex.QueryBuilder<TRecord2, TResult2>;
   <TRecord2 = TRecord, TResult2 = DeferredKeySelection<TRecord2, never>[]>(
     tableName?: Knex.TableDescriptor | Knex.AliasDict,
     options?: TableOptions
@@ -886,6 +896,14 @@ declare namespace Knex {
 
   interface Table<TRecord extends {} = any, TResult extends {} = any> {
     <
+      TTable extends keyof Tables,
+      TRecord2 = Tables[TTable],
+      TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
+    >(
+      tableName: TTable,
+      options?: TableOptions
+    ): QueryBuilder<TRecord2, TResult2>;
+    <
       TRecord2 = unknown,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
     >(
@@ -937,6 +955,14 @@ declare namespace Knex {
       raw: Raw
     ): QueryBuilder<TRecord2, TResult2>;
     <
+      TTable extends keyof Tables,
+      TRecord2 = TRecord & Tables[TTable],
+      TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
+    >(
+      tableName: TTable,
+      clause: JoinCallback
+    ): QueryBuilder<TRecord2, TResult2>;
+    <
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
@@ -961,6 +987,15 @@ declare namespace Knex {
       raw: Raw
     ): QueryBuilder<TRecord2, TResult2>;
     <
+      TTable extends keyof Tables,
+      TRecord2 = TRecord & Tables[TTable],
+      TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
+    >(
+      tableName: TTable,
+      column1: string,
+      column2: string
+    ): QueryBuilder<TRecord2, TResult2>;
+    <
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
@@ -977,6 +1012,16 @@ declare namespace Knex {
       tableName: TableDescriptor | AliasDict | QueryCallback,
       column1: string,
       raw: Raw
+    ): QueryBuilder<TRecord2, TResult2>;
+    <
+      TTable extends keyof Tables,
+      TRecord2 = TRecord & Tables[TTable],
+      TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
+    >(
+      tableName: TTable,
+      column1: string,
+      operator: string,
+      column2: string
     ): QueryBuilder<TRecord2, TResult2>;
     <
       TJoinTargetRecord extends {} = any,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -343,14 +343,10 @@ type ResolveTableType<TCompositeTableType, TScope extends TableInterfaceScope = 
 
 interface Knex<TRecord extends {} = any, TResult = unknown[]>
   extends Knex.QueryInterface<TRecord, TResult>, events.EventEmitter {
-  <
-    TTable extends TableNames,
-    TRecord2 = TableType<TTable>,
-    TResult2 = DeferredKeySelection<ResolveTableType<TRecord2>, never>[]
-  >(
+  <TTable extends TableNames>(
     tableName: TTable,
     options?: TableOptions
-  ): Knex.QueryBuilder<TRecord2, TResult2>;
+  ): Knex.QueryBuilder<TableType<TTable>, DeferredKeySelection<ResolveTableType<TableType<TTable>>, never>[]>;
   <TRecord2 = TRecord, TResult2 = DeferredKeySelection<TRecord2, never>[]>(
     tableName?: Knex.TableDescriptor | Knex.AliasDict,
     options?: TableOptions
@@ -601,7 +597,7 @@ declare namespace Knex {
     pluck<TResult2 extends {}>(column: string): QueryBuilder<TRecord, TResult2>;
 
     insert(
-      data: DbRecordArr<ResolveTableType<TRecord, 'insert'>>,
+      data: TRecord extends CompositeTableType<unknown> ? ResolveTableType<TRecord, 'insert'> : DbRecordArr<TRecord>,
       returning: '*'
     ): QueryBuilder<TRecord, DeferredKeySelection<TRecord, never>[]>;
     insert<
@@ -612,7 +608,7 @@ declare namespace Knex {
         TKey
       >[]
     >(
-      data: DbRecordArr<ResolveTableType<TRecord, 'insert'>>,
+      data: TRecord extends CompositeTableType<unknown> ? ResolveTableType<TRecord, 'insert'> : DbRecordArr<TRecord>,
       returning: TKey
     ): QueryBuilder<TRecord, TResult2>;
     insert<
@@ -623,7 +619,7 @@ declare namespace Knex {
         TKey
       >[]
     >(
-      data: DbRecordArr<ResolveTableType<TRecord, 'insert'>>,
+      data: TRecord extends CompositeTableType<unknown> ? ResolveTableType<TRecord, 'insert'> : DbRecordArr<TRecord>,
       returning: readonly TKey[]
     ): QueryBuilder<TRecord, TResult2>;
     insert<
@@ -634,7 +630,7 @@ declare namespace Knex {
         TKey
       >[]
     >(
-      data: DbRecordArr<TRecord>,
+      data: TRecord extends CompositeTableType<unknown> ? ResolveTableType<TRecord, 'insert'> : DbRecordArr<TRecord>,
       returning: TKey
     ): QueryBuilder<TRecord, TResult2>;
     insert<
@@ -645,11 +641,11 @@ declare namespace Knex {
         TKey
       >[]
     >(
-      data: DbRecordArr<TRecord>,
+      data: TRecord extends CompositeTableType<unknown> ? ResolveTableType<TRecord, 'insert'> : DbRecordArr<TRecord>,
       returning: readonly TKey[]
     ): QueryBuilder<TRecord, TResult2>;
     insert<TResult2 = number[]>(
-      data: DbRecordArr<ResolveTableType<TRecord, 'insert'>>
+      data: TRecord extends CompositeTableType<unknown> ? ResolveTableType<TRecord, 'insert'> : DbRecordArr<TRecord>
     ): QueryBuilder<TRecord, TResult2>;
 
     modify<TRecord2 extends {} = any, TResult2 extends {} = any>(
@@ -703,7 +699,7 @@ declare namespace Knex {
         TKey
       >[]
     >(
-      data: DbRecordArr<ResolveTableType<TRecord, 'update'>>,
+      data: TRecord extends CompositeTableType<unknown> ?  ResolveTableType<TRecord, 'update'> : DbRecordArr<TRecord>,
       returning: TKey
     ): QueryBuilder<TRecord, TResult2>;
     update<
@@ -714,7 +710,7 @@ declare namespace Knex {
         TKey
       >[]
     >(
-      data: DbRecordArr<ResolveTableType<TRecord, 'update'>>,
+      data: TRecord extends CompositeTableType<unknown> ?  ResolveTableType<TRecord, 'update'> : DbRecordArr<TRecord>,
       returning: readonly TKey[]
     ): QueryBuilder<TRecord, TResult2>;
     update<
@@ -725,7 +721,7 @@ declare namespace Knex {
         TKey
       >[]
     >(
-      data: DbRecordArr<ResolveTableType<TRecord, 'update'>>,
+      data: TRecord extends CompositeTableType<unknown> ?  ResolveTableType<TRecord, 'update'> : DbRecordArr<TRecord>,
       returning: TKey | readonly TKey[]
     ): QueryBuilder<TRecord, TResult2>;
     update<
@@ -736,11 +732,11 @@ declare namespace Knex {
         TKey
       >[]
     >(
-      data: DbRecordArr<TRecord>,
+      data: TRecord extends CompositeTableType<unknown> ?  ResolveTableType<TRecord, 'update'> : DbRecordArr<TRecord>,
       returning: readonly TKey[]
     ): QueryBuilder<TRecord, TResult2>;
     update<TResult2 = number>(
-      data: DbRecordArr<ResolveTableType<TRecord, 'update'>>
+      data: TRecord extends CompositeTableType<unknown> ?  ResolveTableType<TRecord, 'update'> : DbRecordArr<TRecord>
     ): QueryBuilder<TRecord, TResult2>;
 
     update<TResult2 = number>(columnName: string, value: Value): QueryBuilder<TRecord, TResult2>;

--- a/types/tables.d.ts
+++ b/types/tables.d.ts
@@ -1,0 +1,4 @@
+// Placeholder interface for Table -> Record mapping
+// Allows to define the mapping of tables and interfaces in one place
+// and to have correct types when using `knex.from('table')`
+export interface Tables {}

--- a/types/test.ts
+++ b/types/test.ts
@@ -94,6 +94,9 @@ declare module './tables' {
     users_inferred: User;
     departments_inferred: Department;
     articles_inferred: Article;
+    users_composite: Knex.CompositeTableType<User, { insert: 'insert' }, { update: 'update' }>;
+    departments_composite: Knex.CompositeTableType<Department, { insert: 'insert' }, { update: 'update' }>;
+    articles_composite: Knex.CompositeTableType<Article, { insert: 'insert' }, { update: 'update' }>;
   }
 }
 
@@ -115,6 +118,9 @@ const main = async () => {
 
   // $ExpectType User[]
   await knex('users_inferred');
+
+  // $ExpectType User[]
+  await knex('users_composite');
 
   // $ExpectType any[]
   await knex('users').select('id');
@@ -157,6 +163,9 @@ const main = async () => {
   // $ExpectType Pick<User, "id"> | undefined
   await knex.first('id').from('users_inferred');
 
+  // $ExpectType Pick<User, "id"> | undefined
+  await knex.first('id').from('users_composite');
+
   // $ExpectType Pick<User, "id" | "name"> | undefined
   await knex<User>('users').first('id', 'name');
 
@@ -171,6 +180,12 @@ const main = async () => {
 
   // $ExpectType { id: number; name: string; }[]
   await knex('users_inferred').select([
+    knex.ref('name'),
+    knex.ref('id')
+  ]);
+
+  // $ExpectType { id: number; name: string; }[]
+  await knex('users_composite').select([
     knex.ref('name'),
     knex.ref('id')
   ]);
@@ -190,13 +205,32 @@ const main = async () => {
   // $ExpectType Pick<User, "id">[]
   await knex('users_inferred').select('id');
 
+  // $ExpectType Pick<User, "id">[]
+  await knex('users_composite').select('id');
+
   // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users')
     .select('id')
     .select('age');
 
   // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_inferred')
+    .select('id')
+    .select('age');
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_composite')
+    .select('id')
+    .select('age');
+
+  // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users').select('id', 'age');
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_inferred').select('id', 'age');
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_composite').select('id', 'age');
 
   // $ExpectType any
   await knex.raw('select * from users');
@@ -241,28 +275,76 @@ const main = async () => {
   await knex<User>('user').where('name', ['a', 'b', 'c']);
 
   // $ExpectType User[]
+  await knex('users_inferred').where('name', ['a', 'b', 'c']);
+
+  // $ExpectType User[]
+  await knex('users_composite').where('name', ['a', 'b', 'c']);
+
+  // $ExpectType User[]
   await knex<User>('user').whereRaw('name = ?', 'L');
+
+  // $ExpectType User[]
+  await knex('users_inferred').whereRaw('name = ?', 'L');
+
+  // $ExpectType User[]
+  await knex('users_composite').whereRaw('name = ?', 'L');
 
   // $ExpectType User[]
   await knex<User>('user').whereRaw('name = ?', 'L').clearWhere();
 
   // $ExpectType User[]
+  await knex('users_inferred').whereRaw('name = ?', 'L').clearWhere();
+
+  // $ExpectType User[]
+  await knex('users_composite').whereRaw('name = ?', 'L').clearWhere();
+
+  // $ExpectType User[]
   await knex<User>('user').whereBetween("id", [1, 2]);
+
+  // $ExpectType User[]
+  await knex('users_inferred').whereBetween('id', [1, 2]);
+
+  // $ExpectType User[]
+  await knex('users_composite').whereBetween('id', [1, 2]);
 
   const range = [1, 2] as const;
   // $ExpectType User[]
   await knex<User>('user').whereBetween("id", range);
 
+  // $ExpectType User[]
+  await knex('users_inferred').whereBetween('id', range);
+
+  // $ExpectType User[]
+  await knex('users_composite').whereBetween('id', range);
+
   // $ExpectType { id: number; }[]
   const r3 = await knex<User>('users').select(knex.ref('id'));
+
+  // $ExpectType { id: number; }[]
+  await knex('users_inferred').select(knex.ref('id'));
+
+  // $ExpectType { id: number; }[]
+  await knex('users_composite').select(knex.ref('id'));
 
   // $ExpectType (Pick<User, "name"> & { id: number; })[]
   const r4 = await knex<User>('users').select(knex.ref('id'), 'name');
   type _TR4 = ExtendsWitness<typeof r4[0], Pick<User, "id" | "name">>;
 
+  // $ExpectType (Pick<User, "name"> & { id: number; })[]
+  await knex('users_inferred').select(knex.ref('id'), 'name');
+
+  // $ExpectType (Pick<User, "name"> & { id: number; })[]
+  await knex('users_composite').select(knex.ref('id'), 'name');
+
   // $ExpectType (Pick<User, "name"> & { identifier: number; })[]
   const r5 = await knex<User>('users').select(knex.ref('id').as('identifier'), 'name');
   type _TR5 = ExtendsWitness<typeof r5[0], {identifier: number; name: string}>;
+
+  // $ExpectType (Pick<User, "name"> & { identifier: number; })[]
+  await knex('users_inferred').select(knex.ref('id').as('identifier'), 'name');
+
+  // $ExpectType (Pick<User, "name"> & { identifier: number; })[]
+  await knex('users_composite').select(knex.ref('id').as('identifier'), 'name');
 
   // $ExpectType (Pick<User, "name"> & { identifier: number; yearsSinceBirth: number; })[]
   const r6 = await knex<User>('users').select(
@@ -271,18 +353,48 @@ const main = async () => {
       knex.ref('age').as('yearsSinceBirth')
   );
   type _TR6 = ExtendsWitness<typeof r6[0], {identifier: number; name: string; yearsSinceBirth: number}>;
+  // $ExpectType (Pick<User, "name"> & { identifier: number; yearsSinceBirth: number; })[]
+  await knex('users_inferred').select(
+      knex.ref('id').as('identifier'),
+      'name',
+      knex.ref('age').as('yearsSinceBirth')
+  );
+  // $ExpectType (Pick<User, "name"> & { identifier: number; yearsSinceBirth: number; })[]
+  await knex('users_composite').select(
+      knex.ref('id').as('identifier'),
+      'name',
+      knex.ref('age').as('yearsSinceBirth')
+  );
 
   // $ExpectType { id: number; }[]
   const r7 = await knex.select(knex.ref('id')).from<User>('users');
   type _TR7 = ExtendsWitness<typeof r7[0], Pick<User, "id">>;
 
+  // $ExpectType { id: number; }[]
+  await knex.select(knex.ref('id')).from('users_inferred');
+
+  // $ExpectType { id: number; }[]
+  await knex.select(knex.ref('id')).from('users_composite');
+
   // $ExpectType (Pick<User, "name"> & { id: number; })[]
   const r8 = await knex.select(knex.ref('id'), 'name').from<User>('users');
   type _TR8 = ExtendsWitness<typeof r8[0], Pick<User, "id" | "name">>;
 
+  // $ExpectType (Pick<User, "name"> & { id: number; })[]
+  await knex.select(knex.ref('id'), 'name').from('users_inferred');
+
+  // $ExpectType (Pick<User, "name"> & { id: number; })[]
+  await knex.select(knex.ref('id'), 'name').from('users_composite');
+
   // $ExpectType (Pick<User, "name"> & { identifier: number; })[]
   const r9 = await knex.select(knex.ref('id').as('identifier'), 'name').from<User>('users');
   type _TR9 = ExtendsWitness<typeof r9[0], {identifier: number; name: string}>;
+
+  // $ExpectType (Pick<User, "name"> & { identifier: number; })[]
+  await knex.select(knex.ref('id').as('identifier'), 'name').from('users_inferred');
+
+  // $ExpectType (Pick<User, "name"> & { identifier: number; })[]
+  await knex.select(knex.ref('id').as('identifier'), 'name').from('users_composite');
 
   // $ExpectType (Pick<User, "name"> & { identifier: number; yearsSinceBirth: number; })[]
   const r10 = await knex.select(
@@ -292,11 +404,37 @@ const main = async () => {
   ).from<User>('users');
   type _TR10 = ExtendsWitness<typeof r10[0], {identifier: number; name: string; yearsSinceBirth: number}>;
 
+  // $ExpectType (Pick<User, "name"> & { identifier: number; yearsSinceBirth: number; })[]
+  await knex.select(
+    knex.ref('id').as('identifier'),
+    'name',
+    knex.ref('age').as('yearsSinceBirth')
+  ).from('users_inferred');
+
+  // $ExpectType (Pick<User, "name"> & { identifier: number; yearsSinceBirth: number; })[]
+  await knex.select(
+    knex.ref('id').as('identifier'),
+    'name',
+    knex.ref('age').as('yearsSinceBirth')
+  ).from('users_composite');
+
   // $ExpectType { id: number; age: any; }[]
   await knex<User>('users').select(knex.ref('id'), {age: 'users.age'});
 
+  // $ExpectType { id: number; age: any; }[]
+  await knex('users_inferred').select(knex.ref('id'), {age: 'users.age'});
+
+  // $ExpectType { id: number; age: any; }[]
+  await knex('users_composite').select(knex.ref('id'), {age: 'users.age'});
+
   // $ExpectType { id: number; age: any; } | undefined
   await knex<User>('users').select(knex.ref('id'), {age: 'users.age'}).first();
+
+  // $ExpectType { id: number; age: any; } | undefined
+  await knex('users_inferred').select(knex.ref('id'), {age: 'users.age'}).first();
+
+  // $ExpectType { id: number; age: any; } | undefined
+  await knex('users_composite').select(knex.ref('id'), {age: 'users.age'}).first();
 
   // $ExpectType { identifier: number; username: string; }[]
   (await knex<User>('users')
@@ -304,9 +442,31 @@ const main = async () => {
     .map((u) => ({ identifier: u.id, username: u.name }));
 
   // $ExpectType { identifier: number; username: string; }[]
+  (await knex('users_inferred')
+    .select('id', 'name'))
+    .map((u) => ({ identifier: u.id, username: u.name }));
+
+  // $ExpectType { identifier: number; username: string; }[]
+  (await knex('users_composite')
+    .select('id', 'name'))
+    .map((u) => ({ identifier: u.id, username: u.name }));
+
+  // $ExpectType { identifier: number; username: string; }[]
   (await knex
     .select('id', 'name')
     .from<User>('users'))
+    .map((u) => ({ identifier: u.id, username: u.name }));
+
+  // $ExpectType { identifier: number; username: string; }[]
+  (await knex
+    .select('id', 'name')
+    .from('users_inferred'))
+    .map((u) => ({ identifier: u.id, username: u.name }));
+
+  // $ExpectType { identifier: number; username: string; }[]
+  (await knex
+    .select('id', 'name')
+    .from('users_composite'))
     .map((u) => ({ identifier: u.id, username: u.name }));
 
   // $ExpectType { identifier: any; username: any; }[]
@@ -319,6 +479,18 @@ const main = async () => {
   (await knex
     .select('id', 'name', 'age')
     .from<User>('users'))
+    .reduce((maxAge: number, user) => (user.age > maxAge ? user.age : maxAge), 0);
+
+  // $ExpectType number
+  (await knex
+    .select('id', 'name', 'age')
+    .from('users_inferred'))
+    .reduce((maxAge: number, user) => (user.age > maxAge ? user.age : maxAge), 0);
+
+  // $ExpectType number
+  (await knex
+    .select('id', 'name', 'age')
+    .from('users_composite'))
     .reduce((maxAge: number, user) => (user.age > maxAge ? user.age : maxAge), 0);
 
   // $ExpectType any
@@ -336,8 +508,24 @@ const main = async () => {
   // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users').select(['id', 'age']);
 
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_inferred').select(['id', 'age']);
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_composite').select(['id', 'age']);
+
   // $ExpectType Pick<User, "id" | "age"> | undefined
   await knex<User>('users')
+    .select(['id', 'age'])
+    .first();
+
+  // $ExpectType Pick<User, "id" | "age"> | undefined
+  await knex('users_inferred')
+    .select(['id', 'age'])
+    .first();
+
+  // $ExpectType Pick<User, "id" | "age"> | undefined
+  await knex('users_composite')
     .select(['id', 'age'])
     .first();
 
@@ -350,8 +538,36 @@ const main = async () => {
     .clearSelect()
     .select(['name']);
 
+  // $ExpectType Pick<User, "name">[]
+  await knex('users_inferred')
+    .select(['id', 'age'])
+    .clearSelect()
+    .select(['name']);
+
+  // $ExpectType Pick<User, "name">[]
+  await knex('users_composite')
+    .select(['id', 'age'])
+    .clearSelect()
+    .select(['name']);
+
   // $ExpectType Pick<User, "name" | "departmentId">[]
   await knex<User>('users')
+    .select('id')
+    .select('age')
+    .clearSelect()
+    .select('name')
+    .select('departmentId');
+
+  // $ExpectType Pick<User, "name" | "departmentId">[]
+  await knex('users_inferred')
+    .select('id')
+    .select('age')
+    .clearSelect()
+    .select('name')
+    .select('departmentId');
+
+  // $ExpectType Pick<User, "name" | "departmentId">[]
+  await knex('users_composite')
     .select('id')
     .select('age')
     .clearSelect()
@@ -366,6 +582,24 @@ const main = async () => {
     .select('name')
     .select('departmentId')
     .from<User>('users');
+
+  // $ExpectType Pick<User, "name" | "departmentId">[]
+  await knex
+    .select('id')
+    .select('age')
+    .clearSelect()
+    .select('name')
+    .select('departmentId')
+    .from('users_inferred');
+
+  // $ExpectType Pick<User, "name" | "departmentId">[]
+  await knex
+    .select('id')
+    .select('age')
+    .clearSelect()
+    .select('name')
+    .select('departmentId')
+    .from('users_composite');
 
   // $ExpectType any[]
   await knex<User>('users')
@@ -382,17 +616,45 @@ const main = async () => {
     .select('id')
     .from<Department>('departments');
 
+  // $ExpectType Pick<Department, "id">[]
+  await knex('users_inferred')
+    .select('id')
+    .from('departments_inferred');
+
+  // $ExpectType Pick<Department, "id">[]
+  await knex('users_composite')
+    .select('id')
+    .from('departments_composite');
+
   // $ExpectType any[]
   await knex.select('id').from('users');
 
   // $ExpectType Pick<User, "id">[]
   await knex.select('id').from<User>('users');
 
+  // $ExpectType Pick<User, "id">[]
+  await knex.select('id').from('users_inferred');
+
+  // $ExpectType Pick<User, "id">[]
+  await knex.select('id').from('users_composite');
+
   // $ExpectType Pick<User, "id" | "age">[]
   await knex.select('id', 'age').from<User>('users');
 
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex.select('id', 'age').from('users_inferred');
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex.select('id', 'age').from('users_composite');
+
   // $ExpectType Pick<User, "id">[]
   await knex.from<User>('users').select('id');
+
+  // $ExpectType Pick<User, "id">[]
+  await knex.from('users_inferred').select('id');
+
+  // $ExpectType Pick<User, "id">[]
+  await knex.from('users_composite').select('id');
 
   // $ExpectType any[]
   await knex.from<User>('users').select('users.id');
@@ -413,12 +675,40 @@ const main = async () => {
     .from<User>('users');
 
   // $ExpectType Pick<User, "id" | "age">[]
+  await knex
+    .column('id', 'age')
+    .select()
+    .from('users_inferred');
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex
+    .column('id', 'age')
+    .select()
+    .from('users_composite');
+
+  // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users')
     .column('id', 'age')
     .select();
 
   // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_inferred')
+    .column('id', 'age')
+    .select();
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_composite')
+    .column('id', 'age')
+    .select();
+
+  // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users').column('id', 'age');
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_inferred').column('id', 'age');
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_composite').column('id', 'age');
 
   // $ExpectType any[]
   await knex('users').distinct('name', 'age');
@@ -426,11 +716,29 @@ const main = async () => {
   // $ExpectType Pick<User, "age" | "name">[]
   await knex<User>('users').distinct('name', 'age');
 
+  // $ExpectType Pick<User, "age" | "name">[]
+  await knex('users_inferred').distinct('name', 'age');
+
+  // $ExpectType Pick<User, "age" | "name">[]
+  await knex('users_composite').distinct('name', 'age');
+
   // $ExpectType Pick<User, "id" | "age" | "name" | "active" | "departmentId">[]
   await knex<User>('users').distinct();
 
+  // $ExpectType Pick<User, "id" | "age" | "name" | "active" | "departmentId">[]
+  await knex('users_inferred').distinct();
+
+  // $ExpectType Pick<User, "id" | "age" | "name" | "active" | "departmentId">[]
+  await knex('users_composite').distinct();
+
   // $ExpectType User[]
   await knex.select('*').from<User>('users');
+
+  // $ExpectType User[]
+  await knex.select('*').from('users_inferred');
+
+  // $ExpectType User[]
+  await knex.select('*').from('users_composite');
 
   const r1 = await knex
     .column('id', { yearsSinceBirth: 'age' })
@@ -444,6 +752,18 @@ const main = async () => {
   type TR1_2 = ExtendsWitness<number, typeof r1[0]['id']>;
   type TR1_3 = ExtendsWitness<any, typeof r1[0]['yearsSinceBirth']>;
 
+  // $ExpectType (Pick<User, "id"> & { yearsSinceBirth: any; })[]
+  await knex
+    .column('id', { yearsSinceBirth: 'age' })
+    .select()
+    .from('users_inferred');
+
+  // $ExpectType (Pick<User, "id"> & { yearsSinceBirth: any; })[]
+  await knex
+    .column('id', { yearsSinceBirth: 'age' })
+    .select()
+    .from('users_composite');
+
   const r2 = await knex
     .column('id', { yearsSinceBirth: 'age' as 'age' })
     .select()
@@ -456,13 +776,41 @@ const main = async () => {
   type TR2_2 = ExtendsWitness<number, typeof r1[0]['id']>;
   type TR2_3 = ExtendsWitness<number, typeof r1[0]['yearsSinceBirth']>;
 
+  // $ExpectType (Pick<User, "id"> & { yearsSinceBirth: number; })[]
+  await knex
+    .column('id', { yearsSinceBirth: 'age' as 'age' })
+    .select()
+    .from('users_inferred');
+
+  // $ExpectType (Pick<User, "id"> & { yearsSinceBirth: number; })[]
+  await knex
+    .column('id', { yearsSinceBirth: 'age' as 'age' })
+    .select()
+    .from('users_composite');
+
   // ## Conditional Selection:
 
   // $ExpectType User[]
   await knex<User>('users').where({ id: 10 });
 
+  // $ExpectType User[]
+  await knex('users_inferred').where({ id: 10 });
+
+  // $ExpectType User[]
+  await knex('users_composite').where({ id: 10 });
+
   // $ExpectType Pick<User, "id" | "name">[]
   await knex<User>('users')
+    .select('id', 'name')
+    .where({ id: 10 });
+
+  // $ExpectType Pick<User, "id" | "name">[]
+  await knex('users_inferred')
+    .select('id', 'name')
+    .where({ id: 10 });
+
+  // $ExpectType Pick<User, "id" | "name">[]
+  await knex('users_composite')
     .select('id', 'name')
     .where({ id: 10 });
 
@@ -493,6 +841,16 @@ const main = async () => {
     .where({ id: 10 })
     .first();
 
+  // $ExpectType User | undefined
+  await knex('users_inferred')
+    .where({ id: 10 })
+    .first();
+
+  // $ExpectType User | undefined
+  await knex('users_composite')
+    .where({ id: 10 })
+    .first();
+
   // $ExpectType any[]
   await knex.where({ id: 10 }).from('users');
 
@@ -502,10 +860,34 @@ const main = async () => {
   // $ExpectType User[]
   await knex.where({ id: 10 }).from<User>('users');
 
+  // $ExpectType User[]
+  await knex.where({ id: 10 }).from('users_inferred');
+
+  // $ExpectType User[]
+  await knex.where({ id: 10 }).from('users_composite');
+
   // $ExpectType User | undefined
   await knex
     .where({ id: 10 })
     .from<User>('users')
+    .clearWhere()
+    .where({ id: 11 })
+    .orWhere({ id: 12 })
+    .first();
+
+  // $ExpectType User | undefined
+  await knex
+    .where({ id: 10 })
+    .from('users_inferred')
+    .clearWhere()
+    .where({ id: 11 })
+    .orWhere({ id: 12 })
+    .first();
+
+  // $ExpectType User | undefined
+  await knex
+    .where({ id: 10 })
+    .from('users_composite')
     .clearWhere()
     .where({ id: 11 })
     .orWhere({ id: 12 })
@@ -518,7 +900,25 @@ const main = async () => {
     .from<User>('users');
 
   // $ExpectType User[]
+  await knex
+    .where({ id: 10 })
+    .where('age', '>', 20)
+    .from('users_inferred');
+
+  // $ExpectType User[]
+  await knex
+    .where({ id: 10 })
+    .where('age', '>', 20)
+    .from('users_composite');
+
+  // $ExpectType User[]
   await knex<User>('users').whereNot('age', '>', 100);
+
+  // $ExpectType User[]
+  await knex('users_inferred').whereNot('age', '>', 100);
+
+  // $ExpectType User[]
+  await knex('users_composite').whereNot('age', '>', 100);
 
   // ### Boolean operations
 
@@ -526,10 +926,28 @@ const main = async () => {
   await knex<User>('users').not.where('id', 10);
 
   // $ExpectType User[]
+  await knex('users_inferred').not.where('id', 10);
+
+  // $ExpectType User[]
+  await knex('users_composite').not.where('id', 10);
+
+  // $ExpectType User[]
   await knex<User>('user').where('name', 'L').and.where('age', 20);
 
   // $ExpectType User[]
+  await knex('users_inferred').where('name', 'L').and.where('age', 20);
+
+  // $ExpectType User[]
+  await knex('users_composite').where('name', 'L').and.where('age', 20);
+
+  // $ExpectType User[]
   await knex<User>('user').where('name', 'L').or.where('age', 20);
+
+  // $ExpectType User[]
+  await knex('users_inferred').where('name', 'L').or.where('age', 20);
+
+  // $ExpectType User[]
+  await knex('users_composite').where('name', 'L').or.where('age', 20);
 
   // ## Aggregation:
 
@@ -555,13 +973,49 @@ const main = async () => {
     .having('age', '>', 10);
 
   // $ExpectType User[]
+  await knex('users_inferred')
+    .groupBy('count')
+    .orderBy('name', 'desc')
+    .having('age', '>', 10);
+
+  // $ExpectType User[]
+  await knex('users_composite')
+    .groupBy('count')
+    .orderBy('name', 'desc')
+    .having('age', '>', 10);
+
+  // $ExpectType User[]
   await knex<User>('users')
     .groupByRaw('count')
     .orderBy('name', 'desc')
     .having('age', '>', 10);
 
   // $ExpectType User[]
+  await knex('users_inferred')
+    .groupByRaw('count')
+    .orderBy('name', 'desc')
+    .having('age', '>', 10);
+
+  // $ExpectType User[]
+  await knex('users_composite')
+    .groupByRaw('count')
+    .orderBy('name', 'desc')
+    .having('age', '>', 10);
+
+  // $ExpectType User[]
   await knex<User>('users')
+    .groupByRaw('count')
+    .orderBy('name', 'desc')
+    .havingRaw('age > ?', [10]);
+
+  // $ExpectType User[]
+  await knex('users_inferred')
+    .groupByRaw('count')
+    .orderBy('name', 'desc')
+    .havingRaw('age > ?', [10]);
+
+  // $ExpectType User[]
+  await knex('users_composite')
     .groupByRaw('count')
     .orderBy('name', 'desc')
     .havingRaw('age > ?', [10]);
@@ -576,6 +1030,27 @@ const main = async () => {
         .where('users.id', 'u.id')
     );
 
+  // $ExpectType User[]
+  await knex('users_inferred')
+    .select()
+    .orderBy(
+      knex('users_inferred')
+        .select('u.id')
+        .from('users as u')
+        .where('users.id', 'u.id')
+    );
+
+  // $ExpectType User[]
+  await knex('users_composite')
+    .select()
+    .orderBy(
+      knex('users_composite')
+        .select('u.id')
+        .from('users as u')
+        .where('users.id', 'u.id')
+    );
+
+  // $ExpectType User[]
   await knex<User>('users')
     .select()
     .orderBy([{
@@ -586,6 +1061,29 @@ const main = async () => {
       order: 'desc'
     }]);
 
+  // $ExpectType User[]
+  await knex('users_inferred')
+    .select()
+    .orderBy([{
+      column: knex('users_inferred')
+        .select('u.id')
+        .from('users as u')
+        .where('users.id', 'u.id'),
+      order: 'desc'
+    }]);
+
+  // $ExpectType User[]
+  await knex('users_composite')
+    .select()
+    .orderBy([{
+      column: knex('users_composite')
+        .select('u.id')
+        .from('users as u')
+        .where('users.id', 'u.id'),
+      order: 'desc'
+    }]);
+
+  // $ExpectType User[]
   await knex<User>('users')
     .select()
     .orderBy([{
@@ -596,7 +1094,46 @@ const main = async () => {
       order: 'desc'
     }]);
 
+  // $ExpectType User[]
+  await knex('users_inferred')
+    .select()
+    .orderBy([{
+      column: 'id',
+      order: 'desc'
+    }, {
+      column: 'name',
+      order: 'desc'
+    }]);
+
+  // $ExpectType User[]
+  await knex('users_composite')
+    .select()
+    .orderBy([{
+      column: 'id',
+      order: 'desc'
+    }, {
+      column: 'name',
+      order: 'desc'
+    }]);
+
+  // $ExpectType User[]
   await knex<User>('users')
+    .select()
+    .orderBy([{
+      column: 'id',
+      order: 'desc'
+    }, 'name']);
+
+  // $ExpectType User[]
+  await knex('users_inferred')
+    .select()
+    .orderBy([{
+      column: 'id',
+      order: 'desc'
+    }, 'name']);
+
+  // $ExpectType User[]
+  await knex('users_composite')
     .select()
     .orderBy([{
       column: 'id',
@@ -607,7 +1144,19 @@ const main = async () => {
   await knex<User>('users').count();
 
   // $ExpectType Dict<string | number>[]
+  await knex('users_inferred').count();
+
+  // $ExpectType Dict<string | number>[]
+  await knex('users_composite').count();
+
+  // $ExpectType Dict<string | number>[]
   await knex<User>('users').count('age');
+
+  // $ExpectType Dict<string | number>[]
+  await knex('users_inferred').count('age');
+
+  // $ExpectType Dict<string | number>[]
+  await knex('users_composite').count('age');
 
   // $ExpectType Dict<string | number>[]
   await knex('users').count('age');
@@ -628,16 +1177,40 @@ const main = async () => {
   await knex<User>('users').first().count('age');
 
   // $ExpectType Dict<string | number>
+  await knex('users_inferred').first().count('age');
+
+  // $ExpectType Dict<string | number>
+  await knex('users_composite').first().count('age');
+
+  // $ExpectType Dict<string | number>
   await knex('users').first().count('age', 'id');
 
   // $ExpectType Dict<string | number>
   await knex<User>('users').first().count();
 
+  // $ExpectType Dict<string | number>
+  await knex('users_inferred').first().count();
+
+  // $ExpectType Dict<string | number>
+  await knex('users_composite').first().count();
+
   // $ExpectType Dict<string | number>[]
   await knex.count().from<User>('users');
 
   // $ExpectType Dict<string | number>[]
+  await knex.count().from('users_inferred');
+
+  // $ExpectType Dict<string | number>[]
+  await knex.count().from('users_composite');
+
+  // $ExpectType Dict<string | number>[]
   await knex.count('age').from<User>('users');
+
+  // $ExpectType Dict<string | number>[]
+  await knex.count('age').from('users_inferred');
+
+  // $ExpectType Dict<string | number>[]
+  await knex.count('age').from('users_composite');
 
   // $ExpectType Dict<string | number>[]
   await knex.count('age').from('users');
@@ -658,16 +1231,40 @@ const main = async () => {
   await knex.first().count('age').from<User>('users');
 
   // $ExpectType Dict<string | number>
+  await knex.first().count('age').from('users_inferred');
+
+  // $ExpectType Dict<string | number>
+  await knex.first().count('age').from('users_composite');
+
+  // $ExpectType Dict<string | number>
   await knex.first().count('age', 'id').from('users');
 
   // $ExpectType Dict<string | number>
   await knex.first().count().from<User>('users');
 
+  // $ExpectType Dict<string | number>
+  await knex.first().count().from('users_inferred');
+
+  // $ExpectType Dict<string | number>
+  await knex.first().count().from('users_composite');
+
   // $ExpectType Dict<number>[]
   await knex<User>('users').max('age');
 
+  // $ExpectType Dict<number>[]
+  await knex('users_inferred').max('age');
+
+  // $ExpectType Dict<number>[]
+  await knex('users_composite').max('age');
+
   // $ExpectType Dict<number>
   await knex<User>('users').first().max('age');
+
+  // $ExpectType Dict<number>
+  await knex('users_inferred').first().max('age');
+
+  // $ExpectType Dict<number>
+  await knex('users_composite').first().max('age');
 
   // $ExpectType Dict<any>[]
   await knex('users').max('age');
@@ -675,20 +1272,50 @@ const main = async () => {
   // $ExpectType Dict<number>[]
   await knex<User>('users').min('age');
 
+  // $ExpectType Dict<number>[]
+  await knex('users_inferred').min('age');
+
+  // $ExpectType Dict<number>[]
+  await knex('users_composite').min('age');
+
   // $ExpectType Dict<number>
   await knex<User>('users').first().min('age');
+
+  // $ExpectType Dict<number>
+  await knex('users_inferred').first().min('age');
+
+  // $ExpectType Dict<number>
+  await knex('users_composite').first().min('age');
 
   // $ExpectType Dict<any>[]
   await knex.max('age').from<User>('users');
 
+  // $ExpectType Dict<any>[]
+  await knex.max('age').from('users_inferred');
+
+  // $ExpectType Dict<any>[]
+  await knex.max('age').from('users_composite');
+
   // $ExpectType Dict<any>
   await knex.first().max('age').from<User>('users');
+
+  // $ExpectType Dict<any>
+  await knex.first().max('age').from('users_inferred');
+
+  // $ExpectType Dict<any>
+  await knex.first().max('age').from('users_composite');
 
   // $ExpectType Dict<any>[]
   await knex.max('age').from('users');
 
   // $ExpectType Dict<any>[]
   await knex.min('age').from<User>('users');
+
+  // $ExpectType Dict<any>[]
+  await knex.min('age').from('users_inferred');
+
+  // $ExpectType Dict<any>[]
+  await knex.min('age').from('users_composite');
 
   // $ExpectType Dict<any>
   await knex.first().min('age').from<User>('users');
@@ -700,14 +1327,50 @@ const main = async () => {
     .max({b: 'age'})
     .from<User>('users');
 
+  // $ExpectType ({ dep: any; } & { a?: any; } & { b?: any; })[]
+  await knex
+    .select({dep: 'departmentId'})
+    .min({a: 'age'})
+    .max({b: 'age'})
+    .from('users_inferred');
+
+  // $ExpectType ({ dep: any; } & { a?: any; } & { b?: any; })[]
+  await knex
+    .select({dep: 'departmentId'})
+    .min({a: 'age'})
+    .max({b: 'age'})
+    .from('users_composite');
+
   // $ExpectType ({ dep: number; } & { a?: any; } & { b?: any; })[]
   await knex<User>('users')
     .select({dep: 'departmentId'})
     .min({a: 'age'})
     .max({b: 'age'});
 
+  // $ExpectType ({ dep: number; } & { a?: any; } & { b?: any; })[]
+  await knex('users_inferred')
+    .select({dep: 'departmentId'})
+    .min({a: 'age'})
+    .max({b: 'age'});
+
+  // $ExpectType ({ dep: number; } & { a?: any; } & { b?: any; })[]
+  await knex('users_composite')
+    .select({dep: 'departmentId'})
+    .min({a: 'age'})
+    .max({b: 'age'});
+
   // $ExpectType ({ dep: number; } & { a?: string | number | undefined; })[]
   await knex<User>('users')
+    .select({dep: 'departmentId'})
+    .count({a: 'age'});
+
+  // $ExpectType ({ dep: number; } & { a?: string | number | undefined; })[]
+  await knex('users_inferred')
+    .select({dep: 'departmentId'})
+    .count({a: 'age'});
+
+  // $ExpectType ({ dep: number; } & { a?: string | number | undefined; })[]
+  await knex('users_composite')
     .select({dep: 'departmentId'})
     .count({a: 'age'});
 
@@ -719,6 +1382,18 @@ const main = async () => {
     .select({dep: 'departmentId'})
     .count({a: 'age'})
     .from<User>('users');
+
+  // $ExpectType ({ dep: any; } & { a?: string | number | undefined; })[]
+  await knex
+    .select({dep: 'departmentId'})
+    .count({a: 'age'})
+    .from('users_inferred');
+
+  // $ExpectType ({ dep: any; } & { a?: string | number | undefined; })[]
+  await knex
+    .select({dep: 'departmentId'})
+    .count({a: 'age'})
+    .from('users_composite');
 
   // ## With inner query:
 
@@ -758,7 +1433,35 @@ const main = async () => {
   });
 
   // $ExpectType User[]
+  await knex('users_inferred').whereNot(function() {
+    this.where('id', 1).orWhereNot('id', '>', 10);
+  });
+
+  // $ExpectType User[]
+  await knex('users_composite').whereNot(function() {
+    this.where('id', 1).orWhereNot('id', '>', 10);
+  });
+
+  // $ExpectType User[]
   await knex<User>('users')
+    .where((builder) =>
+      builder.whereIn('id', [1, 11, 15]).whereNotIn('id', [17, 19])
+    )
+    .andWhere(function() {
+      this.where('id', '>', 10);
+    });
+
+  // $ExpectType User[]
+  await knex('users_inferred')
+    .where((builder) =>
+      builder.whereIn('id', [1, 11, 15]).whereNotIn('id', [17, 19])
+    )
+    .andWhere(function() {
+      this.where('id', '>', 10);
+    });
+
+  // $ExpectType User[]
+  await knex('users_composite')
     .where((builder) =>
       builder.whereIn('id', [1, 11, 15]).whereNotIn('id', [17, 19])
     )
@@ -776,11 +1479,39 @@ const main = async () => {
     })
     .first();
 
+  // $ExpectType User | undefined
+  await knex('users_inferred')
+    .where((builder) =>
+      builder.whereIn('id', [1, 11, 15]).whereNotIn('id', [17, 19])
+    )
+    .andWhere(function() {
+      this.where('id', '>', 10);
+    })
+    .first();
+
+  // $ExpectType User | undefined
+  await knex('users_composite')
+    .where((builder) =>
+      builder.whereIn('id', [1, 11, 15]).whereNotIn('id', [17, 19])
+    )
+    .andWhere(function() {
+      this.where('id', '>', 10);
+    })
+    .first();
+
   const values = [[1, 'a'], [2, 'b']] as const;
   const cols = ['id', 'name'] as const;
 
   // $ExpectType User[]
   await knex<User>('users')
+    .whereIn<"id" | "name">(cols, values);
+
+  // $ExpectType User[]
+  await knex('users_inferred')
+    .whereIn<"id" | "name">(cols, values);
+
+  // $ExpectType User[]
+  await knex('users_composite')
     .whereIn<"id" | "name">(cols, values);
 
   // $ExpectType User[]
@@ -792,7 +1523,27 @@ const main = async () => {
   await knex<User>('user').whereIn(col, idList);
 
   // $ExpectType User[]
+  await knex('users_inferred').whereIn(col, idList);
+
+  // $ExpectType User[]
+  await knex('users_composite').whereIn(col, idList);
+
+  // $ExpectType User[]
   await knex<User>('users').whereNotExists(function() {
+    this.select('*')
+      .from('accounts')
+      .whereRaw('users.account_id = accounts.id');
+  });
+
+  // $ExpectType User[]
+  await knex('users_inferred').whereNotExists(function() {
+    this.select('*')
+      .from('accounts')
+      .whereRaw('users.account_id = accounts.id');
+  });
+
+  // $ExpectType User[]
+  await knex('users_composite').whereNotExists(function() {
     this.select('*')
       .from('accounts')
       .whereRaw('users.account_id = accounts.id');
@@ -818,6 +1569,26 @@ const main = async () => {
     .union(function() {
       this.select('*')
         .from<User>('users')
+        .whereNull('first_name');
+    });
+
+  // $ExpectType User[]
+  await knex('users_inferred')
+    .select('*')
+    .whereNull('name')
+    .union(function() {
+      this.select('*')
+        .from('users_inferred')
+        .whereNull('first_name');
+    });
+
+  // $ExpectType User[]
+  await knex('users_composite')
+    .select('*')
+    .whereNull('name')
+    .union(function() {
+      this.select('*')
+        .from('users_composite')
         .whereNull('first_name');
     });
 
@@ -858,6 +1629,13 @@ const main = async () => {
     'departments_inferred.id'
   );
 
+  // $ExpectType (User & Department)[]
+  await knex('users_composite').innerJoin(
+    'departments_composite',
+    'users_composite.departmentid',
+    'departments_composite.id'
+  );
+
   // $ExpectType (User & Department & Article)[]
   await knex<User>('users')
     .innerJoin<Department>(
@@ -875,6 +1653,15 @@ const main = async () => {
       'departments_inferred.id'
     )
     .innerJoin('articles_inferred', 'articles_inferred.authorId', 'users_inferred.id');
+
+  // $ExpectType (User & Department & Article)[]
+  await knex('users_composite')
+    .innerJoin(
+      'departments_composite',
+      'users_composite.departmentid',
+      'departments_composite.id'
+    )
+    .innerJoin('articles_composite', 'articles_composite.authorId', 'users_composite.id');
 
   // $ExpectType any[]
   await knex<User>('users')
@@ -900,6 +1687,14 @@ const main = async () => {
     'users_inferred.departmentid',
     '=',
     'departments_inferred.id'
+  );
+
+  // $ExpectType (User & Department)[]
+  await knex('users_composite').innerJoin(
+    'departments_composite',
+    'users_composite.departmentid',
+    '=',
+    'departments_composite.id'
   );
 
   // $ExpectType { username: any; }[]
@@ -938,11 +1733,52 @@ const main = async () => {
     });
 
   // $ExpectType { username: string; }[]
+  (await knex('users_composite')
+    .innerJoin(
+      'departments_composite',
+      'users_composite.departmentid',
+      'departments_composite.id'
+    ))
+    .map(function(joined) {
+      return {
+        username: joined.name,
+      };
+    });
+
+  // $ExpectType { username: string; }[]
   (await knex<User>('users')
     .innerJoin<Department>(
       'departments',
       'users.departmentid',
       'departments.id'
+    )
+    .select('*'))
+    .map(function(joined) {
+      return {
+        username: joined.name,
+      };
+    });
+
+  // $ExpectType { username: string; }[]
+  (await knex('users_inferred')
+    .innerJoin(
+      'departments_inferred',
+      'users_inferred.departmentid',
+      'departments_inferred.id'
+    )
+    .select('*'))
+    .map(function(joined) {
+      return {
+        username: joined.name,
+      };
+    });
+
+  // $ExpectType { username: string; }[]
+  (await knex('users_composite')
+    .innerJoin<Department>(
+      'departments_composite',
+      'users_composite.departmentid',
+      'departments_composite.id'
     )
     .select('*'))
     .map(function(joined) {
@@ -966,11 +1802,67 @@ const main = async () => {
     });
 
   // $ExpectType { username: string; }[]
+  (await knex('users_inferred')
+    .innerJoin(
+      'departments_inferred',
+      'users_inferred.departmentid',
+      'departments_inferred.id'
+    )
+    .select())
+    .map(function(joined) {
+      return {
+        username: joined.name,
+      };
+    });
+
+  // $ExpectType { username: string; }[]
+  (await knex('users_composite')
+    .innerJoin(
+      'departments_composite',
+      'users_composite.departmentid',
+      'departments_composite.id'
+    )
+    .select())
+    .map(function(joined) {
+      return {
+        username: joined.name,
+      };
+    });
+
+  // $ExpectType { username: string; }[]
   (await knex<User>('users')
     .innerJoin<Department>(
       'departments',
       'users.departmentid',
       'departments.id'
+    )
+    .select('name', 'age'))
+    .map(function(joined) {
+      return {
+        username: joined.name,
+      };
+    });
+
+  // $ExpectType { username: string; }[]
+  (await knex('users_inferred')
+    .innerJoin(
+      'departments_inferred',
+      'users_inferred.departmentid',
+      'departments_inferred.id'
+    )
+    .select('name', 'age'))
+    .map(function(joined) {
+      return {
+        username: joined.name,
+      };
+    });
+
+  // $ExpectType { username: string; }[]
+  (await knex('users_composite')
+    .innerJoin(
+      'departments_composite',
+      'users_composite.departmentid',
+      'departments_composite.id'
     )
     .select('name', 'age'))
     .map(function(joined) {
@@ -993,6 +1885,34 @@ const main = async () => {
       };
     });
 
+  // $ExpectType { username: any; }[]
+  (await knex('users_inferred')
+    .innerJoin(
+      'departments_inferred',
+      'users_inferred.departmentid',
+      'departments_inferred.id'
+    )
+    .select('users_inferred.name', 'age'))
+    .map(function(joined) {
+      return {
+        username: joined.name,
+      };
+    });
+
+  // $ExpectType { username: any; }[]
+  (await knex('users_composite')
+    .innerJoin(
+      'departments_composite',
+      'users_composite.departmentid',
+      'departments_composite.id'
+    )
+    .select('users_composite.name', 'age'))
+    .map(function(joined) {
+      return {
+        username: joined.name,
+      };
+    });
+
   // $ExpectType (User & Department)[]
   await knex
     .select<(User & Department)[]>('users')
@@ -1006,6 +1926,11 @@ const main = async () => {
   // $ExpectType (User & Department)[]
   await knex('users_inferred').innerJoin('departments_inferred', function() {
     this.on('users_inferred.id', '=', 'departments_inferred.id');
+  });
+
+  // $ExpectType (User & Department)[]
+  await knex('users_composite').innerJoin('departments_composite', function() {
+    this.on('users_composite.id', '=', 'departments_composite.id');
   });
 
   // $ExpectType any[]
@@ -1039,6 +1964,17 @@ const main = async () => {
       });
     });
 
+  // $ExpectType (User & Department)[]
+  await knex
+    .select('*')
+    .from('users_composite')
+    .join('departments_composite', function() {
+      this.on(function() {
+        this.on('departments_composite.id', '=', 'users_composite.department_id');
+        this.orOn('departments_composite.owner_id', '=', 'users_composite.id');
+      });
+    });
+
   // # Insertion
 
   // $ExpectType number[]
@@ -1049,6 +1985,12 @@ const main = async () => {
 
   // $ExpectType number[]
   await knex('users_inferred').insert({ id: 10 });
+
+  // $ExpectError
+  await knex('users_composite').insert({ id: 10 });
+
+  // $ExpectType number[]
+  await knex('users_composite').insert({ insert: 'insert' });
 
   const qb2 = knex<User>('users');
   qb2.returning(['id', 'name']);
@@ -1086,6 +2028,11 @@ const main = async () => {
     .insert({ id: 10 })
     .returning('id');
 
+  // $ExpectType number[]
+  await knex('users_composite')
+    .insert({ insert: 'insert' })
+    .returning('id');
+
   // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users')
     .insert({ id: 10 })
@@ -1100,11 +2047,20 @@ const main = async () => {
   // $ExpectType User[]
   await knex('users_inferred').insert({ id: 10 }, '*');
 
+  // $ExpectError
+  await knex('users_composite').insert({ id: 10 }, '*');
+
+  // $ExpectType User[]
+  await knex('users_composite').insert({ insert: 'insert' }, '*');
+
   // $ExpectType number[]
   await knex.insert({ id: 10 }, 'id').into<User>('users');
 
   // $ExpectType number[]
   await knex.insert({ id: 10 }, 'id').into('users_inferred');
+
+  // $ExpectType number[]
+  await knex.insert({ insert: 'insert' }, 'id').into('users_composite');
 
   // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users')
@@ -1112,8 +2068,38 @@ const main = async () => {
     .returning(['id', 'age']);
 
   // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_inferred')
+    .insert({ id: 10 })
+    .returning(['id', 'age']);
+
+  await knex('users_composite')
+    // $ExpectError
+    .insert({ id: 10 })
+    .returning(['id', 'age']);
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_composite')
+    .insert({ insert: 'insert' })
+    .returning(['id', 'age']);
+
+  // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users')
     .insert({ id: 10 }, 'id')
+    .returning(['id', 'age']);
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_inferred')
+    .insert({ id: 10 }, 'id')
+    .returning(['id', 'age']);
+
+  await knex('users_composite')
+    // $ExpectError
+    .insert({ id: 10 }, 'id')
+    .returning(['id', 'age']);
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_composite')
+    .insert({ insert: 'insert' }, 'id')
     .returning(['id', 'age']);
 
   // $ExpectType any[]
@@ -1124,6 +2110,21 @@ const main = async () => {
   // $ExpectType User[]
   await knex<User>('users')
     .insert({id: 10})
+    .returning('*');
+
+  // $ExpectType User[]
+  await knex('users_inferred')
+    .insert({id: 10})
+    .returning('*');
+
+  await knex('users_composite')
+    // $ExpectError
+    .insert({id: 10})
+    .returning('*');
+
+  // $ExpectType User[]
+  await knex('users_composite')
+    .insert({insert: 'insert'})
     .returning('*');
 
   // $ExpectType any[]
@@ -1146,13 +2147,46 @@ const main = async () => {
 
   // $ExpectType User[]
   await knex
+    .insert({insert: 'insert'})
+    .into('users_composite')
+    .returning('*');
+
+  // $ExpectType User[]
+  await knex
     .insert({id: 10})
     .returning('*')
     .into<User>('users');
 
   // $ExpectType User[]
+  await knex
+    .insert({id: 10})
+    .returning('*')
+    .into('users_inferred');
+
+  // $ExpectType User[]
+  await knex
+    .insert({id: 10})
+    .returning('*')
+    .into('users_composite');
+
+  // $ExpectType User[]
   await knex<User>('users')
     .insert({id: 10}, 'id')
+    .returning('*');
+
+  // $ExpectType User[]
+  await knex('users_inferred')
+    .insert({id: 10}, 'id')
+    .returning('*');
+
+  await knex('users_composite')
+    // $ExpectError
+    .insert({id: 10}, 'id')
+    .returning('*');
+
+  // $ExpectType User[]
+  await knex('users_composite')
+    .insert({insert: 'insert'}, 'id')
     .returning('*');
 
   // $ExpectType Pick<User, "id" | "age">[]
@@ -1160,6 +2194,18 @@ const main = async () => {
     .insert({ id: 10 })
     .returning(['id', 'age'])
     .into<User>('users');
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex
+    .insert({ id: 10 })
+    .returning(['id', 'age'])
+    .into('users_inferred');
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex
+    .insert({ id: 10 })
+    .returning(['id', 'age'])
+    .into('users_composite');
 
   // $ExpectType any[]
   await knex('users')
@@ -1182,6 +2228,16 @@ const main = async () => {
   await knex<User>('users')
     .where('id', 10)
     .update({ active: true });
+
+  // $ExpectType number
+  await knex('users_inferred')
+    .where('id', 10)
+    .update({ active: true });
+
+  // $ExpectType number
+  await knex('users_composite')
+    .where('id', 10)
+    .update({ update: 'update' });
 
   // $ExpectType number
   await knex
@@ -1209,6 +2265,18 @@ const main = async () => {
     .update({ active: true })
     .returning('*');
 
+  // $ExpectType User[]
+  await knex('users_inferred')
+    .where('id', 10)
+    .update({ active: true })
+    .returning('*');
+
+  // $ExpectType User[]
+  await knex('users_composite')
+    .where('id', 10)
+    .update({ update: 'update' })
+    .returning('*');
+
   // $ExpectType any[]
   await knex
     .where('id', 10)
@@ -1223,10 +2291,36 @@ const main = async () => {
     .returning('*')
     .from<User>('users');
 
+  // $ExpectType User[]
+  await knex
+    .where('id', 10)
+    .update({ active: true })
+    .returning('*')
+    .from('users_inferred');
+
+  // $ExpectType User[]
+  await knex
+    .where('id', 10)
+    .update({ update: 'update' })
+    .returning('*')
+    .from('users_composite');
+
   // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users')
     .where('id', 10)
     .update({ active: true })
+    .returning(['id', 'age']);
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_inferred')
+    .where('id', 10)
+    .update({ active: true })
+    .returning(['id', 'age']);
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_composite')
+    .where('id', 10)
+    .update({ update: 'update' })
     .returning(['id', 'age']);
 
   // $ExpectType number[]
@@ -1235,9 +2329,29 @@ const main = async () => {
     .update({ active: true }, 'id');
 
   // $ExpectType number[]
+  await knex('users_inferred')
+    .where('id', 10)
+    .update({ active: true }, 'id');
+
+  // $ExpectType number[]
+  await knex('users_composite')
+    .where('id', 10)
+    .update({ update: 'update' }, 'id');
+
+  // $ExpectType number[]
   await knex<User>('users')
     .where('id', 10)
     .update('active', true, 'id');
+
+  // $ExpectType number[]
+  await knex('users_inferred')
+    .where('id', 10)
+    .update('active', true, 'id');
+
+  // $ExpectType number[]
+  await knex('users_composite')
+    .where('id', 10)
+    .update('update', 'update', 'id');
 
   // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users')
@@ -1245,9 +2359,29 @@ const main = async () => {
     .update({ active: true }, ['id', 'age']);
 
   // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_inferred')
+    .where('id', 10)
+    .update({ active: true }, ['id', 'age']);
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_composite')
+    .where('id', 10)
+    .update({ update: 'update' }, ['id', 'age']);
+
+  // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users')
     .where('id', 10)
     .update('active', true, ['id', 'age']);
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_inferred')
+    .where('id', 10)
+    .update('active', true, ['id', 'age']);
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_composite')
+    .where('id', 10)
+    .update('update', 'update', ['id', 'age']);
 
   const userUpdateReturnCols = ['id', 'age'] as const;
   // $ExpectType Pick<User, "id" | "age">[]
@@ -1255,12 +2389,34 @@ const main = async () => {
     .where('id', 10)
     .update({ active: true }, userUpdateReturnCols);
 
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_inferred')
+    .where('id', 10)
+    .update({ active: true }, userUpdateReturnCols);
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex('users_composite')
+    .where('id', 10)
+    .update({ update: 'update' }, userUpdateReturnCols);
+
   // TODO: .update('active', true', ['id', 'age']) does not works correctly
   // $ExpectType Pick<User, "id" | "age">[]
   await knex
     .where('id', 10)
     .update({ active: true }, ['id', 'age'])
     .into<User>('users');
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex
+    .where('id', 10)
+    .update({ active: true }, ['id', 'age'])
+    .into('users_inferred');
+
+  // $ExpectType Pick<User, "id" | "age">[]
+  await knex
+    .where('id', 10)
+    .update({ update: 'update' }, ['id', 'age'])
+    .into('users_composite');
 
   // # Deletion
 
@@ -1270,12 +2426,42 @@ const main = async () => {
     .delete();
 
   // $ExpectType number
+  await knex('users_inferred')
+    .where('id', 10)
+    .delete();
+
+  // $ExpectType number
+  await knex('users_composite')
+    .where('id', 10)
+    .delete();
+
+  // $ExpectType number
   await knex<User>('users')
+    .where('id', 10)
+    .del();
+
+  // $ExpectType number
+  await knex('users_inferred')
+    .where('id', 10)
+    .del();
+
+  // $ExpectType number
+  await knex('users_composite')
     .where('id', 10)
     .del();
 
   // $ExpectType number[]
   await knex<User>('users')
+    .where('id', 10)
+    .delete('id');
+
+  // $ExpectType number[]
+  await knex('users_inferred')
+    .where('id', 10)
+    .delete('id');
+
+  // $ExpectType number[]
+  await knex('users_composite')
     .where('id', 10)
     .delete('id');
 
@@ -1298,7 +2484,31 @@ const main = async () => {
     .returning('*');
 
   // $ExpectType User[]
+  await knex('users_inferred')
+    .where('id', 10)
+    .del()
+    .returning('*');
+
+  // $ExpectType User[]
+  await knex('users_composite')
+    .where('id', 10)
+    .del()
+    .returning('*');
+
+  // $ExpectType User[]
   await knex<User>('users')
+    .where('id', 10)
+    .delete()
+    .returning('*');
+
+  // $ExpectType User[]
+  await knex('users_inferred')
+    .where('id', 10)
+    .delete()
+    .returning('*');
+
+  // $ExpectType User[]
+  await knex('users_composite')
     .where('id', 10)
     .delete()
     .returning('*');
@@ -1313,9 +2523,37 @@ const main = async () => {
   // $ExpectType User[]
   await knex
     .where('id', 10)
+    .del()
+    .returning('*')
+    .from('users_inferred');
+
+  // $ExpectType User[]
+  await knex
+    .where('id', 10)
+    .del()
+    .returning('*')
+    .from('users_composite');
+
+  // $ExpectType User[]
+  await knex
+    .where('id', 10)
     .delete()
     .returning('*')
     .from<User>('users');
+
+  // $ExpectType User[]
+  await knex
+    .where('id', 10)
+    .delete()
+    .returning('*')
+    .from('users_inferred');
+
+  // $ExpectType User[]
+  await knex
+    .where('id', 10)
+    .delete()
+    .returning('*')
+    .from('users_composite');
 
   // $ExpectType number[]
   await knex
@@ -1323,8 +2561,26 @@ const main = async () => {
     .delete('id')
     .from<User>('users');
 
+  // $ExpectType number[]
+  await knex
+    .where('id', 10)
+    .delete('id')
+    .from('users_inferred');
+
+  // $ExpectType number[]
+  await knex
+    .where('id', 10)
+    .delete('id')
+    .from('users_composite');
+
   // $ExpectType void
   await knex<User>('users').truncate();
+
+  // $ExpectType void
+  await knex('users_inferred').truncate();
+
+  // $ExpectType void
+  await knex('users_composite').truncate();
 
   // $ExpectType void
   await knex('users').truncate();
@@ -1336,6 +2592,12 @@ const main = async () => {
 
   // $ExpectType ColumnInfo
   await knex<User>('users').columnInfo();
+
+  // $ExpectType ColumnInfo
+  await knex('users_inferred').columnInfo();
+
+  // $ExpectType ColumnInfo
+  await knex('users_composite').columnInfo();
 
   // # Modify:
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -1989,6 +1989,9 @@ const main = async () => {
   // $ExpectError
   await knex('users_composite').insert({ id: 10 });
 
+  // $ExpectError
+  await knex('users_composite').insert({});
+
   // $ExpectType number[]
   await knex('users_composite').insert({ insert: 'insert' });
 
@@ -2033,6 +2036,17 @@ const main = async () => {
     .insert({ insert: 'insert' })
     .returning('id');
 
+  await knex('users_composite')
+    // $ExpectError
+    .insert({ id: 10 })
+    .returning('id');
+
+  // Require insert argument to satisfy "insert" interface fully when composite type is available.
+  await knex('users_composite')
+    // $ExpectError
+    .insert({})
+    .returning('id');
+
   // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users')
     .insert({ id: 10 })
@@ -2049,6 +2063,9 @@ const main = async () => {
 
   // $ExpectError
   await knex('users_composite').insert({ id: 10 }, '*');
+
+  // $ExpectError
+  await knex('users_composite').insert({}, '*');
 
   // $ExpectType User[]
   await knex('users_composite').insert({ insert: 'insert' }, '*');
@@ -2077,6 +2094,11 @@ const main = async () => {
     .insert({ id: 10 })
     .returning(['id', 'age']);
 
+  await knex('users_composite')
+    // $ExpectError
+    .insert({})
+    .returning(['id', 'age']);
+
   // $ExpectType Pick<User, "id" | "age">[]
   await knex('users_composite')
     .insert({ insert: 'insert' })
@@ -2095,6 +2117,11 @@ const main = async () => {
   await knex('users_composite')
     // $ExpectError
     .insert({ id: 10 }, 'id')
+    .returning(['id', 'age']);
+
+  await knex('users_composite')
+    // $ExpectError
+    .insert({}, 'id')
     .returning(['id', 'age']);
 
   // $ExpectType Pick<User, "id" | "age">[]
@@ -2120,6 +2147,11 @@ const main = async () => {
   await knex('users_composite')
     // $ExpectError
     .insert({id: 10})
+    .returning('*');
+
+  await knex('users_composite')
+    // $ExpectError
+    .insert({})
     .returning('*');
 
   // $ExpectType User[]
@@ -2184,6 +2216,11 @@ const main = async () => {
     .insert({id: 10}, 'id')
     .returning('*');
 
+  await knex('users_composite')
+    // $ExpectError
+    .insert({}, 'id')
+    .returning('*');
+
   // $ExpectType User[]
   await knex('users_composite')
     .insert({insert: 'insert'}, 'id')
@@ -2239,6 +2276,14 @@ const main = async () => {
     .where('id', 10)
     .update({ update: 'update' });
 
+  await knex('users_composite')
+    // $ExpectError
+    .update({ id: 10 });
+
+  await knex('users_composite')
+    // $ExpectError
+    .update({});
+
   // $ExpectType number
   await knex
     .where('id', 10)
@@ -2269,6 +2314,13 @@ const main = async () => {
   await knex('users_inferred')
     .where('id', 10)
     .update({ active: true })
+    .returning('*');
+
+  // $ExpectType User[]
+  await knex('users_composite')
+    .where('id', 10)
+    // $ExpectError
+    .update({})
     .returning('*');
 
   // $ExpectType User[]
@@ -2323,6 +2375,18 @@ const main = async () => {
     .update({ update: 'update' })
     .returning(['id', 'age']);
 
+  await knex('users_composite')
+    .where('id', 10)
+    // $ExpectError
+    .update({ id: 11 })
+    .returning(['id', 'age']);
+
+  await knex('users_composite')
+    .where('id', 10)
+    // $ExpectError
+    .update({})
+    .returning(['id', 'age']);
+
   // $ExpectType number[]
   await knex<User>('users')
     .where('id', 10)
@@ -2337,6 +2401,16 @@ const main = async () => {
   await knex('users_composite')
     .where('id', 10)
     .update({ update: 'update' }, 'id');
+
+  await knex('users_composite')
+    .where('id', 10)
+    // $ExpectError
+    .update({ id: 11 }, 'id');
+
+  await knex('users_composite')
+    .where('id', 10)
+    // $ExpectError
+    .update({}, 'id');
 
   // $ExpectType number[]
   await knex<User>('users')
@@ -2368,6 +2442,16 @@ const main = async () => {
     .where('id', 10)
     .update({ update: 'update' }, ['id', 'age']);
 
+  await knex('users_composite')
+    .where('id', 10)
+    // $ExpectError
+    .update({ id: 11 }, ['id', 'age']);
+
+  await knex('users_composite')
+    .where('id', 10)
+    // $ExpectError
+    .update({}, ['id', 'age']);
+
   // $ExpectType Pick<User, "id" | "age">[]
   await knex<User>('users')
     .where('id', 10)
@@ -2398,6 +2482,16 @@ const main = async () => {
   await knex('users_composite')
     .where('id', 10)
     .update({ update: 'update' }, userUpdateReturnCols);
+
+  await knex('users_composite')
+    .where('id', 10)
+    // $ExpectError
+    .update({ id: 11 }, userUpdateReturnCols);
+
+  await knex('users_composite')
+    .where('id', 10)
+    // $ExpectError
+    .update({}, userUpdateReturnCols);
 
   // TODO: .update('active', true', ['id', 'age']) does not works correctly
   // $ExpectType Pick<User, "id" | "age">[]

--- a/types/test.ts
+++ b/types/test.ts
@@ -2519,10 +2519,8 @@ const main = async () => {
     .onConflict('id')
     .merge({ active: true })
     .returning('*');
-    
-    
-  // # Deletion
 
+  // # Deletion
   // $ExpectType number
   await knex<User>('users')
     .where('id', 10)


### PR DESCRIPTION
For most use-cases, this would allow to globally define table/record mapping globally once and get all the benefits of static typing without always specifying Records manually.
This is opt-in as it will fall back to old behaviour if Tables interfaces is not extended and it supports all old use-cases.

Opening as a draft for further discussion and improvements.