### PR TITLE
Types: Make .ignore() and .merge() return QueryBuilder rather than QueryInterface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -422,8 +422,8 @@ declare namespace Knex {
   type DbRecordArr<TRecord> = Readonly<MaybeArray<DbRecord<TRecord>>>;
 
   interface OnConflictQueryBuilder<TRecord, TResult> {
-    ignore(): QueryInterface<TRecord, TResult>;
-    merge(data?: DbRecord<TRecord>): QueryInterface<TRecord, TResult>;
+    ignore(): QueryBuilder<TRecord, TResult>;
+    merge(data?: DbRecord<TRecord>): QueryBuilder<TRecord, TResult>;
   }
 
   //

--- a/types/test.ts
+++ b/types/test.ts
@@ -1169,6 +1169,16 @@ const main = async () => {
     .merge({ active: true })
     .returning('*');
 
+  // # Regression test (https://github.com/knex/knex/issues/4101)
+  // # Ensure that .debug() can be called on a query containing an onConflict clause.
+  await knex
+    .table<User>('users')
+    .insert({ id: 10, active: true })
+    .onConflict('id')
+    .merge({ active: true })
+    .debug(true);
+
+
   // # Deletion
 
   // $ExpectType number

--- a/types/test.ts
+++ b/types/test.ts
@@ -1178,9 +1178,7 @@ const main = async () => {
     .merge({ active: true })
     .debug(true);
 
-
   // # Deletion
-
   // $ExpectType number
   await knex<User>('users')
     .where('id', 10)


### PR DESCRIPTION
Fixes part (2) from https://github.com/knex/knex/issues/4101