### PR TITLE
change .map to .forEach

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ knex.schema
       .select('users.user_name as user', 'accounts.account_name as account')
   )
 
-  // map over the results
+  // Display the results
   .then(rows =>
-    rows.map(row => {
+    rows.forEach(row => {
       console.log(row)
     })
   )


### PR DESCRIPTION
It doesn't make sense to use .map here; this allocates and produces an array of `undefined` (the return value of `console.log`) only to be tossed to the garbage collector. Better to use `forEach` if no modifications are applied to the array elements and the intent is to produce a side effect (logging).