### PR TITLE
fix help text being printed twice (#4072)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -352,10 +352,6 @@ function invoke(env) {
         .catch(exit);
     });
 
-  if (!process.argv.slice(2).length) {
-    commander.outputHelp();
-  }
-
   commander.parse(process.argv);
 }
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-subset-in-order": "^2.1.4",
-    "cli-testlab": "^2.0.0",
+    "cli-testlab": "^2.1.1",
     "coveralls": "^3.1.0",
     "cross-env": "^7.0.2",
     "dtslint": "3.6.14",

--- a/test/cli/esm-interop.spec.js
+++ b/test/cli/esm-interop.spec.js
@@ -43,7 +43,6 @@ const fixture = [
     testCase: 'knexfile-esm-module',
     knexArgs: ['migrate:latest'],
     dropDb: true,
-    expectedOutput: 'Batch 1 run: 1 migrations',
     expectedErrorMessage: isNode10
       ? 'Unexpected token export'
       : 'Must use import to load ES Module',

--- a/test/cli/help.spec.js
+++ b/test/cli/help.spec.js
@@ -8,20 +8,20 @@ const KNEX = path.normalize(__dirname + '/../../bin/cli.js');
 describe('help', () => {
   it('Prints help', () => {
     return execCommand(`node ${KNEX} --help`, {
-      expectedOutput: 'Usage',
+      expectedOutput: { expectedText: 'Usage', exactlyTimes: 1 },
     });
   });
 
   it('Prints help using -h flag', () => {
     return execCommand(`node ${KNEX} -h`, {
-      expectedOutput: 'Usage',
+      expectedOutput: { expectedText: 'Usage', exactlyTimes: 1 },
     });
   });
 
   it('Prints help when no arguments are given', () => {
     return execCommand(`node ${KNEX}`, {
       expectedErrorMessage: 'Process exited with error',
-      expectedOutput: 'Usage',
+      expectedOutput: { expectedText: 'Usage', exactlyTimes: 1 },
     });
   });
 


### PR DESCRIPTION
When the cli is called without arguments it prints the help text twice. This pull request makes it print it only once. See issue #4072 