### PR TITLE
Fix(seed:run): irregular seed file execution order

### DIFF
--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const { flatten } = require('lodash');
 const os = require('os');
 const path = require('path');
 const { promisify } = require('util');
@@ -46,23 +47,22 @@ function ensureDirectoryExists(dir) {
  * All found files, concatenated to the current dir
  */
 async function getFilepathsInFolder(dir, recursive = false) {
-  const results = [];
   const pathsList = await readdir(dir);
-  await Promise.all(
-    pathsList.sort().map(async (currentPath) => {
-      const currentFile = path.resolve(dir, currentPath);
-      const statFile = await stat(currentFile);
-      if (statFile && statFile.isDirectory()) {
-        if (recursive) {
-          const subFiles = await getFilepathsInFolder(currentFile, true);
-          results.push(...subFiles);
+  return flatten(
+    await Promise.all(
+      pathsList.sort().map(async (currentPath) => {
+        const currentFile = path.resolve(dir, currentPath);
+        const statFile = await stat(currentFile);
+        if (statFile && statFile.isDirectory()) {
+          if (recursive) {
+            return await getFilepathsInFolder(currentFile, true);
+          }
+          return [];
         }
-      } else {
-        results.push(currentFile);
-      }
-    })
+        return [currentFile];
+      })
+    )
   );
-  return results;
 }
 
 module.exports = {

--- a/test/unit/seed/seeder.js
+++ b/test/unit/seed/seeder.js
@@ -284,7 +284,6 @@ describe('Seeder._listAll', function () {
           process.cwd() +
             '/test/integration/seed/2-seeds/litcoffee-seed.litcoffee',
           process.cwd() + '/test/integration/seed/2-seeds/ls-seed.ls',
-          process.cwd() + '/test/integration/seed/2-seeds/ts-seed.ts',
           process.cwd() +
             '/test/integration/seed/2-seeds/recursive-folder/co-seed.co',
           process.cwd() +
@@ -301,6 +300,7 @@ describe('Seeder._listAll', function () {
             '/test/integration/seed/2-seeds/recursive-folder/ls-seed.ls',
           process.cwd() +
             '/test/integration/seed/2-seeds/recursive-folder/ts-seed.ts',
+          process.cwd() + '/test/integration/seed/2-seeds/ts-seed.ts',
           process.cwd() + '/test/integration/seed/1-seeds/co-seed.co',
           process.cwd() + '/test/integration/seed/1-seeds/coffee-seed.coffee',
           process.cwd() + '/test/integration/seed/1-seeds/eg-seed.eg',

--- a/test/unit/util/fs.js
+++ b/test/unit/util/fs.js
@@ -9,6 +9,7 @@ const {
   writeFile,
   createTemp,
   ensureDirectoryExists,
+  getFilepathsInFolder,
 } = require('../../../lib/util/fs');
 
 describe('FS functions', () => {
@@ -92,6 +93,49 @@ describe('FS functions', () => {
       await ensureDirectoryExists(newPath);
 
       expect(fs.existsSync(newPath)).to.equal(true);
+    });
+  });
+
+  describe('getFilepathsInFolder', () => {
+    it('should return sorted file list under the directory.', async () => {
+      const directory = await createTemp();
+      fs.writeFileSync(path.join(directory, 'testfile1.txt'), 'testfile1');
+      fs.writeFileSync(path.join(directory, 'testfile2.txt'), 'testfile1');
+      fs.writeFileSync(path.join(directory, 'testfile3.txt'), 'testfile1');
+      fs.mkdirSync(path.join(directory, 'dir'));
+      fs.writeFileSync(path.join(directory, 'dir/testfile1.txt'), 'testfile1');
+      fs.writeFileSync(path.join(directory, 'dir/testfile2.txt'), 'testfile2');
+      fs.writeFileSync(path.join(directory, 'dir/testfile3.txt'), 'testfile3');
+
+      const result = await getFilepathsInFolder(directory);
+
+      expect(result).to.deep.equal([
+        `${directory}/testfile1.txt`,
+        `${directory}/testfile2.txt`,
+        `${directory}/testfile3.txt`,
+      ]);
+    });
+
+    it('should return sorted file list under the directory (recursively) with recursive option.', async () => {
+      const directory = await createTemp();
+      fs.writeFileSync(path.join(directory, 'testfile1.txt'), 'testfile1');
+      fs.writeFileSync(path.join(directory, 'testfile2.txt'), 'testfile1');
+      fs.writeFileSync(path.join(directory, 'testfile3.txt'), 'testfile1');
+      fs.mkdirSync(path.join(directory, 'dir'));
+      fs.writeFileSync(path.join(directory, 'dir/testfile1.txt'), 'testfile1');
+      fs.writeFileSync(path.join(directory, 'dir/testfile2.txt'), 'testfile2');
+      fs.writeFileSync(path.join(directory, 'dir/testfile3.txt'), 'testfile3');
+
+      const result = await getFilepathsInFolder(directory, true);
+
+      expect(result).to.deep.equal([
+        `${directory}/dir/testfile1.txt`,
+        `${directory}/dir/testfile2.txt`,
+        `${directory}/dir/testfile3.txt`,
+        `${directory}/testfile1.txt`,
+        `${directory}/testfile2.txt`,
+        `${directory}/testfile3.txt`,
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Problem

- Run `knex seed:run` with `seeds: { sortDirsSeparately: true }` option
	- Run seed files with irregular order (unsorted)
	- Change order every time you run

See https://github.com/progfay/knex-irregular-file-order-poc

## Factor

- In `getFilepathsInFolder` function, push file path to array asynchronously

## Solution

- To avoid async pushing
