### PR TITLE
Add pg-mem to documentation

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -10,4 +10,4 @@ Plugins and tools maintained by the knex team are listed under [Core](#core) whi
 #### [Community](#community)
 
 - [`knex-paginate`](https://github.com/felixmosh/knex-paginate) Extension of the query builder with `paginate` method that helps with pagination tasks.
-- [`pg-mem`](https://github.com/oguimbal/pg-mem) emulates an in-memory postgres instance bound to Knex in order to write blazingly fast tests [(details here)](https://github.com/oguimbal/pg-mem/wiki/Libraries-adapters#-knex)
+- [`pg-mem`](https://github.com/oguimbal/pg-mem) An in-memory emulation of PostgreSQL instance, which can be used for writing blazingly fast tests. Has [adapter for knex](https://github.com/oguimbal/pg-mem/wiki/Libraries-adapters#-knex)

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -10,3 +10,4 @@ Plugins and tools maintained by the knex team are listed under [Core](#core) whi
 #### [Community](#community)
 
 - [`knex-paginate`](https://github.com/felixmosh/knex-paginate) Extension of the query builder with `paginate` method that helps with pagination tasks.
+- [`pg-mem`](https://github.com/oguimbal/pg-mem) emulates an in-memory postgres instance bound to Knex in order to write blazingly fast tests [(details here)](https://github.com/oguimbal/pg-mem/wiki/Libraries-adapters#-knex)


### PR DESCRIPTION
Just adds [pg-mem](https://github.com/oguimbal/pg-mem) to documentation, which now supports Knex.

FYI, `pg-mem`is a small full-js library emulating an in-memory Postgres instance, which is bindable to virtually every library aiming postgres (see [supported bindings](https://github.com/oguimbal/pg-mem#-libraries-adapters) here)