### PR TITLE
Replaced debug and console with anylogger

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-/* eslint no-console:0, no-var:0 */
+/* eslint no-var:0 */
+const log = require('anylogger')('knex:cli');
 const Liftoff = require('liftoff');
 const interpret = require('interpret');
 const path = require('path');
@@ -38,10 +39,7 @@ async function initKnex(env, opts) {
   checkLocalModule(env);
   if (process.cwd() !== env.cwd) {
     process.chdir(env.cwd);
-    console.log(
-      'Working directory changed to',
-      color.magenta(tildify(env.cwd))
-    );
+    log.log('Working directory changed to', color.magenta(tildify(env.cwd)));
   }
 
   env.configuration = env.configPath
@@ -363,11 +361,11 @@ const cli = new Liftoff({
 });
 
 cli.on('require', function (name) {
-  console.log('Requiring external module', color.magenta(name));
+  log.log('Requiring external module', color.magenta(name));
 });
 
 cli.on('requireFail', function (name) {
-  console.log(color.red('Failed to load external module'), color.magenta(name));
+  log.log(color.red('Failed to load external module'), color.magenta(name));
 });
 
 // FYI: The handling for the `--cwd` and `--knexfile` arguments is a bit strange,

--- a/bin/utils/cli-config-utils.js
+++ b/bin/utils/cli-config-utils.js
@@ -1,3 +1,4 @@
+const log = require('anylogger')('knex:cli');
 const { DEFAULT_EXT, DEFAULT_TABLE_NAME } = require('./constants');
 const { resolveClientNameWithAliases } = require('../../lib/helpers');
 const fs = require('fs');
@@ -35,11 +36,11 @@ function resolveEnvironmentConfig(opts, allConfigs, configFilePath) {
   const result = allConfigs[environment] || allConfigs;
 
   if (allConfigs[environment]) {
-    console.log('Using environment:', color.magenta(environment));
+    log.log('Using environment:', color.magenta(environment));
   }
 
   if (!result) {
-    console.log(color.red('Warning: unable to read knexfile config'));
+    log.log(color.red('Warning: unable to read knexfile config'));
     process.exit(1);
   }
 
@@ -58,23 +59,23 @@ function resolveEnvironmentConfig(opts, allConfigs, configFilePath) {
 
 function exit(text) {
   if (text instanceof Error) {
-    console.error(
+    log.error(
       color.red(`${text.detail ? `${text.detail}\n` : ''}${text.stack}`)
     );
   } else {
-    console.error(color.red(text));
+    log.error(color.red(text));
   }
   process.exit(1);
 }
 
 function success(text) {
-  console.log(text);
+  log.log(text);
   process.exit(0);
 }
 
 function checkLocalModule(env) {
   if (!env.modulePath) {
-    console.log(
+    log.log(
       color.red('No local knex install found in:'),
       color.magenta(tildify(env.cwd))
     );
@@ -132,7 +133,7 @@ function getStubPath(configKey, env, opts) {
 
   // using stub <name> must have config[configKey].directory defined
   if (!stubDirectory) {
-    console.log(color.red('Failed to load stub'), color.magenta(stub));
+    log.log(color.red('Failed to load stub'), color.magenta(stub));
     exit(`config.${configKey}.directory in knexfile must be defined`);
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -26,9 +26,9 @@ const uniqueId = require('lodash/uniqueId');
 const Logger = require('./logger');
 const { KnexTimeoutError } = require('./util/timeout');
 
-const debug = require('debug')('knex:client');
-const _debugQuery = require('debug')('knex:query');
-const debugBindings = require('debug')('knex:bindings');
+const debug = require('anylogger')('knex:client');
+const _debugQuery = require('anylogger')('knex:query');
+const debugBindings = require('anylogger')('knex:bindings');
 
 const debugQuery = (sql, txId) => _debugQuery(sql.replace(/%/g, '%%'), txId);
 

--- a/lib/dialects/mssql/transaction.js
+++ b/lib/dialects/mssql/transaction.js
@@ -1,7 +1,9 @@
 const Transaction = require('../../transaction');
-const debug = require('debug')('knex:tx');
+const debug = require('anylogger')('knex:tx');
 
-module.exports = class Transaction_MSSQL extends Transaction {
+module.exports = class Transaction_MSSQL extends (
+  Transaction
+) {
   begin(conn) {
     debug('%s: begin', this.txid);
     return conn.tx_.begin().then(this._resolver, this._rejecter);

--- a/lib/dialects/mysql/transaction.js
+++ b/lib/dialects/mysql/transaction.js
@@ -1,5 +1,5 @@
 const Transaction = require('../../transaction');
-const Debug = require('debug');
+const Debug = require('anylogger');
 
 const debug = Debug('knex:tx');
 

--- a/lib/dialects/mysql2/transaction.js
+++ b/lib/dialects/mysql2/transaction.js
@@ -1,5 +1,5 @@
 const Transaction = require('../../transaction');
-const debug = require('debug')('knex:tx');
+const debug = require('anylogger')('knex:tx');
 
 class Transaction_MySQL2 extends Transaction {}
 

--- a/lib/dialects/oracledb/transaction.js
+++ b/lib/dialects/oracledb/transaction.js
@@ -1,8 +1,10 @@
 const Transaction = require('../../transaction');
 const { timeout, KnexTimeoutError } = require('../../util/timeout');
-const debugTx = require('debug')('knex:tx');
+const debugTx = require('anylogger')('knex:tx');
 
-module.exports = class Oracle_Transaction extends Transaction {
+module.exports = class Oracle_Transaction extends (
+  Transaction
+) {
   // disable autocommit to allow correct behavior (default is true)
   begin() {
     return Promise.resolve();

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,3 @@
-/* eslint no-console:0 */
-
 const isPlainObject = require('lodash/isPlainObject');
 const isTypedArray = require('lodash/isTypedArray');
 const { CLIENT_ALIASES } = require('./constants');

--- a/lib/knex.js
+++ b/lib/knex.js
@@ -1,3 +1,4 @@
+const log = require('anylogger')('knex');
 const Raw = require('./raw');
 const Client = require('./client');
 const QueryBuilder = require('./query/builder');
@@ -69,12 +70,10 @@ Knex.QueryBuilder = {
   },
 };
 
-/* eslint no-console:0 */
-
 // Run a "raw" query, though we can't do anything with it other than put
 // it in a query statement.
 Knex.raw = (sql, bindings) => {
-  console.warn(
+  log.warn(
     'global Knex.raw is deprecated, use knex.raw (chain off an initialized knex object)'
   );
   return new Raw(fakeClient).set(sql, bindings);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,4 @@
-/* eslint no-console:0 */
+const log = require('anylogger')('knex:log');
 
 const color = require('colorette');
 const { inspect } = require('util');
@@ -24,7 +24,7 @@ class Logger {
     this._deprecate = deprecate;
   }
 
-  _log(message, userFn, colorFn) {
+  _log(level, message, userFn, colorFn) {
     if (userFn != null && !isFunction(userFn)) {
       throw new TypeError('Extensions to knex logger must be functions!');
     }
@@ -41,25 +41,25 @@ class Logger {
       });
     }
 
-    console.log(colorFn ? colorFn(message) : message);
+    log[level](colorFn ? colorFn(message) : message);
   }
 
   debug(message) {
-    this._log(message, this._debug);
+    this._log('debug', message, this._debug);
   }
 
   warn(message) {
-    this._log(message, this._warn, color.yellow);
+    this._log('warn', message, this._warn, color.yellow);
   }
 
   error(message) {
-    this._log(message, this._error, color.red);
+    this._log('error', message, this._error, color.red);
   }
 
   deprecate(method, alternative) {
     const message = `${method} is deprecated, please use ${alternative}`;
 
-    this._log(message, this._deprecate, color.yellow);
+    this._log('warn', message, this._deprecate, color.yellow);
   }
 }
 

--- a/lib/query/compiler.js
+++ b/lib/query/compiler.js
@@ -4,7 +4,7 @@ const helpers = require('../helpers');
 const Raw = require('../raw');
 const QueryBuilder = require('./builder');
 const JoinClause = require('./joinclause');
-const debug = require('debug');
+const debug = require('anylogger');
 
 const assign = require('lodash/assign');
 const bind = require('lodash/bind');

--- a/lib/raw.js
+++ b/lib/raw.js
@@ -3,7 +3,7 @@
 const { inherits } = require('util');
 const helpers = require('./helpers');
 const { EventEmitter } = require('events');
-const debug = require('debug');
+const debug = require('anylogger');
 
 const assign = require('lodash/assign');
 const isPlainObject = require('lodash/isPlainObject');

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -1,7 +1,7 @@
 // Transaction
 // -------
 const { EventEmitter } = require('events');
-const Debug = require('debug');
+const Debug = require('anylogger');
 
 const makeKnex = require('./util/make-knex');
 const { callbackify } = require('util');

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
     "stress:destroy": "docker-compose -f scripts/stress-test/docker-compose.yml stop"
   },
   "dependencies": {
+    "anylogger": "^1.0.7",
     "colorette": "1.2.1",
     "commander": "^6.2.0",
-    "debug": "4.3.1",
+    "docker-compose": "^0.23.5",
     "esm": "^3.2.25",
     "getopts": "2.2.5",
     "interpret": "^2.2.0",
@@ -78,12 +79,14 @@
   "devDependencies": {
     "@types/node": "^14.14.9",
     "JSONStream": "^1.3.5",
+    "anylogger-debug": "^1.0.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-subset-in-order": "^2.1.4",
     "cli-testlab": "^2.1.1",
     "coveralls": "^3.1.0",
     "cross-env": "^7.0.2",
+    "debug": "^4.3.1",
     "dtslint": "4.0.6",
     "eslint": "^7.13.0",
     "eslint-config-prettier": "^6.15.0",
@@ -112,6 +115,7 @@
     "ts-node": "^9.0.0",
     "tsd": "^0.13.1",
     "typescript": "4.1.2",
+    "ulog": "^2.0.0-beta.9",
     "webpack-cli": "^3.3.12"
   },
   "buildDependencies": [

--- a/test/tape/harness.js
+++ b/test/tape/harness.js
@@ -1,6 +1,6 @@
 'use strict';
 const tape = require('tape');
-const debug = require('debug')('knex:tests');
+const debug = require('anylogger')('knex:tests');
 
 module.exports = function (tableName, knex) {
   return function (name, dialects, cb) {

--- a/test/testInitializer.js
+++ b/test/testInitializer.js
@@ -1,6 +1,8 @@
+require('anylogger-debug');
+const log = require('anylogger')('knex:tests');
+
 let isInitted = false;
 
-/* eslint-disable no-console */
 function initTests() {
   if (isInitted) {
     return;
@@ -13,7 +15,7 @@ function initTests() {
   const EXPECTED_REJECTION_COUNT = 0;
   const rejectionLog = [];
   process.on('unhandledRejection', (reason) => {
-    console.error('Unhandled rejection:', reason);
+    log.error('Unhandled rejection:', reason);
     rejectionLog.push({
       reason,
     });
@@ -21,16 +23,16 @@ function initTests() {
 
   process.on('exit', (code) => {
     if (rejectionLog.length) {
-      console.error(`Unhandled rejections: ${rejectionLog.length}`);
+      log.error(`Unhandled rejections: ${rejectionLog.length}`);
       rejectionLog.forEach((rejection) => {
-        console.error(rejection);
+        log.error(rejection);
       });
 
       if (rejectionLog.length > EXPECTED_REJECTION_COUNT) {
         process.exitCode = code || 1;
       }
     }
-    console.log('No unhandled exceptions');
+    log.log('No unhandled exceptions');
   });
 
   isInitted = true;


### PR DESCRIPTION
* Uninstalled debug as runtime dependency
* Installed anylogger as runtime dependency to replace debug
* Installed debug and anylogger-debug adapter as development dependencies
* Required anylogger i.s.o debug everywhere debug was used
* Created an anylogger logger everywhere console was used
* Removed eslint exceptions for no-console
* Added a parameter `level` to `logger._log` so e.g. error messages will be actually logged with console.error. This allows stderr redirection.
* Required enylogger-debug in testInitializer.js so tests keep using debug
* Replaced console in testInitializer.js with an anylogger logger to complete decoupling from the console