### PR TITLE
Fixes issue where mssql incorrectly strips off apostrophe characters from identifiers

### DIFF
--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -212,7 +212,7 @@ Object.assign(Client_MSSQL.prototype, {
       return '*';
     }
 
-    return `[${value.replace(/[[\]']+/g, '')}]`;
+    return `[${value.replace(/[[\]]+/g, '')}]`;
   },
 
   // Get a raw connection, called by the `pool` whenever a new

--- a/test/unit/dialects/mssql.js
+++ b/test/unit/dialects/mssql.js
@@ -30,4 +30,13 @@ describe('MSSQL unit tests', () => {
       'select * from [projects] where [id" = 1 UNION SELECT 1, @@version -- --] = ?'
     );
   });
+
+  it("should escape statements with ' correctly", async () => {
+    const sql = knexInstance('projects')
+      .where("id]' = 1 UNION SELECT 1, @@version -- --", 1)
+      .toSQL();
+    expect(sql.sql).to.equal(
+      "select * from [projects] where [id' = 1 UNION SELECT 1, @@version -- --] = ?"
+    );
+  });
 });


### PR DESCRIPTION
@smorey2 [mssql]
We have a column, "NA'ME" that we use for testing to ensure ids are escaped properly.  After upgrading from knex 0.15.2 to 0.21.6, our tests started to fail with an error that the column "NAME" does not exist.  I tracked it down to the mssql dialect is incorrectly stripping out the apostrophe (') character.  This [change](https://github.com/knex/knex/pull/3382/files#diff-4dc449e5e91be857a09660e3069a0f899640116d6b53d30bda039673944cfb3bR214) seems to have included a superfluous apostrophe.  The code should wrap identifiers in [brackets].

If all is good, please kindly tag the PR as "hacktoberfest-accepted" for credit towards [hacktoberfest](https://hacktoberfest.digitalocean.com/faq).