### PR TITLE
Fix performance of asyncStackTraces with enable-source-maps node flag

### DIFF
--- a/lib/interface.js
+++ b/lib/interface.js
@@ -25,9 +25,14 @@ module.exports = function (Target) {
       result = result.catch((err) => {
         err.originalStack = err.stack;
         const firstLine = err.stack.split('\n')[0];
-        this._asyncStack.unshift(firstLine);
+
+        const { error, lines } = this._asyncStack;
+        const stackByLines = error.stack.split('\n');
+        const asyncStack = stackByLines.slice(lines);
+        asyncStack.unshift(firstLine);
+
         // put the fake more helpful "async" stack on the thrown error
-        err.stack = this._asyncStack.join('\n');
+        err.stack = asyncStack.join('\n');
         throw err;
       });
     }

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -26,6 +26,9 @@ module.exports = function (Target) {
         err.originalStack = err.stack;
         const firstLine = err.stack.split('\n')[0];
 
+        // a hack to get a callstack into the client code despite this
+        // node.js bug https://github.com/nodejs/node/issues/11865
+        // see lib/util/save-async-stack.js for more details
         const { error, lines } = this._asyncStack;
         const stackByLines = error.stack.split('\n');
         const asyncStack = stackByLines.slice(lines);

--- a/lib/util/save-async-stack.js
+++ b/lib/util/save-async-stack.js
@@ -2,8 +2,13 @@ module.exports = function saveAsyncStack(instance, lines) {
   if (instance.client.config.asyncStackTraces) {
     // a hack to get a callstack into the client code despite this
     // node.js bug https://github.com/nodejs/node/issues/11865
-    const stackByLines = new Error().stack.split('\n');
-    stackByLines.splice(0, lines);
-    instance._asyncStack = stackByLines;
+
+    // Save error here but not error trace
+    // reading trace with '--enable-source-maps' flag on node can be very costly
+
+    instance._asyncStack = {
+      error: new Error(),
+      lines,
+    };
   }
 };

--- a/test/db-less-test-suite.js
+++ b/test/db-less-test-suite.js
@@ -6,6 +6,8 @@ describe('Util Tests', function () {
   // Unit Tests for utilities.
   require('./unit/query/string');
   require('./unit/util/fs');
+  require('./unit/util/nanoid');
+  require('./unit/util/save-async-stack');
 });
 
 describe('Query Building Tests', function () {

--- a/test/unit/interface.js
+++ b/test/unit/interface.js
@@ -30,9 +30,13 @@ describe('interface', function () {
     }
 
     _interface(SomeClass);
+
     const fakeInstance = new SomeClass();
     chai.expect(fakeInstance[Symbol.toStringTag]).to.eq('object');
-    fakeInstance._asyncStack = ['line1', 'line2', 'line3'];
+    fakeInstance._asyncStack = {
+      error: { stack: 'line1\nline2\nline3' },
+      lines: 0,
+    };
     fakeInstance.then();
   });
 });

--- a/test/unit/util/save-async-stack.js
+++ b/test/unit/util/save-async-stack.js
@@ -13,7 +13,11 @@ describe('saveAsyncStack', function () {
     };
     saveAsyncStack(fakeInstance, 1);
 
-    chai.expect(fakeInstance._asyncStack[0]).to.match(/at saveAsyncStack /);
+    const { error, lines } = fakeInstance._asyncStack;
+    const stackByLines = error.stack.split('\n');
+    const asyncStack = stackByLines.slice(lines);
+
+    chai.expect(asyncStack[0]).to.match(/at saveAsyncStack /);
   });
 
   it('should not store an error stack when config is disabled', function () {


### PR DESCRIPTION
Reading stack trace with '--enable-source-maps' flag on node can be very costly, 
in our case when using knex it takes 100-200ms for every query what in case of multiple queries gives huge delays.

Instead of reading stack trace at saveAsyncStack function better to read it when needed at catch error.
