### PR TITLE
Timestamp UTC Standardization

### DIFF
--- a/lib/util/timestamp.js
+++ b/lib/util/timestamp.js
@@ -1,13 +1,12 @@
 function yyyymmddhhmmss(...time) {
 	const rYear = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 	const timeZones = {
-		'60':   'ECT', '120':  'EET', '180':  'EAT',
-		'210':  'MET', '240':  'NET', '300':  'PLT', '330':  'IST',
-		'360':  'BST', '420':  'VST', '480':  'CTT', '540':  'JST',
-		'570':  'ACT', '600':  'AET', '660':  'SST', '720':  'NST',
-		'-660': 'MIT', '-600': 'HST', '-540': 'AST', '-480': 'PST',
-		'-420': 'MST', '-360': 'CST', '-300': 'EST',
-		'-240': 'PRT', '-210': 'CNT',
+		'60':   'ECT', '120':  'EET', '180':  'EAT', '210':  'MET',
+		'240':  'NET', '300':  'PLT', '330':  'IST', '360':  'BST',
+		'420':  'VST', '480':  'CTT', '540':  'JST', '570':  'ACT',
+		'600':  'AET', '660':  'SST', '720':  'NST', '-660': 'MIT',
+		'-600': 'HST', '-540': 'AST', '-480': 'PST', '-420': 'MST',
+		'-360': 'CST', '-300': 'EST', '-240': 'PRT', '-210': 'CNT',
 		'-180': 'BET', '-60':  'CAT'
 	}
 	
@@ -51,8 +50,8 @@ function yyyymmddhhmmss(...time) {
 		}
 	}
 	
-	dateTime[3]++;
 	dateTime[2]++;
+	dateTime[3]++;
 	
 	if ((dateTime[4]%4 !== 0) && (dateTime[2] === 29) && (dateTime[3] === 2)) {
 		if (forward) {

--- a/lib/util/timestamp.js
+++ b/lib/util/timestamp.js
@@ -1,16 +1,78 @@
-// Get a date object in the correct format, without requiring a full out library
-// like "moment.js".
-function yyyymmddhhmmss() {
-  const d = new Date();
-
-  return (
-    d.getFullYear().toString() +
-    (d.getMonth() + 1).toString().padStart(2, '0') +
-    d.getDate().toString().padStart(2, '0') +
-    d.getHours().toString().padStart(2, '0') +
-    d.getMinutes().toString().padStart(2, '0') +
-    d.getSeconds().toString().padStart(2, '0')
-  );
+function yyyymmddhhmmss(...time) {
+	const rYear = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+	const timeZones = {
+		'60':   'ECT', '120':  'EET', '180':  'EAT',
+		'210':  'MET', '240':  'NET', '300':  'PLT', '330':  'IST',
+		'360':  'BST', '420':  'VST', '480':  'CTT', '540':  'JST',
+		'570':  'ACT', '600':  'AET', '660':  'SST', '720':  'NST',
+		'-660': 'MIT', '-600': 'HST', '-540': 'AST', '-480': 'PST',
+		'-420': 'MST', '-360': 'CST', '-300': 'EST',
+		'-240': 'PRT', '-210': 'CNT',
+		'-180': 'BET', '-60':  'CAT'
+	}
+	
+	let d = new Date()
+	let offset = d.getTimezoneOffset()
+	let zoneName = 'UTC'
+	if (time.length > 0) {
+		d = new Date(time[0])
+		offset = time[1]
+		if (Object.keys(timeZones).includes(offset.toString())) {
+			zoneName = timeZones[offset.toString()]
+		}
+	}
+	
+	let dateTime = [d.getMinutes() + offset, d.getHours(), d.getDate()-1, d.getMonth(), d.getFullYear()];
+	let forward = false;
+	
+	for (let i = 0; i < 4; i++) {
+		let unitCeil = (i === 0 ? 59 : (i === 1 ? 23 : (i === 2 ? rYear[dateTime[3]]-1 : (i === 3 ? 11 : 400000))))
+		while(dateTime[i] > unitCeil || dateTime[i] < 0) {
+			if (dateTime[i] < 0) {
+				dateTime[i+1] -= 1
+				if (i === 2) {
+					if (dateTime[3] < 0) {
+						dateTime[i] += 31
+					} else {
+						dateTime[i] += (rYear[dateTime[3]])
+					}
+				} else {
+					dateTime[i]   += (unitCeil+1)
+				}
+			} else if (dateTime[i] > unitCeil) {
+				if (i === 2) {
+					dateTime[i]   -= (rYear[dateTime[3]])
+				} else {
+					dateTime[i]   -= (unitCeil+1)
+				}
+				dateTime[i+1] += 1
+				forward = true
+			}
+		}
+	}
+	
+	dateTime[3]++;
+	dateTime[2]++;
+	
+	if ((dateTime[4]%4 !== 0) && (dateTime[2] === 29) && (dateTime[3] === 2)) {
+		if (forward) {
+			dateTime[3] = 3
+			dateTime[2] = 1
+		} else {
+			dateTime[3] = 2
+			dateTime[2] = 28
+		}
+	}
+	
+	return (
+		zoneName +
+		dateTime[4].toString() +
+		dateTime[3].toString().padStart(2, '0') +
+		dateTime[2].toString().padStart(2, '0') +
+		dateTime[1].toString().padStart(2, '0') +
+		dateTime[0].toString().padStart(2, '0') +
+		d.getSeconds().toString().padStart(2, '0')
+	);
 }
 
 module.exports = { yyyymmddhhmmss };

--- a/lib/util/timestamp.js
+++ b/lib/util/timestamp.js
@@ -15,15 +15,17 @@ function yyyymmddhhmmss(...time) {
 	let zoneName = 'UTC'
 	if (time.length > 0) {
 		//'2016-02-28T21:12:45.678'
-		let regex = new RegExp('^[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}\.[0-9]{3}$')
-		if ()
-		d = new Date(time[0])
-		offset = time[1]
-		if (offset > 840 || offset < -840) {
-			offset = 0;
-		}
-		if (Object.keys(timeZones).includes(offset.toString())) {
-			zoneName = timeZones[offset.toString()]
+		let timeRegex = new RegExp('^[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}\.[0-9]{3}$')
+		let offsetRegex = new RegeExp('^[0-9]{3}$')
+		if (timeRegex.test(time[0]) && offsetRegex.test(time[1])) {
+			d = new Date(time[0])
+			offset = time[1]
+			if (offset > 840 || offset < -840) {
+				offset = 0;
+			}
+			if (Object.keys(timeZones).includes(offset.toString())) {
+				zoneName = timeZones[offset.toString()]
+			}
 		}
 	}
 	

--- a/lib/util/timestamp.js
+++ b/lib/util/timestamp.js
@@ -72,8 +72,7 @@ function yyyymmddhhmmss(...time) {
 	}
 	
 	return (
-		//feature for designating Time Zones
-		zoneName +
+		//zoneName +
 		dateTime[4].toString() +
 		dateTime[3].toString().padStart(2, '0') +
 		dateTime[2].toString().padStart(2, '0') +

--- a/lib/util/timestamp.js
+++ b/lib/util/timestamp.js
@@ -15,12 +15,12 @@ function yyyymmddhhmmss(...time) {
 	let zoneName = 'UTC'
 	if (time.length > 0) {
 		//'2016-02-28T21:12:45.678'
-		let timeRegex = new RegExp('^[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}\.[0-9]{3}$')
-		let offsetRegex = new RegeExp('^[0-9]{3}$')
+		let timeRegex = new RegExp('[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}\.[0-9]{3}')
+		let offsetRegex = new RegExp('[0-9]{2,3}')
 		if (timeRegex.test(time[0]) && offsetRegex.test(time[1])) {
 			d = new Date(time[0])
 			offset = time[1]
-			if (offset > 840 || offset < -840) {
+			if (offset > 841 || offset < -841) {
 				offset = 0;
 			}
 			if (Object.keys(timeZones).includes(offset.toString())) {
@@ -73,7 +73,7 @@ function yyyymmddhhmmss(...time) {
 	
 	return (
 		//feature for designating Time Zones
-		//zoneName +
+		zoneName +
 		dateTime[4].toString() +
 		dateTime[3].toString().padStart(2, '0') +
 		dateTime[2].toString().padStart(2, '0') +

--- a/lib/util/timestamp.js
+++ b/lib/util/timestamp.js
@@ -14,8 +14,14 @@ function yyyymmddhhmmss(...time) {
 	let offset = d.getTimezoneOffset()
 	let zoneName = 'UTC'
 	if (time.length > 0) {
+		//'2016-02-28T21:12:45.678'
+		let regex = new RegExp('^[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}\.[0-9]{3}$')
+		if ()
 		d = new Date(time[0])
 		offset = time[1]
+		if (offset > 840 || offset < -840) {
+			offset = 0;
+		}
 		if (Object.keys(timeZones).includes(offset.toString())) {
 			zoneName = timeZones[offset.toString()]
 		}
@@ -64,7 +70,8 @@ function yyyymmddhhmmss(...time) {
 	}
 	
 	return (
-		zoneName +
+		//feature for designating Time Zones
+		//zoneName +
 		dateTime[4].toString() +
 		dateTime[3].toString().padStart(2, '0') +
 		dateTime[2].toString().padStart(2, '0') +

--- a/test/util/timestamp.js
+++ b/test/util/timestamp.js
@@ -88,7 +88,7 @@ const trueDate = [
 
 describe('timestamp', function() {
 	it('should return valid dates for edge cases of leap years', function() {
-		let regex = new RegExp('^([a-z]|[A-Z]){3}[0-9]{14}$')
+		let regex = new RegExp('([a-z]|[A-Z]){3}[0-9]{14}')
 		for (let i = 0; i < 6; i++) {
 			let testDate = timestamp(checkDates[i], checkOffsets[i])
 			
@@ -98,7 +98,7 @@ describe('timestamp', function() {
 	})
 	
 	it('should give back a valid date structure with no arguments', function() {
-		let regex = new RegExp('^([a-z]|[A-Z]){3}[0-9]{14}$')
+		let regex = new RegExp('([a-z]|[A-Z]){3}[0-9]{14}')
 		
 		let testDate = timestamp()
 		
@@ -106,7 +106,7 @@ describe('timestamp', function() {
 	})
 	
 	it('should be able to convert standard time zones when given offsets manually', function() {
-		let regex = new RegExp('^([a-z]|[A-Z]){3}[0-9]{14}$')
+		let regex = new RegExp('([a-z]|[A-Z]){3}[0-9]{14}')
 		for (let i = 6; i < trueDate.length; i++) {
 			let testDate = timestamp(checkDates[6], checkOffsets[i])
 			

--- a/test/util/timestamp.js
+++ b/test/util/timestamp.js
@@ -1,4 +1,3 @@
-'use strict';
 const assert = require('chai').assert
 const timestamp = require('../../lib/util/timestamp').yyyymmddhhmmss
 
@@ -50,45 +49,45 @@ const checkOffsets = [
 ]
 
 const trueDate = [
-	'UTC20160229111245',
-	'UTC20160229183259',
-	'UTC20150301134502',
-	'UTC20150228143659',
-	'UTC20210101053058',
-	'UTC20181231100841',
+	'20160229111245',
+	'20160229183259',
+	'20150301134502',
+	'20150228143659',
+	'20210101053058',
+	'20181231100841',
 	
-	'ECT19991225130046',
-	'EET19991225140046',
-	'EAT19991225150046',
-	'MET19991225153046',
-	'NET19991225160046',
-	'PLT19991225170046',
-	'IST19991225173046',
-	'BST19991225180046',
-	'VST19991225190046',
-	'CTT19991225200046',
-	'JST19991225210046',
-	'ACT19991225213046',
-	'AET19991225220046',
-	'SST19991225230046',
-	'NST19991226000046',
-	'MIT19991225010046',
-	'HST19991225020046',
-	'AST19991225030046',
-	'PST19991225040046',
-	'MST19991225050046',
-	'CST19991225060046',
-	'EST19991225070046',
-	'PRT19991225080046',
-	'CNT19991225083046',
-	'BET19991225090046',
-	'CAT19991225110046'
+	'19991225130046',
+	'19991225140046',
+	'19991225150046',
+	'19991225153046',
+	'19991225160046',
+	'19991225170046',
+	'19991225173046',
+	'19991225180046',
+	'19991225190046',
+	'19991225200046',
+	'19991225210046',
+	'19991225213046',
+	'19991225220046',
+	'19991225230046',
+	'19991226000046',
+	'19991225010046',
+	'19991225020046',
+	'19991225030046',
+	'19991225040046',
+	'19991225050046',
+	'19991225060046',
+	'19991225070046',
+	'19991225080046',
+	'19991225083046',
+	'19991225090046',
+	'19991225110046'
 ]
 
 
 describe('timestamp', function() {
 	it('should return valid dates for edge cases of leap years', function() {
-		let regex = new RegExp('([a-z]|[A-Z]){3}[0-9]{14}')
+		let regex = new RegExp('[0-9]{14}')
 		for (let i = 0; i < 6; i++) {
 			let testDate = timestamp(checkDates[i], checkOffsets[i])
 			
@@ -98,7 +97,7 @@ describe('timestamp', function() {
 	})
 	
 	it('should give back a valid date structure with no arguments', function() {
-		let regex = new RegExp('([a-z]|[A-Z]){3}[0-9]{14}')
+		let regex = new RegExp('[0-9]{14}')
 		
 		let testDate = timestamp()
 		
@@ -106,7 +105,7 @@ describe('timestamp', function() {
 	})
 	
 	it('should be able to convert standard time zones when given offsets manually', function() {
-		let regex = new RegExp('([a-z]|[A-Z]){3}[0-9]{14}')
+		let regex = new RegExp('[0-9]{14}')
 		for (let i = 6; i < trueDate.length; i++) {
 			let testDate = timestamp(checkDates[6], checkOffsets[i])
 			

--- a/test/util/timestamp.js
+++ b/test/util/timestamp.js
@@ -1,0 +1,119 @@
+'use strict';
+const assert = require('chai').assert
+const timestamp = require('../../lib/util/timestamp').yyyymmddhhmmss
+
+const checkDates = [
+	'2016-02-28T21:12:45.678',
+	'2016-03-01T08:32:59.870',
+	'2015-02-28T23:45:02.125',
+	'2015-03-01T04:36:59.014',
+	'2020-12-31T15:30:58.409',
+	'2019-01-01T00:08:41.603',
+	
+	'1999-12-25T12:00:46.692'
+]
+
+const checkOffsets = [
+	840,
+	-840,
+	840,
+	-840,
+	840,
+	-840,
+	
+	60,   //ECT European Central Time
+	120,  //EET Eastern European Time
+	180,  //EAT Eastern African Time
+	210,  //MET Middle Eastern Time
+	240,  //NET Near Eastern Time
+	300,  //PLT Pakistan Labor Time
+	330,  //IST India Standard Time
+	360,  //BST Bangladesh Standard Time
+	420,  //VST Vietnam Standard Time
+	480,  //CTT China Taiwan Time
+	540,  //JST Japan Standard Time
+	570,  //ACT Australia Central Time
+	600,  //AET Australia Eastern Time
+	660,  //SST Solomon Standard Time
+	720,  //NST New Zealand Standard Time
+	-660, //MIT Midway Islands Time
+	-600, //HST Hawaii Standard Time
+	-540, //AST Alaska Standard Time
+	-480, //PST Pacific Standard Time
+	-420, //MST Mountain Standard Time
+	-360, //CST Central Standard Time
+	-300, //EST Eastern Standard Time
+	-240, //PRT Puerto rico and US Virgin Islands Time
+	-210, //CNT Canada Newfoundland Time
+	-180, //BET Brazil Eastern Time
+	-60   //CAT Central African Time
+]
+
+const trueDate = [
+	'UTC20160229111245',
+	'UTC20160229183259',
+	'UTC20150301134502',
+	'UTC20150228143659',
+	'UTC20210101053058',
+	'UTC20181231100841',
+	
+	'ECT19991225130046',
+	'EET19991225140046',
+	'EAT19991225150046',
+	'MET19991225153046',
+	'NET19991225160046',
+	'PLT19991225170046',
+	'IST19991225173046',
+	'BST19991225180046',
+	'VST19991225190046',
+	'CTT19991225200046',
+	'JST19991225210046',
+	'ACT19991225213046',
+	'AET19991225220046',
+	'SST19991225230046',
+	'NST19991226000046',
+	'MIT19991225010046',
+	'HST19991225020046',
+	'AST19991225030046',
+	'PST19991225040046',
+	'MST19991225050046',
+	'CST19991225060046',
+	'EST19991225070046',
+	'PRT19991225080046',
+	'CNT19991225083046',
+	'BET19991225090046',
+	'CAT19991225110046'
+]
+
+
+describe('timestamp', function() {
+	it('should return valid dates for edge cases of leap years', function() {
+		let regex = new RegExp('^([a-z]|[A-Z]){3}[0-9]{14}$')
+		for (let i = 0; i < 6; i++) {
+			let testDate = timestamp(checkDates[i], checkOffsets[i])
+			
+			assert.isTrue(regex.test(testDate), 'regex should match on output')
+			assert.equal(testDate, trueDate[i], 'These dates should match exactly')
+		}
+	})
+	
+	it('should give back a valid date structure with no arguments', function() {
+		let regex = new RegExp('^([a-z]|[A-Z]){3}[0-9]{14}$')
+		
+		let testDate = timestamp()
+		
+		assert.isTrue(regex.test(testDate))
+	})
+	
+	it('should be able to convert standard time zones when given offsets manually', function() {
+		let regex = new RegExp('^([a-z]|[A-Z]){3}[0-9]{14}$')
+		for (let i = 6; i < trueDate.length; i++) {
+			let testDate = timestamp(checkDates[6], checkOffsets[i])
+			
+			assert.isTrue(regex.test(testDate), 'regex should match on output')
+			assert.equal(testDate, trueDate[i], 'These dates should match exactly')
+		}
+	})
+})
+
+


### PR DESCRIPTION
Currently you are using whatever timezone the user who creates migrations has for their migration file names. This Pull will change the timestamps to all be UTC by default. I also added in a Rest API parameter to the function so you can pass it a standard offset(the const array at the top of timestamp.js) to change the timezone for the file. I would think adding a timezone option in the knexfile.js for users would allow teams to use a central timezone such as EST or JST. Right now teams that are not co-geo-located together have to finagle files to get migrate:latest to work properly since the files do not use UTC by default.

TLDR: formats all times for migrate:make and seed:make files to UTC.