### PR TITLE
Fix SQLite foreign key constraints when altering a table

### DIFF
--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -12,6 +12,9 @@ const {
   dropOriginal,
   renameTable,
   getTableSql,
+  isForeignCheckEnabled,
+  setForeignCheck,
+  executeForeignCheck,
 } = require('./internal/sqlite-ddl-operations');
 const { parseCreateTable, parseCreateIndex } = require('./internal/parser');
 const {
@@ -43,349 +46,323 @@ class SQLite3_DDL {
   getTableSql() {
     const tableName = this.tableName();
 
-    this.trx.disableProcessing();
-    return this.trx.raw(getTableSql(tableName)).then((result) => {
-      this.trx.enableProcessing();
-      return {
-        createTable: result.filter((create) => create.type === 'table')[0].sql,
-        createIndices: result
-          .filter((create) => create.type === 'index')
-          .map((create) => create.sql),
-      };
-    });
-  }
-
-  renameTable() {
-    return this.trx.raw(renameTable(this.alteredName, this.tableName()));
-  }
-
-  dropOriginal() {
-    return this.trx.raw(dropOriginal(this.tableName()));
-  }
-
-  copyData(columns) {
-    return this.trx.raw(copyData(this.tableName(), this.alteredName, columns));
-  }
-
-  createNewTable(sql) {
-    return this.trx.raw(
-      createNewTable(sql, this.tableName(), this.alteredName)
-    );
-  }
-
-  alterColumn(columns) {
     return this.client.transaction(
       async (trx) => {
-        this.trx = trx;
+        trx.disableProcessing();
+        const result = await trx.raw(getTableSql(tableName));
+        trx.enableProcessing();
 
-        const { createTable, createIndices } = await this.getTableSql();
-
-        const parsedTable = parseCreateTable(createTable);
-
-        parsedTable.columns = parsedTable.columns.map((column) => {
-          const newColumnInfo = columns.find((c) =>
-            isEqualId(c.name, column.name)
-          );
-
-          if (newColumnInfo) {
-            column.type = newColumnInfo.type;
-
-            column.constraints.default =
-              newColumnInfo.defaultTo !== null
-                ? {
-                    name: null,
-                    value: newColumnInfo.defaultTo,
-                    expression: false,
-                  }
-                : null;
-
-            column.constraints.notnull = newColumnInfo.notNull
-              ? { name: null, conflict: null }
-              : null;
-
-            column.constraints.null = newColumnInfo.notNull
-              ? null
-              : column.constraints.null;
-          }
-
-          return column;
-        });
-
-        const newTable = compileCreateTable(parsedTable, this.wrap);
-
-        return this.alter(newTable, createIndices);
+        return {
+          createTable: result.filter((create) => create.type === 'table')[0]
+            .sql,
+          createIndices: result
+            .filter((create) => create.type === 'index')
+            .map((create) => create.sql),
+        };
       },
       { connection: this.connection }
     );
   }
 
-  dropColumn(columns) {
-    return this.client.transaction(
-      async (trx) => {
-        this.trx = trx;
+  async isForeignCheckEnabled() {
+    const result = await this.client
+      .raw(isForeignCheckEnabled())
+      .connection(this.connection);
 
-        const { createTable, createIndices } = await this.getTableSql();
-
-        const parsedTable = parseCreateTable(createTable);
-
-        parsedTable.columns = parsedTable.columns.filter(
-          (parsedColumn) =>
-            parsedColumn.expression || !includesId(columns, parsedColumn.name)
-        );
-
-        if (parsedTable.columns.length === 0) {
-          throw new Error('Unable to drop last column from table');
-        }
-
-        parsedTable.constraints = parsedTable.constraints.filter(
-          (constraint) => {
-            if (
-              constraint.type === 'PRIMARY KEY' ||
-              constraint.type === 'UNIQUE'
-            ) {
-              return constraint.columns.every(
-                (constraintColumn) =>
-                  constraintColumn.expression ||
-                  !includesId(columns, constraintColumn.name)
-              );
-            } else if (constraint.type === 'FOREIGN KEY') {
-              return (
-                constraint.columns.every(
-                  (constraintColumnName) =>
-                    !includesId(columns, constraintColumnName)
-                ) &&
-                (constraint.references.table !== parsedTable.table ||
-                  constraint.references.columns.every(
-                    (referenceColumnName) =>
-                      !includesId(columns, referenceColumnName)
-                  ))
-              );
-            } else {
-              return true;
-            }
-          }
-        );
-
-        const newColumns = parsedTable.columns.map((column) => column.name);
-
-        const newTable = compileCreateTable(parsedTable, this.wrap);
-
-        const newIndices = [];
-        for (const createIndex of createIndices) {
-          const parsedIndex = parseCreateIndex(createIndex);
-
-          parsedIndex.columns = parsedIndex.columns.filter(
-            (parsedColumn) =>
-              parsedColumn.expression || !includesId(columns, parsedColumn.name)
-          );
-
-          if (parsedIndex.columns.length > 0) {
-            newIndices.push(compileCreateIndex(parsedIndex, this.wrap));
-          }
-        }
-
-        return this.alter(newTable, newIndices, newColumns);
-      },
-      { connection: this.connection }
-    );
+    return result[0].foreign_keys === 1;
   }
 
-  dropForeign(columns, foreignKeyName) {
-    return this.client.transaction(
-      async (trx) => {
-        this.trx = trx;
+  async setForeignCheck(enable) {
+    await this.client.raw(setForeignCheck(enable)).connection(this.connection);
+  }
 
-        const { createTable, createIndices } = await this.getTableSql();
+  renameTable(trx) {
+    return trx.raw(renameTable(this.alteredName, this.tableName()));
+  }
 
-        const parsedTable = parseCreateTable(createTable);
+  dropOriginal(trx) {
+    return trx.raw(dropOriginal(this.tableName()));
+  }
 
-        if (!foreignKeyName) {
-          parsedTable.columns = parsedTable.columns.map((column) => ({
-            ...column,
-            references: includesId(columns, column.name)
-              ? null
-              : column.references,
-          }));
-        }
+  copyData(trx, columns) {
+    return trx.raw(copyData(this.tableName(), this.alteredName, columns));
+  }
 
-        parsedTable.constraints = parsedTable.constraints.filter(
-          (constraint) => {
-            if (constraint.type === 'FOREIGN KEY') {
-              if (foreignKeyName) {
-                return (
-                  !constraint.name ||
-                  !isEqualId(constraint.name, foreignKeyName)
-                );
+  createNewTable(trx, sql) {
+    return trx.raw(createNewTable(sql, this.tableName(), this.alteredName));
+  }
+
+  async alterColumn(columns) {
+    const { createTable, createIndices } = await this.getTableSql();
+
+    const parsedTable = parseCreateTable(createTable);
+
+    parsedTable.columns = parsedTable.columns.map((column) => {
+      const newColumnInfo = columns.find((c) => isEqualId(c.name, column.name));
+
+      if (newColumnInfo) {
+        column.type = newColumnInfo.type;
+
+        column.constraints.default =
+          newColumnInfo.defaultTo !== null
+            ? {
+                name: null,
+                value: newColumnInfo.defaultTo,
+                expression: false,
               }
+            : null;
 
-              return constraint.columns.every(
-                (constraintColumnName) =>
-                  !includesId(columns, constraintColumnName)
-              );
-            } else {
-              return true;
-            }
-          }
-        );
-
-        const newTable = compileCreateTable(parsedTable, this.wrap);
-
-        return this.alter(newTable, createIndices);
-      },
-      { connection: this.connection }
-    );
-  }
-
-  dropPrimary(constraintName) {
-    return this.client.transaction(
-      async (trx) => {
-        this.trx = trx;
-
-        const { createTable, createIndices } = await this.getTableSql();
-
-        const parsedTable = parseCreateTable(createTable);
-
-        parsedTable.columns = parsedTable.columns.map((column) => ({
-          ...column,
-          primary: null,
-        }));
-
-        parsedTable.constraints = parsedTable.constraints.filter(
-          (constraint) => {
-            if (constraint.type === 'PRIMARY KEY') {
-              if (constraintName) {
-                return (
-                  !constraint.name ||
-                  !isEqualId(constraint.name, constraintName)
-                );
-              } else {
-                return false;
-              }
-            } else {
-              return true;
-            }
-          }
-        );
-
-        const newTable = compileCreateTable(parsedTable, this.wrap);
-
-        return this.alter(newTable, createIndices);
-      },
-      { connection: this.connection }
-    );
-  }
-
-  primary(columns, constraintName) {
-    return this.client.transaction(
-      async (trx) => {
-        this.trx = trx;
-
-        const { createTable, createIndices } = await this.getTableSql();
-
-        const parsedTable = parseCreateTable(createTable);
-
-        parsedTable.columns = parsedTable.columns.map((column) => ({
-          ...column,
-          primary: null,
-        }));
-
-        parsedTable.constraints = parsedTable.constraints.filter(
-          (constraint) => constraint.type !== 'PRIMARY KEY'
-        );
-
-        parsedTable.constraints.push({
-          type: 'PRIMARY KEY',
-          name: constraintName || null,
-          columns: columns.map((column) => ({
-            name: column,
-            expression: false,
-            collation: null,
-            order: null,
-          })),
-          conflict: null,
-        });
-
-        const newTable = compileCreateTable(parsedTable, this.wrap);
-
-        return this.alter(newTable, createIndices);
-      },
-      { connection: this.connection }
-    );
-  }
-
-  foreign(foreignInfo) {
-    return this.client.transaction(
-      async (trx) => {
-        this.trx = trx;
-
-        const { createTable, createIndices } = await this.getTableSql();
-
-        const parsedTable = parseCreateTable(createTable);
-
-        parsedTable.constraints.push({
-          type: 'FOREIGN KEY',
-          name: foreignInfo.keyName || null,
-          columns: foreignInfo.column,
-          references: {
-            table: foreignInfo.inTable,
-            columns: foreignInfo.references,
-            delete: foreignInfo.onDelete || null,
-            update: foreignInfo.onUpdate || null,
-            match: null,
-            deferrable: null,
-          },
-        });
-
-        const newTable = compileCreateTable(parsedTable, this.wrap);
-
-        return this.generateAlterCommands(newTable, createIndices);
-      },
-      { connection: this.connection }
-    );
-  }
-
-  setNullable(column, isNullable) {
-    return this.client.transaction(
-      async (trx) => {
-        this.trx = trx;
-
-        const { createTable, createIndices } = await this.getTableSql();
-
-        const parsedTable = parseCreateTable(createTable);
-        const parsedColumn = parsedTable.columns.find((c) =>
-          isEqualId(column, c.name)
-        );
-
-        if (!parsedColumn) {
-          throw new Error(
-            `.setNullable: Column ${column} does not exist in table ${this.tableName()}.`
-          );
-        }
-
-        parsedColumn.constraints.notnull = isNullable
-          ? null
-          : { name: null, conflict: null };
-
-        parsedColumn.constraints.null = isNullable
-          ? parsedColumn.constraints.null
+        column.constraints.notnull = newColumnInfo.notNull
+          ? { name: null, conflict: null }
           : null;
 
-        const newTable = compileCreateTable(parsedTable, this.wrap);
+        column.constraints.null = newColumnInfo.notNull
+          ? null
+          : column.constraints.null;
+      }
 
-        return this.generateAlterCommands(newTable, createIndices);
-      },
-      { connection: this.connection }
+      return column;
+    });
+
+    const newTable = compileCreateTable(parsedTable, this.wrap);
+
+    return this.alter(newTable, createIndices);
+  }
+
+  async dropColumn(columns) {
+    const { createTable, createIndices } = await this.getTableSql();
+
+    const parsedTable = parseCreateTable(createTable);
+
+    parsedTable.columns = parsedTable.columns.filter(
+      (parsedColumn) =>
+        parsedColumn.expression || !includesId(columns, parsedColumn.name)
     );
+
+    if (parsedTable.columns.length === 0) {
+      throw new Error('Unable to drop last column from table');
+    }
+
+    parsedTable.constraints = parsedTable.constraints.filter((constraint) => {
+      if (constraint.type === 'PRIMARY KEY' || constraint.type === 'UNIQUE') {
+        return constraint.columns.every(
+          (constraintColumn) =>
+            constraintColumn.expression ||
+            !includesId(columns, constraintColumn.name)
+        );
+      } else if (constraint.type === 'FOREIGN KEY') {
+        return (
+          constraint.columns.every(
+            (constraintColumnName) => !includesId(columns, constraintColumnName)
+          ) &&
+          (constraint.references.table !== parsedTable.table ||
+            constraint.references.columns.every(
+              (referenceColumnName) => !includesId(columns, referenceColumnName)
+            ))
+        );
+      } else {
+        return true;
+      }
+    });
+
+    const newColumns = parsedTable.columns.map((column) => column.name);
+
+    const newTable = compileCreateTable(parsedTable, this.wrap);
+
+    const newIndices = [];
+    for (const createIndex of createIndices) {
+      const parsedIndex = parseCreateIndex(createIndex);
+
+      parsedIndex.columns = parsedIndex.columns.filter(
+        (parsedColumn) =>
+          parsedColumn.expression || !includesId(columns, parsedColumn.name)
+      );
+
+      if (parsedIndex.columns.length > 0) {
+        newIndices.push(compileCreateIndex(parsedIndex, this.wrap));
+      }
+    }
+
+    return this.alter(newTable, newIndices, newColumns);
+  }
+
+  async dropForeign(columns, foreignKeyName) {
+    const { createTable, createIndices } = await this.getTableSql();
+
+    const parsedTable = parseCreateTable(createTable);
+
+    if (!foreignKeyName) {
+      parsedTable.columns = parsedTable.columns.map((column) => ({
+        ...column,
+        references: includesId(columns, column.name) ? null : column.references,
+      }));
+    }
+
+    parsedTable.constraints = parsedTable.constraints.filter((constraint) => {
+      if (constraint.type === 'FOREIGN KEY') {
+        if (foreignKeyName) {
+          return (
+            !constraint.name || !isEqualId(constraint.name, foreignKeyName)
+          );
+        }
+
+        return constraint.columns.every(
+          (constraintColumnName) => !includesId(columns, constraintColumnName)
+        );
+      } else {
+        return true;
+      }
+    });
+
+    const newTable = compileCreateTable(parsedTable, this.wrap);
+
+    return this.alter(newTable, createIndices);
+  }
+
+  async dropPrimary(constraintName) {
+    const { createTable, createIndices } = await this.getTableSql();
+
+    const parsedTable = parseCreateTable(createTable);
+
+    parsedTable.columns = parsedTable.columns.map((column) => ({
+      ...column,
+      primary: null,
+    }));
+
+    parsedTable.constraints = parsedTable.constraints.filter((constraint) => {
+      if (constraint.type === 'PRIMARY KEY') {
+        if (constraintName) {
+          return (
+            !constraint.name || !isEqualId(constraint.name, constraintName)
+          );
+        } else {
+          return false;
+        }
+      } else {
+        return true;
+      }
+    });
+
+    const newTable = compileCreateTable(parsedTable, this.wrap);
+
+    return this.alter(newTable, createIndices);
+  }
+
+  async primary(columns, constraintName) {
+    const { createTable, createIndices } = await this.getTableSql();
+
+    const parsedTable = parseCreateTable(createTable);
+
+    parsedTable.columns = parsedTable.columns.map((column) => ({
+      ...column,
+      primary: null,
+    }));
+
+    parsedTable.constraints = parsedTable.constraints.filter(
+      (constraint) => constraint.type !== 'PRIMARY KEY'
+    );
+
+    parsedTable.constraints.push({
+      type: 'PRIMARY KEY',
+      name: constraintName || null,
+      columns: columns.map((column) => ({
+        name: column,
+        expression: false,
+        collation: null,
+        order: null,
+      })),
+      conflict: null,
+    });
+
+    const newTable = compileCreateTable(parsedTable, this.wrap);
+
+    return this.alter(newTable, createIndices);
+  }
+
+  async foreign(foreignInfo) {
+    const { createTable, createIndices } = await this.getTableSql();
+
+    const parsedTable = parseCreateTable(createTable);
+
+    parsedTable.constraints.push({
+      type: 'FOREIGN KEY',
+      name: foreignInfo.keyName || null,
+      columns: foreignInfo.column,
+      references: {
+        table: foreignInfo.inTable,
+        columns: foreignInfo.references,
+        delete: foreignInfo.onDelete || null,
+        update: foreignInfo.onUpdate || null,
+        match: null,
+        deferrable: null,
+      },
+    });
+
+    const newTable = compileCreateTable(parsedTable, this.wrap);
+
+    return this.generateAlterCommands(newTable, createIndices);
+  }
+
+  async setNullable(column, isNullable) {
+    const { createTable, createIndices } = await this.getTableSql();
+
+    const parsedTable = parseCreateTable(createTable);
+    const parsedColumn = parsedTable.columns.find((c) =>
+      isEqualId(column, c.name)
+    );
+
+    if (!parsedColumn) {
+      throw new Error(
+        `.setNullable: Column ${column} does not exist in table ${this.tableName()}.`
+      );
+    }
+
+    parsedColumn.constraints.notnull = isNullable
+      ? null
+      : { name: null, conflict: null };
+
+    parsedColumn.constraints.null = isNullable
+      ? parsedColumn.constraints.null
+      : null;
+
+    const newTable = compileCreateTable(parsedTable, this.wrap);
+
+    return this.generateAlterCommands(newTable, createIndices);
   }
 
   async alter(newSql, createIndices, columns) {
-    await this.createNewTable(newSql);
-    await this.copyData(columns);
-    await this.dropOriginal();
-    await this.renameTable();
+    const wasForeignCheckEnabled = await this.isForeignCheckEnabled();
 
-    for (const createIndex of createIndices) {
-      await this.trx.raw(createIndex);
+    if (wasForeignCheckEnabled) {
+      await this.setForeignCheck(false);
+    }
+
+    try {
+      await this.client.transaction(
+        async (trx) => {
+          await this.createNewTable(trx, newSql);
+          await this.copyData(trx, columns);
+          await this.dropOriginal(trx);
+          await this.renameTable(trx);
+
+          for (const createIndex of createIndices) {
+            await trx.raw(createIndex);
+          }
+
+          if (wasForeignCheckEnabled) {
+            const foreignViolations = await trx.raw(executeForeignCheck());
+
+            if (foreignViolations.length > 0) {
+              throw new Error('FOREIGN KEY constraint failed');
+            }
+          }
+        },
+        { connection: this.connection }
+      );
+    } finally {
+      if (wasForeignCheckEnabled) {
+        await this.setForeignCheck(true);
+      }
     }
   }
 

--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -366,19 +366,31 @@ class SQLite3_DDL {
     }
   }
 
-  generateAlterCommands(newSql, createIndices, columns) {
-    const result = [];
+  async generateAlterCommands(newSql, createIndices, columns) {
+    const sql = [];
+    const pre = [];
+    const post = [];
+    let check = null;
 
-    result.push(createNewTable(newSql, this.tableName(), this.alteredName));
-    result.push(copyData(this.tableName(), this.alteredName, columns));
-    result.push(dropOriginal(this.tableName()));
-    result.push(renameTable(this.alteredName, this.tableName()));
+    sql.push(createNewTable(newSql, this.tableName(), this.alteredName));
+    sql.push(copyData(this.tableName(), this.alteredName, columns));
+    sql.push(dropOriginal(this.tableName()));
+    sql.push(renameTable(this.alteredName, this.tableName()));
 
     for (const createIndex of createIndices) {
-      result.push(createIndex);
+      sql.push(createIndex);
     }
 
-    return result;
+    const isForeignCheckEnabled = await this.isForeignCheckEnabled();
+
+    if (isForeignCheckEnabled) {
+      pre.push(setForeignCheck(false));
+      post.push(setForeignCheck(true));
+
+      check = executeForeignCheck();
+    }
+
+    return { pre, sql, check, post };
   }
 }
 

--- a/lib/dialects/sqlite3/schema/internal/sqlite-ddl-operations.js
+++ b/lib/dialects/sqlite3/schema/internal/sqlite-ddl-operations.js
@@ -22,10 +22,25 @@ function getTableSql(tableName) {
   return `SELECT type, sql FROM sqlite_master WHERE (type="table" OR (type="index" AND sql IS NOT NULL)) AND tbl_name="${tableName}"`;
 }
 
+function isForeignCheckEnabled() {
+  return `PRAGMA foreign_keys`;
+}
+
+function setForeignCheck(enable) {
+  return `PRAGMA foreign_keys = ${enable ? 'ON' : 'OFF'}`;
+}
+
+function executeForeignCheck() {
+  return `PRAGMA foreign_key_check`;
+}
+
 module.exports = {
   createNewTable,
   copyData,
   dropOriginal,
   renameTable,
   getTableSql,
+  isForeignCheckEnabled,
+  setForeignCheck,
+  executeForeignCheck,
 };

--- a/lib/dialects/sqlite3/schema/sqlite-compiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-compiler.js
@@ -55,21 +55,25 @@ class SchemaCompiler_SQLite3 extends SchemaCompiler {
       this[query.method].apply(this, query.args);
     }
 
-    const result = [];
     const commandSources = this.sequence;
-    for (const commandSource of commandSources) {
-      const command = commandSource.statementsProducer
-        ? await commandSource.statementsProducer()
-        : commandSource.sql;
 
-      if (Array.isArray(command)) {
-        result.push(...command);
-      } else {
-        result.push(command);
+    if (commandSources.length === 1 && commandSources[0].statementsProducer) {
+      return commandSources[0].statementsProducer();
+    } else {
+      const result = [];
+
+      for (const commandSource of commandSources) {
+        const command = commandSource.sql;
+
+        if (Array.isArray(command)) {
+          result.push(...command);
+        } else {
+          result.push(command);
+        }
       }
-    }
 
-    return { pre: [], sql: result, post: [] };
+      return { pre: [], sql: result, check: null, post: [] };
+    }
   }
 }
 

--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -246,25 +246,27 @@ class Runner {
 
       await this.queryArray(preQueryObjects);
 
-      await this.client.transaction(
-        async (trx) => {
-          const transactionRunner = new Runner(trx.client, this.builder);
-          transactionRunner.connection = this.connection;
+      try {
+        await this.client.transaction(
+          async (trx) => {
+            const transactionRunner = new Runner(trx.client, this.builder);
+            transactionRunner.connection = this.connection;
 
-          results = await transactionRunner.queryArray(sqlQueryObjects);
+            results = await transactionRunner.queryArray(sqlQueryObjects);
 
-          if (statements.check) {
-            const foreignViolations = await trx.raw(statements.check);
+            if (statements.check) {
+              const foreignViolations = await trx.raw(statements.check);
 
-            if (foreignViolations.length > 0) {
-              throw new Error('FOREIGN KEY constraint failed');
+              if (foreignViolations.length > 0) {
+                throw new Error('FOREIGN KEY constraint failed');
+              }
             }
-          }
-        },
-        { connection: this.connection }
-      );
-
-      await this.queryArray(postQueryObjects);
+          },
+          { connection: this.connection }
+        );
+      } finally {
+        await this.queryArray(postQueryObjects);
+      }
 
       return results;
     }

--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -228,12 +228,45 @@ class Runner {
         undefined,
         this.connection
       );
-      const queryObjects = statements.map((statement) => ({
+
+      const sqlQueryObjects = statements.sql.map((statement) => ({
+        sql: statement,
+        bindings: query.bindings,
+      }));
+      const preQueryObjects = statements.pre.map((statement) => ({
+        sql: statement,
+        bindings: query.bindings,
+      }));
+      const postQueryObjects = statements.post.map((statement) => ({
         sql: statement,
         bindings: query.bindings,
       }));
 
-      return this.queryArray(queryObjects);
+      let results = [];
+
+      await this.queryArray(preQueryObjects);
+
+      await this.client.transaction(
+        async (trx) => {
+          const transactionRunner = new Runner(trx.client, this.builder);
+          transactionRunner.connection = this.connection;
+
+          results = await transactionRunner.queryArray(sqlQueryObjects);
+
+          if (statements.check) {
+            const foreignViolations = await trx.raw(statements.check);
+
+            if (foreignViolations.length > 0) {
+              throw new Error('FOREIGN KEY constraint failed');
+            }
+          }
+        },
+        { connection: this.connection }
+      );
+
+      await this.queryArray(postQueryObjects);
+
+      return results;
     }
 
     const results = [];

--- a/lib/schema/compiler.js
+++ b/lib/schema/compiler.js
@@ -106,6 +106,7 @@ class SchemaCompiler {
       sql: Array.isArray(generatedCommands)
         ? generatedCommands
         : [generatedCommands],
+      check: null,
       post: [],
     };
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1866,7 +1866,7 @@ export declare namespace Knex {
     readonly [Symbol.toStringTag]: string;
   }
   interface ChainableInterface<T = any> extends Pick<Promise<T>, keyof Promise<T> & ExposedPromiseKeys>, StringTagSupport {
-    generateDdlCommands(): Promise<{ pre: string[], sql: string[], post: string[] }>;
+    generateDdlCommands(): Promise<{ pre: string[], sql: string[], check: string | null, post: string[] }>;
     toQuery(): string;
     options(options: Readonly<{ [key: string]: any }>): this;
     connection(connection: any): this;


### PR DESCRIPTION
Some notes/questions:

- Is it safe to execute raw queries directly on the client?
- What was the reasoning behind doing `disableProcessing()` / `enableProcessing()` in `getTableSql()`? It seems like this does not work when using the client directly instead of through a transaction.
- Unless I am missing something, with this change `reinsertMapped()` should be treated like a critical section, so another invocation of the function can't interfere with the procedure of querying, disabling and reenabling foreign key constraint enforcement.
- When using indices, the manual foreign key check will likely fail as they are not recreated for the new table. (According to the [SQLite Docs for ALTER TABLE](https://sqlite.org/lang_altertable.html) this also applies to triggers and views, but I'm not sure how relevant that is for Knex)
- With this change would it be possible to enable foreign key constraint enforcement for SQLite by default? (Maybe with an option to disable it)

Fixes #4155