### PR TITLE
Add transaction isolation support

### DIFF
--- a/lib/dialects/mssql/transaction.js
+++ b/lib/dialects/mssql/transaction.js
@@ -111,6 +111,7 @@ function nameToIsolationLevelEnum(level) {
       `Unknown Isolation level, was expecting one of: ${JSON.stringify(keys)}`
     );
   }
+  return knownEnum;
 }
 
 // Based on: https://github.com/tediousjs/node-mssql/blob/master/lib/isolationlevel.js

--- a/lib/dialects/mssql/transaction.js
+++ b/lib/dialects/mssql/transaction.js
@@ -101,19 +101,23 @@ module.exports = class Transaction_MSSQL extends Transaction {
 /** MSSQL is annoying this way */
 function nameToIsolationLevelEnum(level) {
   if (!level) return;
-  level = level.toLowerCase();
-  switch (level) {
-    case 'read uncommitted':
-      return 'READ_UNCOMMITTED';
-    case 'read committed':
-      return 'READ_COMMITTED';
-    case 'repeatable read':
-      return 'REPEATABLE_READ';
-    case 'snapshot':
-      return 'SNAPSHOT';
-    case 'serializable':
-      return 'SERIALIZABLE';
-    default:
-      return level;
+  level = level.toUpperCase().replace(' ', '_');
+  const knownEnum = isolationEnum[level];
+  if (!knownEnum) {
+    const keys = Object.keys(isolationEnum).map((key) =>
+      key.toLowerCase().replace('_', ' ')
+    );
+    throw new Error(
+      `Unknown Isolation level, was expecting one of: ${JSON.stringify(keys)}`
+    );
   }
 }
+
+// Based on: https://github.com/tediousjs/node-mssql/blob/master/lib/isolationlevel.js
+const isolationEnum = {
+  READ_UNCOMMITTED: 0x01,
+  READ_COMMITTED: 0x02,
+  REPEATABLE_READ: 0x03,
+  SERIALIZABLE: 0x04,
+  SNAPSHOT: 0x05,
+};

--- a/lib/dialects/mssql/transaction.js
+++ b/lib/dialects/mssql/transaction.js
@@ -4,7 +4,9 @@ const debug = require('debug')('knex:tx');
 module.exports = class Transaction_MSSQL extends Transaction {
   begin(conn) {
     debug('%s: begin', this.txid);
-    return conn.tx_.begin().then(this._resolver, this._rejecter);
+    return conn.tx_
+      .begin(this.isolationLevel)
+      .then(this._resolver, this._rejecter);
   }
 
   async savepoint(conn) {

--- a/lib/dialects/mssql/transaction.js
+++ b/lib/dialects/mssql/transaction.js
@@ -100,6 +100,7 @@ module.exports = class Transaction_MSSQL extends Transaction {
 
 /** MSSQL is annoying this way */
 function nameToIsolationLevelEnum(level) {
+  if (!level) return;
   level = level.toLowerCase();
   switch (level) {
     case 'read uncommitted':

--- a/lib/dialects/mssql/transaction.js
+++ b/lib/dialects/mssql/transaction.js
@@ -104,11 +104,10 @@ function nameToIsolationLevelEnum(level) {
   level = level.toUpperCase().replace(' ', '_');
   const knownEnum = isolationEnum[level];
   if (!knownEnum) {
-    const keys = Object.keys(isolationEnum).map((key) =>
-      key.toLowerCase().replace('_', ' ')
-    );
     throw new Error(
-      `Unknown Isolation level, was expecting one of: ${JSON.stringify(keys)}`
+      `Unknown Isolation level, was expecting one of: ${JSON.stringify(
+        humanReadableKeys
+      )}`
     );
   }
   return knownEnum;
@@ -122,3 +121,6 @@ const isolationEnum = {
   SERIALIZABLE: 0x04,
   SNAPSHOT: 0x05,
 };
+const humanReadableKeys = Object.keys(isolationEnum).map((key) =>
+  key.toLowerCase().replace('_', ' ')
+);

--- a/lib/dialects/mssql/transaction.js
+++ b/lib/dialects/mssql/transaction.js
@@ -5,7 +5,7 @@ module.exports = class Transaction_MSSQL extends Transaction {
   begin(conn) {
     debug('%s: begin', this.txid);
     return conn.tx_
-      .begin(this.isolationLevel)
+      .begin(nameToIsolationLevelEnum(this.isolationLevel))
       .then(this._resolver, this._rejecter);
   }
 
@@ -97,3 +97,22 @@ module.exports = class Transaction_MSSQL extends Transaction {
     }
   }
 };
+
+/** MSSQL is annoying this way */
+function nameToIsolationLevelEnum(level) {
+  level = level.toLowerCase();
+  switch (level) {
+    case 'read uncommitted':
+      return 'READ_UNCOMMITTED';
+    case 'read committed':
+      return 'READ_COMMITTED';
+    case 'repeatable read':
+      return 'REPEATABLE_READ';
+    case 'snapshot':
+      return 'SNAPSHOT';
+    case 'serializable':
+      return 'SERIALIZABLE';
+    default:
+      return level;
+  }
+}

--- a/lib/dialects/mssql/transaction.js
+++ b/lib/dialects/mssql/transaction.js
@@ -98,7 +98,6 @@ module.exports = class Transaction_MSSQL extends Transaction {
   }
 };
 
-/** MSSQL is annoying this way */
 function nameToIsolationLevelEnum(level) {
   if (!level) return;
   level = level.toUpperCase().replace(' ', '_');

--- a/lib/dialects/oracledb/transaction.js
+++ b/lib/dialects/oracledb/transaction.js
@@ -4,7 +4,11 @@ const debugTx = require('debug')('knex:tx');
 
 module.exports = class Oracle_Transaction extends Transaction {
   // disable autocommit to allow correct behavior (default is true)
-  begin() {
+  begin(conn) {
+    if (this.isolationLevel) {
+      // Only supports read committed and serializable, there's also a "read only"
+      return this.query(conn, `SET TRANSACTION ${this.isolationLevel}`);
+    }
     return Promise.resolve();
   }
 

--- a/lib/dialects/oracledb/transaction.js
+++ b/lib/dialects/oracledb/transaction.js
@@ -14,7 +14,12 @@ module.exports = class Oracle_Transaction extends Transaction {
           'Oracle only supports read committed and serializable transactions, ignoring the isolation level param'
         );
       } else {
-        return this.query(conn, `SET TRANSACTION ${this.isolationLevel}`);
+        this.client.logger.warn(
+          'Not supporting Oracle transaction isolation right now'
+        );
+        // I tried this, but it didn't work
+        // Doc here: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/SET-TRANSACTION.html
+        // return this.query(conn, `SET TRANSACTION ${this.isolationLevel}`);
       }
     }
     return Promise.resolve();

--- a/lib/dialects/oracledb/transaction.js
+++ b/lib/dialects/oracledb/transaction.js
@@ -2,12 +2,20 @@ const Transaction = require('../../execution/transaction');
 const { timeout, KnexTimeoutError } = require('../../util/timeout');
 const debugTx = require('debug')('knex:tx');
 
+const supportedIsolationLevels = ['read committed', 'serializable'];
+
 module.exports = class Oracle_Transaction extends Transaction {
   // disable autocommit to allow correct behavior (default is true)
   begin(conn) {
     if (this.isolationLevel) {
-      // Only supports read committed and serializable, there's also a "read only"
-      return this.query(conn, `SET TRANSACTION ${this.isolationLevel}`);
+      // There's also a "read only", but that's not really an "isolationLevel"
+      if (!supportedIsolationLevels.includes(this.isolationLevel)) {
+        this.client.logger.warn(
+          'Oracle only supports read committed and serializable transactions, ignoring the isolation level param'
+        );
+      } else {
+        return this.query(conn, `SET TRANSACTION ${this.isolationLevel}`);
+      }
     }
     return Promise.resolve();
   }

--- a/lib/dialects/oracledb/transaction.js
+++ b/lib/dialects/oracledb/transaction.js
@@ -2,24 +2,29 @@ const Transaction = require('../../execution/transaction');
 const { timeout, KnexTimeoutError } = require('../../util/timeout');
 const debugTx = require('debug')('knex:tx');
 
+// There's also a "read only", but that's not really an "isolationLevel"
 const supportedIsolationLevels = ['read committed', 'serializable'];
+// Remove this if you make it work and set it to true
+const isIsolationLevelEnabled = false;
 
 module.exports = class Oracle_Transaction extends Transaction {
   // disable autocommit to allow correct behavior (default is true)
   begin(conn) {
     if (this.isolationLevel) {
-      // There's also a "read only", but that's not really an "isolationLevel"
-      if (!supportedIsolationLevels.includes(this.isolationLevel)) {
-        this.client.logger.warn(
-          'Oracle only supports read committed and serializable transactions, ignoring the isolation level param'
-        );
+      if (isIsolationLevelEnabled) {
+        if (!supportedIsolationLevels.includes(this.isolationLevel)) {
+          this.client.logger.warn(
+            'Oracle only supports read committed and serializable transactions, ignoring the isolation level param'
+          );
+        } else {
+          // I tried this, but it didn't work
+          // Doc here: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/SET-TRANSACTION.html
+          return this.query(conn, `SET TRANSACTION ${this.isolationLevel}`);
+        }
       } else {
         this.client.logger.warn(
-          'Not supporting Oracle transaction isolation right now'
+          'Transaction isolation is not currently supported for Oracle'
         );
-        // I tried this, but it didn't work
-        // Doc here: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/SET-TRANSACTION.html
-        // return this.query(conn, `SET TRANSACTION ${this.isolationLevel}`);
       }
     }
     return Promise.resolve();

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -5,6 +5,7 @@ const map = require('lodash/map');
 const { promisify, inherits } = require('util');
 const Client = require('../../client');
 
+const Transaction = require('./transaction');
 const QueryCompiler = require('./query/compiler');
 const ColumnCompiler = require('./schema/columncompiler');
 const TableCompiler = require('./schema/tablecompiler');
@@ -25,6 +26,10 @@ function Client_PG(config) {
 inherits(Client_PG, Client);
 
 Object.assign(Client_PG.prototype, {
+  transaction() {
+    return new Transaction(this, ...arguments);
+  },
+
   queryCompiler() {
     return new QueryCompiler(this, ...arguments);
   },

--- a/lib/dialects/postgres/transaction.js
+++ b/lib/dialects/postgres/transaction.js
@@ -4,9 +4,8 @@ class Transaction_PG extends Transaction {
   begin(conn) {
     if (this.isolationLevel) {
       return this.query(conn, `BEGIN ISOLATION LEVEL ${this.isolationLevel};`);
-    } else {
-      return this.query(conn, 'BEGIN;');
     }
+    return this.query(conn, 'BEGIN;');
   }
 }
 

--- a/lib/dialects/postgres/transaction.js
+++ b/lib/dialects/postgres/transaction.js
@@ -1,0 +1,13 @@
+const Transaction = require('../../execution/transaction');
+
+class Transaction_PG extends Transaction {
+  begin(conn) {
+    if (this.isolationLevel) {
+      return this.query(conn, `BEGIN ISOLATION LEVEL ${this.isolationLevel};`);
+    } else {
+      return this.query(conn, 'BEGIN;');
+    }
+  }
+}
+
+module.exports = Transaction_PG;

--- a/lib/dialects/redshift/transaction.js
+++ b/lib/dialects/redshift/transaction.js
@@ -1,6 +1,14 @@
 const Transaction = require('../../execution/transaction');
 
 module.exports = class Redshift_Transaction extends Transaction {
+  begin(conn) {
+    if (this.isolationLevel) {
+      return this.query(conn, `BEGIN ISOLATION LEVEL ${this.isolationLevel};`);
+    } else {
+      return this.query(conn, 'BEGIN;');
+    }
+  }
+
   savepoint(conn) {
     this.trxClient.logger('Redshift does not support savepoints.');
     return Promise.resolve();

--- a/lib/dialects/redshift/transaction.js
+++ b/lib/dialects/redshift/transaction.js
@@ -4,9 +4,8 @@ module.exports = class Redshift_Transaction extends Transaction {
   begin(conn) {
     if (this.isolationLevel) {
       return this.query(conn, `BEGIN ISOLATION LEVEL ${this.isolationLevel};`);
-    } else {
-      return this.query(conn, 'BEGIN;');
     }
+    return this.query(conn, 'BEGIN;');
   }
 
   savepoint(conn) {

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -6,6 +6,7 @@ const { promisify, inherits } = require('util');
 
 const Client = require('../../client');
 
+const Transaction = require('./transaction');
 const QueryCompiler = require('./query/compiler');
 const SchemaCompiler = require('./schema/compiler');
 const ColumnCompiler = require('./schema/columncompiler');
@@ -37,6 +38,10 @@ Object.assign(Client_SQLite3.prototype, {
 
   schemaCompiler() {
     return new SchemaCompiler(this, ...arguments);
+  },
+
+  transaction() {
+    return new Transaction(this, ...arguments);
   },
 
   queryCompiler() {

--- a/lib/dialects/sqlite3/transaction.js
+++ b/lib/dialects/sqlite3/transaction.js
@@ -7,8 +7,8 @@ class Transaction_Sqlite extends Transaction {
     // There is a `PRAGMA read_uncommitted = true;`, but that's probably not
     // what the user wants
     if (this.isolationLevel) {
-      throw new Error(
-        'sqlite3 only supports "serializable", don\'t try and set the isolation level'
+      this.client.logger.warn(
+        'sqlite3 only supports serializable transactions, ignoring the isolation level param'
       );
     }
     return this.query(conn, 'BEGIN;');

--- a/lib/dialects/sqlite3/transaction.js
+++ b/lib/dialects/sqlite3/transaction.js
@@ -6,10 +6,11 @@ class Transaction_Sqlite extends Transaction {
     // default and so we override it to ignore isolation level.
     // There is a `PRAGMA read_uncommitted = true;`, but that's probably not
     // what the user wants
-    //
-    // As a style choice the alternative is to throw an error here if an
-    // isolation level is set, but the default doesn't make sense as it doesn't
-    // produce a useful error message
+    if (this.isolationLevel) {
+      throw new Error(
+        'sqlite3 only supports "serializable", don\'t try and set the isolation level'
+      );
+    }
     return this.query(conn, 'BEGIN;');
   }
 }

--- a/lib/dialects/sqlite3/transaction.js
+++ b/lib/dialects/sqlite3/transaction.js
@@ -1,0 +1,12 @@
+const Transaction = require('../../execution/transaction');
+
+class Transaction_Sqlite extends Transaction {
+  begin(conn) {
+    const setIsolationLevel = this.isolationLevel
+      ? this.query(conn, `PRAGMA read_uncommitted = true;`)
+      : Promise.resolve();
+    return setIsolationLevel.then(() => this.query(conn, 'BEGIN;'));
+  }
+}
+
+module.exports = Transaction_Sqlite;

--- a/lib/dialects/sqlite3/transaction.js
+++ b/lib/dialects/sqlite3/transaction.js
@@ -2,10 +2,15 @@ const Transaction = require('../../execution/transaction');
 
 class Transaction_Sqlite extends Transaction {
   begin(conn) {
-    const setIsolationLevel = this.isolationLevel
-      ? this.query(conn, `PRAGMA read_uncommitted = true;`)
-      : Promise.resolve();
-    return setIsolationLevel.then(() => this.query(conn, 'BEGIN;'));
+    // SQLite doesn't really support isolation levels, it is serializable by
+    // default and so we override it to ignore isolation level.
+    // There is a `PRAGMA read_uncommitted = true;`, but that's probably not
+    // what the user wants
+    //
+    // As a style choice the alternative is to throw an error here if an
+    // isolation level is set, but the default doesn't make sense as it doesn't
+    // produce a useful error message
+    return this.query(conn, 'BEGIN;');
   }
 }
 

--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -79,7 +79,10 @@ class Transaction extends EventEmitter {
 
   begin(conn) {
     const setIsolationLevel = this.isolationLevel
-      ? this.query(conn, `SET ISOLATION LEVEL ${this.isolationLevel};`)
+      ? this.query(
+          conn,
+          `SET TRANSACTION ISOLATION LEVEL ${this.isolationLevel};`
+        )
       : Promise.resolve();
     return setIsolationLevel.then(() => this.query(conn, 'BEGIN;'));
   }

--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -94,13 +94,13 @@ class Transaction extends EventEmitter {
   }
 
   begin(conn) {
-    const setIsolationLevel = this.isolationLevel
+    const runIsolationLevelQuery = this.isolationLevel
       ? this.query(
           conn,
           `SET TRANSACTION ISOLATION LEVEL ${this.isolationLevel};`
         )
       : Promise.resolve();
-    return setIsolationLevel.then(() => this.query(conn, 'BEGIN;'));
+    return runIsolationLevelQuery.then(() => this.query(conn, 'BEGIN;'));
   }
 
   savepoint(conn) {

--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -55,6 +55,10 @@ class Transaction extends EventEmitter {
     this._completed = false;
     this._debug = client.config && client.config.debug;
 
+    if (config.isolationLevel) {
+      this.setIsolationLevel(config.isolationLevel);
+    }
+
     debug(
       '%s: Starting %s transaction',
       txid,

--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -96,10 +96,10 @@ class Transaction extends EventEmitter {
     return this.query(conn, `RELEASE SAVEPOINT ${this.txid};`, 1, value);
   }
 
-  setIsolationLevel = (value) => {
+  setIsolationLevel(value) {
     this.isolationLevel = value;
     return this;
-  };
+  }
 
   rollback(conn, error) {
     return timeout(this.query(conn, 'ROLLBACK', 2, error), 5000).catch(

--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -188,9 +188,6 @@ class Transaction extends EventEmitter {
           // Directly thrown errors are treated as automatic rollbacks.
           let result;
           try {
-            if (!container) {
-              container = this._resolver;
-            }
             result = container(transactor);
           } catch (err) {
             result = Promise.reject(err);

--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -78,7 +78,10 @@ class Transaction extends EventEmitter {
   }
 
   begin(conn) {
-    return this.query(conn, 'BEGIN;');
+    const setIsolationLevel = this.isolationLevel
+      ? this.query(conn, `SET ISOLATION LEVEL ${this.isolationLevel};`)
+      : Promise.resolve();
+    return setIsolationLevel.then(() => this.query(conn, 'BEGIN;'));
   }
 
   savepoint(conn) {
@@ -92,6 +95,11 @@ class Transaction extends EventEmitter {
   release(conn, value) {
     return this.query(conn, `RELEASE SAVEPOINT ${this.txid};`, 1, value);
   }
+
+  setIsolationLevel = (value) => {
+    this.isolationLevel = value;
+    return this;
+  };
 
   rollback(conn, error) {
     return timeout(this.query(conn, 'ROLLBACK', 2, error), 5000).catch(
@@ -180,6 +188,9 @@ class Transaction extends EventEmitter {
           // Directly thrown errors are treated as automatic rollbacks.
           let result;
           try {
+            if (!container) {
+              container = this._resolver;
+            }
             result = container(transactor);
           } catch (err) {
             result = Promise.reject(err);

--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -21,6 +21,22 @@ function DEFAULT_CONFIG() {
     doNotRejectOnRollback: true,
   };
 }
+// These aren't supported in sqlite3 which is serialized already so it's as
+// safe as reasonable, except for a special read_uncommitted pragma
+const validIsolationLevels = [
+  // Doesn't really work in postgres, it treats it as read committed
+  'read uncommitted',
+  'read committed',
+  'snapshot',
+  // snapshot and repeatable read are basically the same, most "repeatable
+  // read" implementations are actually "snapshot" also known as Multi Version
+  // Concurrency Control (MVCC). Mssql's repeatable read doesn't stop
+  // repeated reads for inserts as it uses a pessimistic locking system so
+  // you should probably use 'snapshot' to stop read skew.
+  'repeatable read',
+  // mysql pretends to have serializable, but it is not
+  'serializable',
+];
 
 // Acts as a facade for a Promise, keeping the internal state
 // and managing any child transactions.
@@ -99,8 +115,15 @@ class Transaction extends EventEmitter {
     return this.query(conn, `RELEASE SAVEPOINT ${this.txid};`, 1, value);
   }
 
-  setIsolationLevel(value) {
-    this.isolationLevel = value;
+  setIsolationLevel(isolationLevel) {
+    if (!validIsolationLevels.includes(isolationLevel)) {
+      throw new Error(
+        `Invalid isolationLevel, supported isolation levels are: ${JSON.stringify(
+          validIsolationLevels
+        )}`
+      );
+    }
+    this.isolationLevel = isolationLevel;
     return this;
   }
 

--- a/lib/knex-builder/make-knex.js
+++ b/lib/knex-builder/make-knex.js
@@ -6,6 +6,7 @@ const FunctionHelper = require('./FunctionHelper');
 const QueryInterface = require('../query/methods');
 const merge = require('lodash/merge');
 const batchInsert = require('../execution/batch-insert');
+const { isObject } = require('../util/is');
 
 // Javascript does not officially support "callable objects".  Instead,
 // you must create a regular Function and inject properties/methods
@@ -124,7 +125,7 @@ function initContext(knexFn) {
     // when transaction is ready to be used.
     transaction(container, _config) {
       // Overload support of `transaction(config)`
-      if (!_config && typeof container === 'object') {
+      if (!_config && isObject(container)) {
         _config = container;
         container = null;
       }

--- a/lib/knex-builder/make-knex.js
+++ b/lib/knex-builder/make-knex.js
@@ -123,6 +123,12 @@ function initContext(knexFn) {
     // If container is not provided, returns a promise with a transaction that is resolved
     // when transaction is ready to be used.
     transaction(container, _config) {
+      // Overload support of `transaction(config)`
+      if (!_config && typeof container === 'object') {
+        _config = container;
+        container = null;
+      }
+
       const config = Object.assign({}, _config);
       config.userParams = this.userParams || {};
       if (config.doNotRejectOnRollback === undefined) {
@@ -141,21 +147,9 @@ function initContext(knexFn) {
         const trx = this.client.transaction(container, config, outerTx);
         return trx;
       } else {
-        // Added a setIsolationLevel and because we made this expect to return
-        // a promise rather than a transaction object, had to do this fancy stuff
-        let _resolve = () => {};
-        let _reject = () => {};
-        const p = new Promise((resolve, reject) => {
-          _resolve = resolve;
-          _reject = reject;
+        return new Promise((resolve, reject) => {
+          this.client.transaction(resolve, config, outerTx).catch(reject);
         });
-        const trx = this.client.transaction(_resolve, config, outerTx);
-        trx.catch(_reject);
-        p.setIsolationLevel = (value) => {
-          trx.setIsolationLevel(value);
-          return p;
-        };
-        return p;
       }
     },
 

--- a/lib/knex-builder/make-knex.js
+++ b/lib/knex-builder/make-knex.js
@@ -141,6 +141,8 @@ function initContext(knexFn) {
         const trx = this.client.transaction(container, config, outerTx);
         return trx;
       } else {
+        // Added a setIsolationLevel and because we made this expect to return
+        // a promise rather than a transaction object, had to do this fancy stuff
         let _resolve = () => {};
         let _reject = () => {};
         const p = new Promise((resolve, reject) => {

--- a/lib/knex-builder/make-knex.js
+++ b/lib/knex-builder/make-knex.js
@@ -141,10 +141,8 @@ function initContext(knexFn) {
         const trx = this.client.transaction(container, config, outerTx);
         return trx;
       } else {
-        return new Promise((resolve, reject) => {
-          const trx = this.client.transaction(resolve, config, outerTx);
-          trx.catch(reject);
-        });
+        const trx = this.client.transaction(null, config, outerTx);
+        return trx;
       }
     },
 

--- a/lib/knex-builder/make-knex.js
+++ b/lib/knex-builder/make-knex.js
@@ -141,8 +141,19 @@ function initContext(knexFn) {
         const trx = this.client.transaction(container, config, outerTx);
         return trx;
       } else {
-        const trx = this.client.transaction(null, config, outerTx);
-        return trx;
+        let _resolve = () => {};
+        let _reject = () => {};
+        const p = new Promise((resolve, reject) => {
+          _resolve = resolve;
+          _reject = reject;
+        });
+        const trx = this.client.transaction(_resolve, config, outerTx);
+        trx.catch(_reject);
+        p.setIsolationLevel = (value) => {
+          trx.setIsolationLevel(value);
+          return p;
+        };
+        return p;
       }
     },
 

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - bash
       - -c
       # https://docs.microsoft.com/en-us/sql/relational-databases/logs/control-transaction-durability?view=sql-server-ver15#bkmk_DbControl
-      - 'until /opt/mssql-tools/bin/sqlcmd -S mssql -U sa -P S0meVeryHardPassword -d master -Q "CREATE DATABASE knex_test; ALTER DATABASE knex_test SET DELAYED_DURABILITY = FORCED"; do sleep 5; done'
+      - 'until /opt/mssql-tools/bin/sqlcmd -S mssql -U sa -P S0meVeryHardPassword -d master -Q "CREATE DATABASE knex_test; ALTER DATABASE knex_test SET ALLOW_SNAPSHOT_ISOLATION ON; ALTER DATABASE knex_test SET DELAYED_DURABILITY = FORCED"; do sleep 5; done'
 
   mysql:
     image: mysql

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -46,6 +46,7 @@ describe('Transaction', () => {
           if (isSQLite(knex)) {
             return;
           }
+          // NOTE: for mssql, it requires an alter database call that happens in docker-compose
           const isolationLevel = isMssql(knex) ? 'snapshot' : 'repeatable read';
           const trx = await knex
             .transaction()

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -52,12 +52,17 @@ describe('Transaction', () => {
             );
           }
           const isolationLevel = isMssql(knex) ? 'snapshot' : 'repeatable read';
+          console.log('before transaction');
           const trx = await knex
             .transaction()
             .setIsolationLevel(isolationLevel);
+          console.log('before select');
           const result1 = await trx(tableName).select();
+          console.log('before insert');
           await knex(tableName).insert({ id: 1, value: 1 });
+          console.log('after insert');
           const result2 = await trx(tableName).select();
+          console.log('after select');
           await trx.commit();
           expect(result1).to.deep.equal(result2);
         });

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -47,9 +47,9 @@ describe('Transaction', () => {
             return;
           }
           if (isMssql(knex)) {
-            await knex.raw(
-              'ALTER DATABASE knex_test SET ALLOW_SNAPSHOT_ISOLATION ON'
-            );
+            await knex
+              .raw('ALTER DATABASE knex_test SET ALLOW_SNAPSHOT_ISOLATION ON')
+              .timeout(500);
           }
           const isolationLevel = isMssql(knex) ? 'snapshot' : 'repeatable read';
           console.log('before transaction');
@@ -57,11 +57,11 @@ describe('Transaction', () => {
             .transaction()
             .setIsolationLevel(isolationLevel);
           console.log('before select');
-          const result1 = await trx(tableName).select();
+          const result1 = await trx(tableName).select().timeout(500);
           console.log('before insert');
-          await knex(tableName).insert({ id: 1, value: 1 });
+          await knex(tableName).insert({ id: 1, value: 1 }).timeout(500);
           console.log('after insert');
-          const result2 = await trx(tableName).select();
+          const result2 = await trx(tableName).select().timeout(500);
           console.log('after select');
           await trx.commit();
           expect(result1).to.deep.equal(result2);

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -42,13 +42,15 @@ describe('Transaction', () => {
           expect(result1).to.not.equal(result2);
         });
 
-        it('Expect to avoid read skew when repeatable read (snapshot isolation)', async () => {
+        it.only('Expect to avoid read skew when repeatable read (snapshot isolation)', async () => {
           if (isSQLite(knex)) {
             return;
           }
           if (isMssql(knex)) {
             await knex
-              .raw('ALTER DATABASE knex_test SET ALLOW_SNAPSHOT_ISOLATION ON')
+              .raw(
+                'ALTER DATABASE knex_test SET ALLOW_SNAPSHOT_ISOLATION ON WITH ROLLBACK IMMEDIATE'
+              )
               .timeout(500)
               .catch(() => {
                 throw new Error('alter db');

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -46,6 +46,11 @@ describe('Transaction', () => {
           if (isSQLite(knex)) {
             return;
           }
+          if (isMssql(knex)) {
+            await knex.raw(
+              'ALTER DATABASE knex_test SET ALLOW_SNAPSHOT_ISOLATION ON'
+            );
+          }
           const isolationLevel = isMssql(knex) ? 'snapshot' : 'repeatable read';
           const trx = await knex
             .transaction()

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -32,9 +32,9 @@ describe('Transaction', () => {
           if (isSQLite(knex)) {
             return;
           }
-          const trx = await knex
-            .transaction()
-            .setIsolationLevel('read committed');
+          const trx = await knex.transaction({
+            isolationLevel: 'read committed',
+          });
           const result1 = await trx(tableName).select();
           await knex(tableName).insert({ id: 1, value: 1 });
           const result2 = await trx(tableName).select();
@@ -53,9 +53,7 @@ describe('Transaction', () => {
             : isMssql(knex)
             ? 'snapshot'
             : 'repeatable read';
-          const trx = await knex
-            .transaction()
-            .setIsolationLevel(isolationLevel);
+          const trx = await knex.transaction({ isolationLevel });
           const result1 = await trx(tableName).select();
           await knex(tableName).insert({ id: 1, value: 1 });
           const result2 = await trx(tableName).select();

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -27,7 +27,7 @@ describe('Transaction', () => {
           await knex.schema.dropTable(tableName);
         });
 
-        it('Expect to read transactions when read uncommited', async () => {
+        it('Expect to read transactions when read uncommitted', async () => {
           if (isSQLite(knex)) {
             return this.skip();
           }
@@ -37,23 +37,23 @@ describe('Transaction', () => {
               const result = await knex(tableName).select();
               expect(result.length).to.equal(1);
             })
-            .setIsolationLevel('read uncommited');
+            .setIsolationLevel('read uncommitted');
         });
 
-        it('Expect to not read transactions when read commited', async () => {
+        it('Expect to not read transactions when read committed', async () => {
           await knex
             .transaction(async (trx) => {
               await trx(tableName).insert({ id: 1, value: 1 });
               const result = await knex(tableName).select();
               expect(result.length).to.equal(0);
             })
-            .setIsolationLevel('read commited');
+            .setIsolationLevel('read committed');
         });
 
-        it('Expect to not read transactions when read commited alternative syntax', async () => {
+        it('Expect to not read transactions when read committed alternative syntax', async () => {
           const trx = await knex
             .transaction()
-            .setIsolationLevel('read commited');
+            .setIsolationLevel('read committed');
           await trx(tableName).insert({ id: 1, value: 1 });
           const result = await knex(tableName).select();
           await trx.commit();

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -1,5 +1,5 @@
 const { getAllDbs, getKnexForDb } = require('../util/knex-instance-provider');
-const { isSQLite, isMssql } = require('../../util/db-helpers');
+const { isSQLite, isMssql, isOracle } = require('../../util/db-helpers');
 const { expect } = require('chai');
 
 describe('Transaction', () => {
@@ -47,7 +47,12 @@ describe('Transaction', () => {
             return;
           }
           // NOTE: for mssql, it requires an alter database call that happens in docker-compose
-          const isolationLevel = isMssql(knex) ? 'snapshot' : 'repeatable read';
+          // Oracle only supports Serializable, so lets use that for this test
+          const isolationLevel = isOracle(knex)
+            ? 'serializable'
+            : isMssql(knex)
+            ? 'snapshot'
+            : 'repeatable read';
           const trx = await knex
             .transaction()
             .setIsolationLevel(isolationLevel);

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -46,25 +46,32 @@ describe('Transaction', () => {
           if (isSQLite(knex)) {
             return;
           }
-          if (isMssql(knex)) {
-            await knex
-              .raw('ALTER DATABASE knex_test SET ALLOW_SNAPSHOT_ISOLATION ON')
-              .timeout(500);
+          try {
+            if (isMssql(knex)) {
+              await knex
+                .raw('ALTER DATABASE knex_test SET ALLOW_SNAPSHOT_ISOLATION ON')
+                .timeout(500);
+            }
+            const isolationLevel = isMssql(knex)
+              ? 'snapshot'
+              : 'repeatable read';
+            console.log('before transaction');
+            const trx = await knex
+              .transaction()
+              .setIsolationLevel(isolationLevel);
+            console.log('before select');
+            const result1 = await trx(tableName).select().timeout(500);
+            console.log('before insert');
+            await knex(tableName).insert({ id: 1, value: 1 }).timeout(500);
+            console.log('after insert');
+            const result2 = await trx(tableName).select().timeout(500);
+            console.log('after select');
+            await trx.commit();
+            expect(result1).to.deep.equal(result2);
+          } catch (err) {
+            console.error(err);
+            throw err;
           }
-          const isolationLevel = isMssql(knex) ? 'snapshot' : 'repeatable read';
-          console.log('before transaction');
-          const trx = await knex
-            .transaction()
-            .setIsolationLevel(isolationLevel);
-          console.log('before select');
-          const result1 = await trx(tableName).select().timeout(500);
-          console.log('before insert');
-          await knex(tableName).insert({ id: 1, value: 1 }).timeout(500);
-          console.log('after insert');
-          const result2 = await trx(tableName).select().timeout(500);
-          console.log('after select');
-          await trx.commit();
-          expect(result1).to.deep.equal(result2);
         });
       });
     });

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -1,5 +1,5 @@
 const { getAllDbs, getKnexForDb } = require('../util/knex-instance-provider');
-const { isSQLite, isPostgreSQL } = require('../../util/db-helpers');
+const { isSQLite, isMssql } = require('../../util/db-helpers');
 const { expect } = require('chai');
 
 describe('Transaction', () => {
@@ -46,9 +46,10 @@ describe('Transaction', () => {
           if (isSQLite(knex)) {
             return;
           }
+          const isolationLevel = isMssql(knex) ? 'snapshot' : 'repeatable read';
           const trx = await knex
             .transaction()
-            .setIsolationLevel('repeatable read');
+            .setIsolationLevel(isolationLevel);
           const result1 = await trx(tableName).select();
           await knex(tableName).insert({ id: 1, value: 1 });
           const result2 = await trx(tableName).select();

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -43,16 +43,11 @@ describe('Transaction', () => {
         });
 
         it('Expect to avoid read skew when repeatable read (snapshot isolation)', async () => {
-          if (isSQLite(knex)) {
+          if (isSQLite(knex) || isOracle(knex)) {
             return;
           }
           // NOTE: for mssql, it requires an alter database call that happens in docker-compose
-          // Oracle only supports Serializable, so lets use that for this test
-          const isolationLevel = isOracle(knex)
-            ? 'serializable'
-            : isMssql(knex)
-            ? 'snapshot'
-            : 'repeatable read';
+          const isolationLevel = isMssql(knex) ? 'snapshot' : 'repeatable read';
           const trx = await knex.transaction({ isolationLevel });
           const result1 = await trx(tableName).select();
           await knex(tableName).insert({ id: 1, value: 1 });

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -1,8 +1,5 @@
-const {
-  getAllDbs,
-  getKnexForDb,
-} = require('../../util/knex-instance-provider');
-const { isSQLite } = require('../../../util/db-helpers');
+const { getAllDbs, getKnexForDb } = require('../util/knex-instance-provider');
+const { isSQLite } = require('../../util/db-helpers');
 const { expect } = require('chai');
 
 describe('Transaction', () => {

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -56,9 +56,9 @@ describe('Transaction', () => {
           const trx = await knex
             .transaction()
             .setIsolationLevel(isolationLevel);
-          const result1 = await trx(tableName).select().timeout(500);
-          await knex(tableName).insert({ id: 1, value: 1 }).timeout(500);
-          const result2 = await trx(tableName).select().timeout(500);
+          const result1 = await trx(tableName).select();
+          await knex(tableName).insert({ id: 1, value: 1 });
+          const result2 = await trx(tableName).select();
           await trx.commit();
           expect(result1).to.deep.equal(result2);
         });

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -42,7 +42,7 @@ describe('Transaction', () => {
           expect(result1).to.not.equal(result2);
         });
 
-        it.only('Expect to avoid read skew when repeatable read (snapshot isolation)', async () => {
+        it('Expect to avoid read skew when repeatable read (snapshot isolation)', async () => {
           if (isSQLite(knex)) {
             return;
           }
@@ -51,10 +51,7 @@ describe('Transaction', () => {
               .raw(
                 'ALTER DATABASE knex_test SET ALLOW_SNAPSHOT_ISOLATION ON WITH ROLLBACK IMMEDIATE'
               )
-              .timeout(500)
-              .catch(() => {
-                throw new Error('alter db');
-              });
+              .timeout(500);
           }
           const isolationLevel = isMssql(knex) ? 'snapshot' : 'repeatable read';
           const trx = await knex

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -53,7 +53,7 @@ describe('Transaction', () => {
           await knex(tableName).insert({ id: 1, value: 1 });
           const result2 = await trx(tableName).select();
           await trx.commit();
-          expect(result1).to.equal(result2);
+          expect(result1).to.deep.equal(result2);
         });
       });
     });

--- a/test/integration2/transaction/set-isolation-level.spec.js
+++ b/test/integration2/transaction/set-isolation-level.spec.js
@@ -1,0 +1,68 @@
+const {
+  getAllDbs,
+  getKnexForDb,
+} = require('../../util/knex-instance-provider');
+const { isSQLite } = require('../../../util/db-helpers');
+const { expect } = require('chai');
+
+describe('Transaction', () => {
+  describe('setIsolationLevel', () => {
+    getAllDbs().forEach((db) => {
+      describe(db, () => {
+        let knex;
+        const tableName = 'key_value';
+        before(() => {
+          knex = getKnexForDb(db);
+        });
+
+        after(() => {
+          return knex.destroy();
+        });
+
+        beforeEach(async () => {
+          await knex.schema.createTable(tableName, (table) => {
+            table.integer('id').primary().notNull();
+            table.integer('value').notNull();
+          });
+        });
+
+        afterEach(async () => {
+          await knex.schema.dropTable(tableName);
+        });
+
+        it('Expect to read transactions when read uncommited', async () => {
+          if (isSQLite(knex)) {
+            return this.skip();
+          }
+          await knex
+            .transaction(async (trx) => {
+              await trx(tableName).insert({ id: 1, value: 1 });
+              const result = await knex(tableName).select();
+              expect(result.length).to.equal(1);
+            })
+            .setIsolationLevel('read uncommited');
+        });
+
+        it('Expect to not read transactions when read commited', async () => {
+          await knex
+            .transaction(async (trx) => {
+              await trx(tableName).insert({ id: 1, value: 1 });
+              const result = await knex(tableName).select();
+              expect(result.length).to.equal(0);
+            })
+            .setIsolationLevel('read commited');
+        });
+
+        it('Expect to not read transactions when read commited alternative syntax', async () => {
+          const trx = await knex
+            .transaction()
+            .setIsolationLevel('read commited');
+          await trx(tableName).insert({ id: 1, value: 1 });
+          const result = await knex(tableName).select();
+          await trx.commit();
+          expect(result.length).to.equal(0);
+        });
+      });
+    });
+  });
+});

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -447,13 +447,6 @@ describe('knex', () => {
       return knex.destroy();
     });
 
-    it('supports transaction isolation', async () => {
-      const knex = Knex(sqliteConfig);
-      const trx = await knex.transaction().setIsolationLevel('serializable');
-      trx.commit();
-      return knex.destroy();
-    });
-
     it('does not reject rolled back nested transactions by default', async () => {
       const knex = Knex(sqliteConfig);
       const trx = await knex.transaction();

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -447,6 +447,13 @@ describe('knex', () => {
       return knex.destroy();
     });
 
+    it('supports transaction isolation', async () => {
+      const knex = Knex(sqliteConfig);
+      const trx = await knex.transaction().setIsolationLevel('serializable');
+      trx.commit();
+      return knex.destroy();
+    });
+
     it('does not reject rolled back nested transactions by default', async () => {
       const knex = Knex(sqliteConfig);
       const trx = await knex.transaction();

--- a/test/util/db-helpers.js
+++ b/test/util/db-helpers.js
@@ -2,6 +2,10 @@ function isPostgreSQL(knex) {
   return knex.client.driverName === 'pg';
 }
 
+function isMssql(knex) {
+  return knex.client.driverName === 'mssql';
+}
+
 function isOracle(knex) {
   return /oracle/i.test(knex.client.driverName);
 }
@@ -31,6 +35,7 @@ function isOneOfDbs(knex, supportedDbs) {
 module.exports = {
   isOneOfDbs,
   isMysql,
+  isMssql,
   isOracle,
   isPostgreSQL,
   isRedshift,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -330,9 +330,12 @@ interface DMLOptions {
 
 // Not all of these are possible for all drivers, notably, sqlite doesn't support any of these
 type IsolationLevels = 'read uncommitted' | 'read committed' | 'snapshot' | 'repeatable read' | 'serializable';
-interface TransactionMethods<T> {
-  setIsolationLevel: (isolationLevel: IsolationLevels) => T;
-}
+interface TransactionConfig {
+  isolationLevel?: IsolationLevels;
+  userParams?: Record<string, any>;
+  doNotRejectOnRollback?: boolean;
+  connection?: any;
+};
 
 interface Knex<TRecord extends {} = any, TResult = unknown[]>
   extends Knex.QueryInterface<TRecord, TResult>, events.EventEmitter {
@@ -350,16 +353,19 @@ interface Knex<TRecord extends {} = any, TResult = unknown[]>
   raw: Knex.RawBuilder<TRecord>;
 
   transactionProvider(
-    config?: any
+    config?: TransactionConfig
   ): () => Promise<Knex.Transaction>;
   transaction(
+    config?: TransactionConfig
+  ): Promise<Knex.Transaction>;
+  transaction(
     transactionScope?: null,
-    config?: any
-  ): Promise<Knex.Transaction> & TransactionMethods<Promise<Knex.Transaction>>;
+    config?: TransactionConfig
+  ): Promise<Knex.Transaction>;
   transaction<T>(
     transactionScope: (trx: Knex.Transaction) => Promise<T> | void,
-    config?: any
-  ): Promise<T> & TransactionMethods<Promise<T>>;
+    config?: TransactionConfig
+  ): Promise<T>;
   initialize(config?: Knex.Config): void;
   destroy(callback: Function): void;
   destroy(): Promise<void>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -328,8 +328,9 @@ interface DMLOptions {
   includeTriggerModifications?: boolean;
 }
 
+type IsolationLevels = 'read uncommitted' | 'read committed' | 'snapshot' | 'repeatable read' | 'serializable';
 interface TransactionMethods<T> {
-  setIsolationLevel: (value: string) => T;
+  setIsolationLevel: (isolationLevel: IsolationLevels) => T;
 }
 
 interface Knex<TRecord extends {} = any, TResult = unknown[]>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -328,6 +328,10 @@ interface DMLOptions {
   includeTriggerModifications?: boolean;
 }
 
+interface TransactionMethods<T> {
+  setIsolationLevel: (value: string) => T;
+}
+
 interface Knex<TRecord extends {} = any, TResult = unknown[]>
   extends Knex.QueryInterface<TRecord, TResult>, events.EventEmitter {
   <TTable extends Knex.TableNames>(
@@ -349,11 +353,11 @@ interface Knex<TRecord extends {} = any, TResult = unknown[]>
   transaction(
     transactionScope?: null,
     config?: any
-  ): Promise<Knex.Transaction>;
+  ): Promise<Knex.Transaction> & TransactionMethods<Promise<Knex.Transaction>>;
   transaction<T>(
     transactionScope: (trx: Knex.Transaction) => Promise<T> | void,
     config?: any
-  ): Promise<T>;
+  ): Promise<T> & TransactionMethods<Promise<T>>;
   initialize(config?: Knex.Config): void;
   destroy(callback: Function): void;
   destroy(): Promise<void>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -328,6 +328,7 @@ interface DMLOptions {
   includeTriggerModifications?: boolean;
 }
 
+// Not all of these are possible for all drivers, notably, sqlite doesn't support any of these
 type IsolationLevels = 'read uncommitted' | 'read committed' | 'snapshot' | 'repeatable read' | 'serializable';
 interface TransactionMethods<T> {
   setIsolationLevel: (isolationLevel: IsolationLevels) => T;


### PR DESCRIPTION
Attempt to solve #581 
Probably needs some extra tests, not sure where the best place to put them is.
Also probably needs to implement for all drivers rather than just half of them

Syntax is `knex.transaction(...).setIsolationLevel('string')`