### PR TITLE
Add types for userParams and withUserParams

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -370,6 +370,8 @@ interface Knex<TRecord extends {} = any, TResult = unknown[]>
   seed: Knex.Seeder;
   fn: Knex.FunctionHelper;
   ref: Knex.RefBuilder;
+  userParams: Record<string, any>;
+  withUserParams(params: Record<string, any>): Knex;
 }
 
 declare function Knex<TRecord extends {} = any, TResult = unknown[]>(


### PR DESCRIPTION
Add types to index.d.ts for missing `knex.userParams` param and `knex.withUserParams({})` method, as suggested in issue: https://github.com/knex/knex/issues/3962

The types are pretty open as looking at the source there don't seem to be any restrictions on what the user can pass, so long as it's a literal object, the values can be anything.