### PR TITLE
Remove redundant async in tests

### DIFF
--- a/types/test.ts
+++ b/types/test.ts
@@ -1262,12 +1262,12 @@ const main = async () => {
   // Transactions:
 
   // $ExpectType any[]
-  await knex.transaction(async (trx) => {
+  await knex.transaction((trx) => {
     return trx.insert({ name: 'Old Books' }, 'id').into('articles');
   });
 
   // $ExpectType Pick<Article, "id" | "subject">[]
-  await knex.transaction(async (trx) => {
+  await knex.transaction((trx) => {
     const articles: Article[] = [
       { id: 1, subject: 'Canterbury Tales' },
       { id: 2, subject: 'Moby Dick' },
@@ -1280,7 +1280,7 @@ const main = async () => {
   });
 
   // $ExpectType Pick<Article, "id" | "subject">[]
-  await knex.transaction(async (trx) => {
+  await knex.transaction((trx) => {
     const articles = [
       { id: 1, subject: 'Canterbury Tales' },
       { id: 2, subject: 'Moby Dick' },


### PR DESCRIPTION
This fixes the issue that was causing tests to fail although I'm not sure what's the actual cause. Might be a TypeScript error. The `async` in this case was redundant anyway. And it also works if we do
```
  await knex.transaction((trx) => {
    const result = await trx.insert({ name: 'Old Books' }, 'id').into('articles');
    return result
});
```
Anyway, this should fix test errors for now without losing any safety of tests.