### PR TITLE
Make sure query-response and query-error events contain _knexTxId

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -169,14 +169,14 @@ Object.assign(Runner.prototype, {
         this.builder.emit(
           'query-response',
           postProcessedResponse,
-          Object.assign({ __knexUid: this.connection.__knexUid }, obj),
+          Object.assign({ __knexUid, __knexTxId }, obj),
           this.builder
         );
 
         this.client.emit(
           'query-response',
           postProcessedResponse,
-          Object.assign({ __knexUid: this.connection.__knexUid }, obj),
+          Object.assign({ __knexUid, __knexTxId }, obj),
           this.builder
         );
 
@@ -230,7 +230,7 @@ Object.assign(Runner.prototype, {
         this.builder.emit(
           'query-error',
           error,
-          Object.assign({ __knexUid: this.connection.__knexUid }, obj)
+          Object.assign({ __knexUid, __knexTxId }, obj)
         );
         throw error;
       });


### PR DESCRIPTION
The docs said that these events contain both __knexUid and __knexTxId but I found that it were lacking __knexTxId