### PR TITLE
Add support for WHERE clauses to "upsert" queries

### DIFF
--- a/lib/dialects/mysql/query/compiler.js
+++ b/lib/dialects/mysql/query/compiler.js
@@ -26,7 +26,13 @@ class QueryCompiler_MySQL extends QueryCompiler {
 
     const { ignore, merge, insert } = this.single;
     if (ignore) sql = sql.replace('insert into', 'insert ignore into');
-    if (merge) sql += this._merge(merge.updates, insert);
+    if (merge) {
+      sql += this._merge(merge.updates, insert);
+      const wheres = this.where();
+      if (wheres) {
+        throw new Error('.onConflict().merge().where() is not supported for mysql');
+      }
+    }
 
     return sql;
   }

--- a/lib/dialects/postgres/query/compiler.js
+++ b/lib/dialects/postgres/query/compiler.js
@@ -26,10 +26,11 @@ class QueryCompiler_PG extends QueryCompiler {
 
     const { returning, onConflict, ignore, merge, insert } = this.single;
     if (onConflict && ignore) sql += this._ignore(onConflict);
-    if (onConflict && merge)
+    if (onConflict && merge) {
       sql += this._merge(merge.updates, onConflict, insert);
       const wheres = this.where();
       sql += wheres ? ` ${wheres}` : '';
+    }
     if (returning) sql += this._returning(returning);
 
     return {

--- a/lib/dialects/postgres/query/compiler.js
+++ b/lib/dialects/postgres/query/compiler.js
@@ -28,6 +28,8 @@ class QueryCompiler_PG extends QueryCompiler {
     if (onConflict && ignore) sql += this._ignore(onConflict);
     if (onConflict && merge)
       sql += this._merge(merge.updates, onConflict, insert);
+      const wheres = this.where();
+      sql += wheres ? ` ${wheres}` : '';
     if (returning) sql += this._returning(returning);
 
     return {

--- a/lib/dialects/postgres/query/compiler.js
+++ b/lib/dialects/postgres/query/compiler.js
@@ -29,7 +29,7 @@ class QueryCompiler_PG extends QueryCompiler {
     if (onConflict && merge) {
       sql += this._merge(merge.updates, onConflict, insert);
       const wheres = this.where();
-      sql += wheres ? ` ${wheres}` : '';
+      if (wheres) sql += ` ${wheres}`;
     }
     if (returning) sql += this._returning(returning);
 

--- a/lib/dialects/sqlite3/query/compiler.js
+++ b/lib/dialects/sqlite3/query/compiler.js
@@ -87,6 +87,8 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
       if (onConflict && ignore) sql += this._ignore(onConflict);
       else if (onConflict && merge) {
         sql += this._merge(merge.updates, onConflict, insertValues);
+        const wheres = this.where();
+        if (wheres) sql += ` ${wheres}`;
       }
 
       return sql;

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -1499,6 +1499,11 @@ module.exports = function (knex) {
               'insert into "upsert_tests" ("email", "name") values (?, ?) on conflict ("email") do update set "email" = excluded."email", "name" = excluded."name" where "upsert_tests"."role" = ? returning "email"',
               ['mergetest@example.com', 'AFTER', 'tester']
             );
+            tester(
+              'sqlite3',
+              'insert into `upsert_tests` (`email`, `name`) values (?, ?) on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name` where `upsert_tests`.`role` = ? returning `email`',
+              ['mergetest@example.com', 'AFTER', 'tester']
+            );
           });
       } catch (err) {
         if (/oracle|mssql/i.test(knex.client.driverName)) {
@@ -1549,6 +1554,11 @@ module.exports = function (knex) {
             tester(
               'pg',
               'insert into "upsert_tests" ("email", "name") values (?, ?) on conflict ("email") do update set "email" = excluded."email", "name" = excluded."name" where "upsert_tests"."role" = ? returning "email"',
+              ['mergetest@example.com', 'AFTER', 'fake-role']
+            );
+            tester(
+              'sqlite3',
+              'insert into `upsert_tests` (`email`, `name`) values (?, ?) on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name` where `upsert_tests`.`role` = ? returning `email`',
               ['mergetest@example.com', 'AFTER', 'fake-role']
             );
           });

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -1511,6 +1511,11 @@ module.exports = function (knex) {
           if (err.message.includes('.onConflict() is not supported for'))
             return;
         }
+        if (knex.client.driverName === 'mysql') {
+          expect(err).to.be.an('error');
+          if (err.message.includes('.onConflict().merge().where() is not supported for'))
+            return;
+        }
         throw err;
       }
 
@@ -1566,6 +1571,11 @@ module.exports = function (knex) {
         if (/oracle|mssql/i.test(knex.client.driverName)) {
           expect(err).to.be.an('error');
           if (err.message.includes('.onConflict() is not supported for'))
+            return;
+        }
+        if (knex.client.driverName === 'mysql') {
+          expect(err).to.be.an('error');
+          if (err.message.includes('.onConflict().merge().where() is not supported for'))
             return;
         }
         throw err;

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -1465,6 +1465,110 @@ module.exports = function (knex) {
       expect(rows[0].name).to.equal('AFTER');
     });
 
+    it('conditionally updates rows when inserting a duplicate key to unique column and merge with where clause matching row(s) is specified', async function () {
+      if (/redshift/i.test(knex.client.driverName)) {
+        return this.skip();
+      }
+
+      // Setup: Create table with unique email column
+      await knex.schema.dropTableIfExists('upsert_tests');
+      await knex.schema.createTable('upsert_tests', (table) => {
+        table.string('name');
+        table.string('email');
+        table.string('role');
+        table.unique('email');
+      });
+
+      // Setup: Create row to conflict against
+      await knex('upsert_tests').insert({
+        email: 'mergetest@example.com',
+        role: 'tester',
+        name: 'BEFORE',
+      });
+
+      // Perform insert..merge (upsert)
+      try {
+        await knex('upsert_tests')
+          .insert({ email: 'mergetest@example.com', name: 'AFTER' }, 'email')
+          .onConflict('email')
+          .merge()
+          .where('upsert_tests.role', 'tester')
+          .testSql(function (tester) {
+            tester(
+              'pg',
+              'insert into "upsert_tests" ("email", "name") values (?, ?) on conflict ("email") do update set "email" = excluded."email", "name" = excluded."name" where "upsert_tests"."role" = ? returning "email"',
+              ['mergetest@example.com', 'AFTER', 'tester']
+            );
+          });
+      } catch (err) {
+        if (/oracle|mssql/i.test(knex.client.driverName)) {
+          expect(err).to.be.an('error');
+          if (err.message.includes('.onConflict() is not supported for'))
+            return;
+        }
+        throw err;
+      }
+
+      // Check that row HAS been updated
+      const rows = await knex('upsert_tests')
+        .where({ email: 'mergetest@example.com' })
+        .select();
+      expect(rows.length).to.equal(1);
+      expect(rows[0].name).to.equal('AFTER');
+    });
+
+    it('will silently do nothing when inserting a duplicate key to unique column and merge with where clause matching no rows is specified', async function () {
+      if (/redshift/i.test(knex.client.driverName)) {
+        return this.skip();
+      }
+
+      // Setup: Create table with unique email column
+      await knex.schema.dropTableIfExists('upsert_tests');
+      await knex.schema.createTable('upsert_tests', (table) => {
+        table.string('name');
+        table.string('email');
+        table.string('role');
+        table.unique('email');
+      });
+
+      // Setup: Create row to conflict against
+      await knex('upsert_tests').insert({
+        email: 'mergetest@example.com',
+        role: 'tester',
+        name: 'BEFORE',
+      });
+
+      // Perform insert..merge (upsert)
+      try {
+        await knex('upsert_tests')
+          .insert({ email: 'mergetest@example.com', name: 'AFTER' }, 'email')
+          .onConflict('email')
+          .merge()
+          .where('upsert_tests.role', 'fake-role')
+          .testSql(function (tester) {
+            tester(
+              'pg',
+              'insert into "upsert_tests" ("email", "name") values (?, ?) on conflict ("email") do update set "email" = excluded."email", "name" = excluded."name" where "upsert_tests"."role" = ? returning "email"',
+              ['mergetest@example.com', 'AFTER', 'fake-role']
+            );
+          });
+      } catch (err) {
+        if (/oracle|mssql/i.test(knex.client.driverName)) {
+          expect(err).to.be.an('error');
+          if (err.message.includes('.onConflict() is not supported for'))
+            return;
+        }
+        throw err;
+      }
+
+      // Check that row HAS NOT been updated
+      const rows = await knex('upsert_tests')
+        .where({ email: 'mergetest@example.com' })
+        .select();
+      expect(rows.length).to.equal(1);
+      expect(rows[0].name).to.equal('BEFORE');
+    });
+
     it('updates columns with raw value when inserting a duplicate key to unique column and merge is specified', async function () {
       if (/redshift/i.test(knex.client.driverName)) {
         return this.skip();

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -1466,7 +1466,7 @@ module.exports = function (knex) {
     });
 
     it('conditionally updates rows when inserting a duplicate key to unique column and merge with where clause matching row(s) is specified', async function () {
-      if (/redshift/i.test(knex.client.driverName)) {
+      if (/redshift|mysql/i.test(knex.client.driverName)) {
         return this.skip();
       }
 
@@ -1518,7 +1518,7 @@ module.exports = function (knex) {
     });
 
     it('will silently do nothing when inserting a duplicate key to unique column and merge with where clause matching no rows is specified', async function () {
-      if (/redshift/i.test(knex.client.driverName)) {
+      if (/redshift|mysql/i.test(knex.client.driverName)) {
         return this.skip();
       }
 

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -1501,7 +1501,7 @@ module.exports = function (knex) {
             );
             tester(
               'sqlite3',
-              'insert into `upsert_tests` (`email`, `name`) values (?, ?) on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name` where `upsert_tests`.`role` = ? returning `email`',
+              'insert into `upsert_tests` (`email`, `name`) values (?, ?) on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name` where `upsert_tests`.`role` = ?',
               ['mergetest@example.com', 'AFTER', 'tester']
             );
           });
@@ -1511,7 +1511,7 @@ module.exports = function (knex) {
           if (err.message.includes('.onConflict() is not supported for'))
             return;
         }
-        if (knex.client.driverName === 'mysql') {
+        if (/mysql|mysql2/i.test(knex.client.driverName)) {
           expect(err).to.be.an('error');
           if (err.message.includes('.onConflict().merge().where() is not supported for'))
             return;
@@ -1563,7 +1563,7 @@ module.exports = function (knex) {
             );
             tester(
               'sqlite3',
-              'insert into `upsert_tests` (`email`, `name`) values (?, ?) on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name` where `upsert_tests`.`role` = ? returning `email`',
+              'insert into `upsert_tests` (`email`, `name`) values (?, ?) on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name` where `upsert_tests`.`role` = ?',
               ['mergetest@example.com', 'AFTER', 'fake-role']
             );
           });
@@ -1573,7 +1573,7 @@ module.exports = function (knex) {
           if (err.message.includes('.onConflict() is not supported for'))
             return;
         }
-        if (knex.client.driverName === 'mysql') {
+        if (/mysql|mysql2/i.test(knex.client.driverName)) {
           expect(err).to.be.an('error');
           if (err.message.includes('.onConflict().merge().where() is not supported for'))
             return;

--- a/test/integration/builder/inserts.js
+++ b/test/integration/builder/inserts.js
@@ -1466,7 +1466,7 @@ module.exports = function (knex) {
     });
 
     it('conditionally updates rows when inserting a duplicate key to unique column and merge with where clause matching row(s) is specified', async function () {
-      if (/redshift|mysql/i.test(knex.client.driverName)) {
+      if (/redshift/i.test(knex.client.driverName)) {
         return this.skip();
       }
 
@@ -1528,7 +1528,7 @@ module.exports = function (knex) {
     });
 
     it('will silently do nothing when inserting a duplicate key to unique column and merge with where clause matching no rows is specified', async function () {
-      if (/redshift|mysql/i.test(knex.client.driverName)) {
+      if (/redshift/i.test(knex.client.driverName)) {
         return this.skip();
       }
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -6348,7 +6348,7 @@ describe('QueryBuilder', () => {
     );
   });
 
-  it('insert merge with where clause', () => {
+  it.only('insert merge with where clause', () => {
     testsql(
       qb()
         .from('users')
@@ -6360,6 +6360,11 @@ describe('QueryBuilder', () => {
         pg: {
           sql:
             'insert into "users" ("email", "name") values (?, ?) on conflict ("email") do update set "email" = excluded."email", "name" = excluded."name" where "email" = ?',
+          bindings: ['foo', 'taylor', 'foo2'],
+        },
+        sqlite3: {
+          sql:
+            'insert into `users` (`email`, `name`) values (?, ?) on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name` where `email` = ?',
           bindings: ['foo', 'taylor', 'foo2'],
         },
       }

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -6348,6 +6348,24 @@ describe('QueryBuilder', () => {
     );
   });
 
+  it('insert merge with where clause', () => {
+    testsql(
+      qb()
+        .from('users')
+        .insert({ email: 'foo', name: 'taylor' })
+        .onConflict('email')
+        .merge()
+        .where('email', 'foo2'),
+      {
+        pg: {
+          sql:
+            'insert into "users" ("email", "name") values (?, ?) on conflict ("email") do update set "email" = excluded."email", "name" = excluded."name" where "email" = ?',
+          bindings: ['foo', 'taylor', 'foo2'],
+        },
+      }
+    );
+  });
+
   it('Calling decrement and then increment will overwrite the previous value', () => {
     testsql(
       qb()

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -6369,6 +6369,16 @@ describe('QueryBuilder', () => {
         },
       }
     );
+
+    expect(() => {
+      clients.mysql
+        .queryBuilder()
+        .insert({ email: 'foo', name: 'taylor' })
+        .onConflict('email')
+        .merge()
+        .where('email', 'foo2')
+        .toString();
+    }).to.throw('onConflict().merge().where() is not supported for mysql');
   });
 
   it('Calling decrement and then increment will overwrite the previous value', () => {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -6348,7 +6348,7 @@ describe('QueryBuilder', () => {
     );
   });
 
-  it.only('insert merge with where clause', () => {
+  it('insert merge with where clause', () => {
     testsql(
       qb()
         .from('users')


### PR DESCRIPTION
This is a follow-up to #3763, which adds support for WHERE clauses to "upsert" queries for the DB engines that support this functionality.

Based on my research on the DB engines that support "upsert" queries, it seems like PostgreSQL and SQLite support WHERE clauses for them, but MySQL does not:

https://www.postgresql.org/docs/10/sql-insert.html
https://sqlite.org/lang_upsert.html
https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html

To do:

- [x] Add support for WHERE clause to upsert queries in PostgreSQL and add tests
- [x] Add support for WHERE clause to upsert queries in SQLite and add tests
- [x] Update documentation: https://github.com/knex/documentation/pull/300

Closes #4145 