### PR TITLE
Drop liftoff

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,10 @@
 ## Upgrading to new knex.js versions
 
+### Upgrading to version 0.22.0+
+
+* v8 flags are no longer supported in cli. To pass these flags use [`NODE_OPTIONS` environment variable](https://nodejs.org/api/cli.html#cli_node_options_options).
+  For example `NODE_OPTIONS="--max-old-space-size=1536" npm run knex`
+
 ### Upgrading to version 0.21.0+
 
 * Node.js older than 10 is no longer supported, make sure to update your environment; 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,7 +2,6 @@
 const rechoir = require('rechoir');
 const interpret = require('interpret');
 const resolveFrom = require('resolve-from');
-const escalade = require('escalade/sync');
 const path = require('path');
 const tildify = require('tildify');
 const commander = require('commander');
@@ -18,6 +17,8 @@ const {
   getMigrationExtension,
   getSeedExtension,
   getStubPath,
+  findUpModulePath,
+  findUpConfig,
 } = require('./utils/cli-config-utils');
 const { existsSync, readFile, writeFile } = require('./../lib/util/fs');
 
@@ -56,36 +57,6 @@ async function initKnex(env, opts) {
   );
   const knex = require(env.modulePath);
   return knex(resolvedConfig);
-}
-
-function findUpModulePath(cwd, packageName) {
-  const modulePackagePath = escalade(cwd, (dir, names) => {
-    if (names.includes('package.json')) {
-      return 'package.json';
-    }
-    return false;
-  });
-  try {
-    const modulePackage = require(modulePackagePath);
-    if (modulePackage.name === packageName) {
-      return path.join(
-        path.dirname(modulePackagePath),
-        modulePackage.main || 'index.js'
-      );
-    }
-  } catch (e) {}
-}
-
-function findUpConfig(cwd, name, extensions) {
-  return escalade(cwd, (dir, names) => {
-    for (const ext of extensions) {
-      const filename = `${name}.${ext}`;
-      if (names.includes(filename)) {
-        return filename;
-      }
-    }
-    return false;
-  });
 }
 
 function invoke() {

--- a/bin/utils/cli-config-utils.js
+++ b/bin/utils/cli-config-utils.js
@@ -2,6 +2,7 @@ const { DEFAULT_EXT, DEFAULT_TABLE_NAME } = require('./constants');
 const { resolveClientNameWithAliases } = require('../../lib/helpers');
 const fs = require('fs');
 const path = require('path');
+const escalade = require('escalade/sync');
 const tildify = require('tildify');
 const color = require('colorette');
 const argv = require('getopts')(process.argv.slice(2));
@@ -139,6 +140,36 @@ function getStubPath(configKey, env, opts) {
   return path.join(stubDirectory, stub);
 }
 
+function findUpModulePath(cwd, packageName) {
+  const modulePackagePath = escalade(cwd, (dir, names) => {
+    if (names.includes('package.json')) {
+      return 'package.json';
+    }
+    return false;
+  });
+  try {
+    const modulePackage = require(modulePackagePath);
+    if (modulePackage.name === packageName) {
+      return path.join(
+        path.dirname(modulePackagePath),
+        modulePackage.main || 'index.js'
+      );
+    }
+  } catch (e) {}
+}
+
+function findUpConfig(cwd, name, extensions) {
+  return escalade(cwd, (dir, names) => {
+    for (const ext of extensions) {
+      const filename = `${name}.${ext}`;
+      if (names.includes(filename)) {
+        return filename;
+      }
+    }
+    return false;
+  });
+}
+
 module.exports = {
   mkConfigObj,
   resolveEnvironmentConfig,
@@ -148,4 +179,6 @@ module.exports = {
   getSeedExtension,
   getMigrationExtension,
   getStubPath,
+  findUpModulePath,
+  findUpConfig,
 };

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -11,6 +11,15 @@ const writeFile = promisify(fs.writeFile);
 const readdir = promisify(fs.readdir);
 const mkdir = promisify(fs.mkdir);
 
+function existsSync(path) {
+  try {
+    fs.accessSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Creates a temporary directory and returns it path.
  *
@@ -66,6 +75,7 @@ async function getFilepathsInFolder(dir, recursive = false) {
 }
 
 module.exports = {
+  existsSync,
   stat,
   readdir,
   readFile,

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -15,7 +15,7 @@ function existsSync(path) {
   try {
     fs.accessSync(path);
     return true;
-  } catch {
+  } catch (e) {
     return false;
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,15 +42,16 @@
     "colorette": "1.2.1",
     "commander": "^6.2.0",
     "debug": "4.3.1",
+    "escalade": "^3.1.1",
     "esm": "^3.2.25",
     "getopts": "2.2.5",
     "interpret": "^2.2.0",
-    "liftoff": "3.1.0",
     "lodash": "^4.17.20",
     "pg-connection-string": "2.4.0",
+    "rechoir": "^0.7.0",
+    "resolve-from": "^5.0.0",
     "tarn": "^3.0.1",
-    "tildify": "2.0.0",
-    "v8flags": "^3.2.0"
+    "tildify": "2.0.0"
   },
   "peerDependencies": {
     "mssql": "^6.2.1",


### PR DESCRIPTION
Liftoff has very poor support and a lot of legacy dependencies.
The package takes half of knex size.
https://packagephobia.com/result?p=liftoff
https://packagephobia.com/result?p=knex

The package is not abandoned though there are no clear deadlines.
https://github.com/js-cli/js-liftoff/pull/114

I also found most liftoff features are not used by knex and in some
cases the usage is wrong.

For example I found `--knexpath` is not used at all. It's consumed
from liftoff's env.knexpath which is always undefined.

I reimplemented all resolutions with a few small utilities like escalade
and resolve-from.

v8flags and flagged-respawn looks like black magic so I suggest to
recommend using `NODE_OPTIONS="...flags..." npm run knex` instead.

For config transpilation still used interpret and rechoir which is used
in liftoff internally.