### PR TITLE
Add support for application_name in PG connection types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2020,6 +2020,7 @@ declare namespace Knex {
     connectionTimeoutMillis?: number;
     keepAliveInitialDelayMillis?: number;
     ssl?: boolean | ConnectionOptions;
+    application_name?: string;
   }
 
   type RedshiftConnectionConfig = PgConnectionConfig;


### PR DESCRIPTION
Adds support for application_name as a valid type.

This option is already supported in `pg`, see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/pg/index.d.ts

Also confirmed that it passes through correctly. Let me know if I should also be adding a test for this typing change.

