### PR TITLE
Add a few missing types for MSSQL Connection

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1840,6 +1840,10 @@ declare namespace Knex {
       abortTransactionOnError?: boolean;
       trustedConnection?: boolean;
       enableArithAbort?: boolean;
+      isolationLevel?: 'READ_UNCOMMITTED' | 'READ_COMMITTED' | 'REPEATABLE_READ' | 'SERIALIZABLE' | 'SNAPSHOT';
+      maxRetriesOnTransientErrors?: number;
+      multiSubnetFailover?: boolean;
+      packetSize?: number;
     }>;
     pool?: Readonly<{
       min?: number;


### PR DESCRIPTION
Added the following options for MsSqlConnectionConfig TS interface

- isolationLevel
- maxRetriesOnTransientErrors
- multiSubnetFailover
- packetSize

These are documented in the [Tedious driver docs](https://tediousjs.github.io/tedious/api-connection.html)

I personally want to use `multiSubnetFailover` and `packetSize` for a production deployment we recently migrated from Flow