### PR TITLE
Use SQLite rename column instead of ddl helper

### DIFF
--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -6,7 +6,6 @@
 
 const find = require('lodash/find');
 const fromPairs = require('lodash/fromPairs');
-const invert = require('lodash/invert');
 const isEmpty = require('lodash/isEmpty');
 const negate = require('lodash/negate');
 const omit = require('lodash/omit');
@@ -245,38 +244,6 @@ class SQLite3_DDL {
     return oneLineSql
       .replace(/\(.*\)/, () => `(${args.join(', ')})`)
       .replace(/,\s*([,)])/, '$1');
-  }
-
-  async renameColumn(from, to) {
-    return this.client.transaction(
-      async (trx) => {
-        this.trx = trx;
-        const column = await this.getColumn(from);
-        const sql = await this.getTableSql(column);
-        const a = this.client.wrapIdentifier(from);
-        const b = this.client.wrapIdentifier(to);
-        const createTable = sql[0];
-        const newSql = this._doReplace(createTable.sql, a, b);
-        if (sql === newSql) {
-          throw new Error('Unable to find the column to change');
-        }
-
-        const { from: mappedFrom, to: mappedTo } = invert(
-          this.client.postProcessResponse(
-            invert({
-              from,
-              to,
-            })
-          )
-        );
-
-        return this.reinsertMapped(createTable, newSql, (row) => {
-          row[mappedTo] = row[mappedFrom];
-          return omit(row, mappedFrom);
-        });
-      },
-      { connection: this.connection }
-    );
   }
 
   async dropColumn(columns) {

--- a/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
@@ -205,16 +205,11 @@ class TableCompiler_SQLite3 extends TableCompiler {
     return this.getColumns().concat().join(',');
   }
 
-  // Compile a rename column command... very complex in sqlite
   renameColumn(from, to) {
-    const compiler = this;
     this.pushQuery({
-      sql: `PRAGMA table_info(${this.tableName()})`,
-      output(pragma) {
-        return compiler.client
-          .ddl(compiler, pragma, this.connection)
-          .renameColumn(from, to);
-      },
+      sql: `alter table ${this.tableName()} rename ${this.formatter.wrap(
+        from
+      )} to ${this.formatter.wrap(to)}`,
     });
   }
 

--- a/test/integration/query/additional.js
+++ b/test/integration/query/additional.js
@@ -617,7 +617,9 @@ module.exports = function (knex) {
               tester('pg-redshift', [
                 'alter table "accounts" rename "about" to "about_col"',
               ]);
-              tester('sqlite3', ['PRAGMA table_info(`accounts`)']);
+              tester('sqlite3', [
+                'alter table `accounts` rename `about` to `about_col`',
+              ]);
               tester('oracledb', [
                 'DECLARE PK_NAME VARCHAR(200); IS_AUTOINC NUMBER := 0; BEGIN  EXECUTE IMMEDIATE (\'ALTER TABLE "accounts" RENAME COLUMN "about" TO "about_col"\');  SELECT COUNT(*) INTO IS_AUTOINC from "USER_TRIGGERS" where trigger_name = \'accounts_autoinc_trg\';  IF (IS_AUTOINC > 0) THEN    SELECT cols.column_name INTO PK_NAME    FROM all_constraints cons, all_cons_columns cols    WHERE cons.constraint_type = \'P\'    AND cons.constraint_name = cols.constraint_name    AND cons.owner = cols.owner    AND cols.table_name = \'accounts\';    IF (\'about_col\' = PK_NAME) THEN      EXECUTE IMMEDIATE (\'DROP TRIGGER "accounts_autoinc_trg"\');      EXECUTE IMMEDIATE (\'create or replace trigger "accounts_autoinc_trg"      BEFORE INSERT on "accounts" for each row        declare        checking number := 1;        begin          if (:new."about_col" is null) then            while checking >= 1 loop              select "accounts_seq".nextval into :new."about_col" from dual;              select count("about_col") into checking from "accounts"              where "about_col" = :new."about_col";            end loop;          end if;        end;\');    end if;  end if;END;',
               ]);

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -1239,55 +1239,6 @@ module.exports = (knex) => {
           });
         });
       });
-
-      if (knex.client.driverName === 'sqlite3') {
-        describe('using wrapIdentifier and postProcessResponse', () => {
-          const tableName = 'processor_test';
-
-          beforeEach(() => {
-            knex.client.config.postProcessResponse = postProcessResponse;
-            knex.client.config.wrapIdentifier = wrapIdentifier;
-
-            return knex.schema
-              .createTable(tableName, (tbl) => {
-                tbl.integer('field_foo');
-                tbl.integer('other_field');
-              })
-              .then(() => {
-                // Data is necessary to "force" the sqlite3 dialect to actually
-                // attempt to copy data to the temp table, triggering errors
-                // if columns were not correctly copied/created/dropped.
-                return knex
-                  .insert({
-                    field_foo: 1,
-                    other_field: 1,
-                  })
-                  .into(tableName);
-              });
-          });
-
-          afterEach(() => {
-            knex.client.config.postProcessResponse = null;
-            knex.client.config.wrapIdentifier = null;
-
-            return knex.schema.dropTable(tableName);
-          });
-
-          for (const from of ['field_foo', 'FIELD_FOO']) {
-            for (const to of ['field_bar', 'FIELD_BAR']) {
-              it(`renames the column from '${from}' to '${to}'`, () =>
-                knex.schema
-                  .table(tableName, (tbl) =>
-                    tbl.renameColumn('field_foo', 'field_bar')
-                  )
-                  .then(() => knex.schema.hasColumn(tableName, 'field_bar'))
-                  .then((exists) => {
-                    expect(exists).to.equal(true);
-                  }));
-            }
-          }
-        });
-      }
     });
 
     describe('dropColumn', () => {


### PR DESCRIPTION
Since SQLite version 3.25.0 renaming columns is supported natively.

Knex depends on `sqlite3@5.0.0` which bundles SQLite version 3.32.3, so this should be safe unless someone manually builds `sqlite3` with an older version.