### PR TITLE
Allow optimizer hints

### DIFF
--- a/lib/dialects/mssql/query/mssql-querycompiler.js
+++ b/lib/dialects/mssql/query/mssql-querycompiler.js
@@ -277,7 +277,7 @@ class QueryCompiler_MSSQL extends QueryCompiler {
     let distinctClause = '';
     if (this.onlyUnions()) return '';
     const top = this.top();
-    const hints = this._optimizerHints()
+    const hints = this._hintComments()
     const columns = this.grouped.columns || [];
     let i = -1,
       sql = [];

--- a/lib/dialects/mssql/query/mssql-querycompiler.js
+++ b/lib/dialects/mssql/query/mssql-querycompiler.js
@@ -277,6 +277,7 @@ class QueryCompiler_MSSQL extends QueryCompiler {
     let distinctClause = '';
     if (this.onlyUnions()) return '';
     const top = this.top();
+    const hints = this._optimizerHints()
     const columns = this.grouped.columns || [];
     let i = -1,
       sql = [];
@@ -302,7 +303,7 @@ class QueryCompiler_MSSQL extends QueryCompiler {
     if (sql.length === 0) sql = ['*'];
 
     return (
-      `select ${distinctClause}` +
+      `select ${hints}${distinctClause}` +
       (top ? top + ' ' : '') +
       sql.join(', ') +
       (this.tableName ? ` from ${this.tableName}` : '')

--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -148,6 +148,25 @@ class Builder extends EventEmitter {
     return this;
   }
 
+  // Adds a one or more optimizer hits to the list of "optimizerHints" on the query.
+  optimizerHint() {
+    const hints = helpers.normalizeArr.apply(null, arguments);
+    if (hints.some((hint) => !isString(hint))) {
+      throw new Error('Optimizer hint must be a string');
+    }
+    if (hints.some((hint) => hint.includes('/*') || hint.includes('*/'))) {
+      throw new Error('Optimizer hint cannot include "/*" or "*/"');
+    }
+    if (hints.some((hint) => hint.includes('?'))) {
+      throw new Error('Optimizer hint cannot include "?"');
+    }
+    this._statements.push({
+      grouping: 'optimizerHints',
+      value: hints,
+    })
+    return this;
+  }
+
   // Prepends the `schemaName` on `tableName` defined by `.table` and `.join`.
   withSchema(schemaName) {
     this._single.schema = schemaName;
@@ -1040,6 +1059,7 @@ class Builder extends EventEmitter {
         'with',
         'select',
         'columns',
+        'optimizerHints',
         'where',
         'union',
         'join',

--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -148,20 +148,20 @@ class Builder extends EventEmitter {
     return this;
   }
 
-  // Adds a single hint or an array of hits to the list of "optimizerHints" on the query.
-  optimizerHint(hints) {
+  // Adds a single hint or an array of hits to the list of "hintComments" on the query.
+  hintComment(hints) {
     hints = Array.isArray(hints) ? hints : [hints]
     if (hints.some((hint) => !isString(hint))) {
-      throw new Error('Optimizer hint must be a string');
+      throw new Error('Hint comment must be a string');
     }
     if (hints.some((hint) => hint.includes('/*') || hint.includes('*/'))) {
-      throw new Error('Optimizer hint cannot include "/*" or "*/"');
+      throw new Error('Hint comment cannot include "/*" or "*/"');
     }
     if (hints.some((hint) => hint.includes('?'))) {
-      throw new Error('Optimizer hint cannot include "?"');
+      throw new Error('Hint comment cannot include "?"');
     }
     this._statements.push({
-      grouping: 'optimizerHints',
+      grouping: 'hintComments',
       value: hints,
     })
     return this;
@@ -1059,7 +1059,7 @@ class Builder extends EventEmitter {
         'with',
         'select',
         'columns',
-        'optimizerHints',
+        'hintComments',
         'where',
         'union',
         'join',

--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -148,9 +148,9 @@ class Builder extends EventEmitter {
     return this;
   }
 
-  // Adds a one or more optimizer hits to the list of "optimizerHints" on the query.
-  optimizerHint() {
-    const hints = helpers.normalizeArr.apply(null, arguments);
+  // Adds a single hint or an array of hits to the list of "optimizerHints" on the query.
+  optimizerHint(hints) {
+    hints = Array.isArray(hints) ? hints : [hints]
     if (hints.some((hint) => !isString(hint))) {
       throw new Error('Optimizer hint must be a string');
     }

--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -199,10 +199,21 @@ class QueryCompiler {
     );
   }
 
+  _optimizerHints() {
+    let hints = this.grouped.optimizerHints || [];
+    hints = hints.map((hint) => compact(hint.value).join(' '));
+    hints = compact(hints).join(' ');
+    if (hints) {
+      return `/*+ ${hints} */ `
+    }
+    return ''
+  }
+
   // Compiles the columns in the query, specifying if an item was distinct.
   columns() {
     let distinctClause = '';
     if (this.onlyUnions()) return '';
+    const hints = this._optimizerHints()
     const columns = this.grouped.columns || [];
     let i = -1,
       sql = [];
@@ -234,7 +245,7 @@ class QueryCompiler {
     }
     if (sql.length === 0) sql = ['*'];
     return (
-      `select ${distinctClause}` +
+      `select ${hints}${distinctClause}` +
       sql.join(', ') +
       (this.tableName
         ? ` from ${this.single.only ? 'only ' : ''}${this.tableName}`

--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -199,8 +199,8 @@ class QueryCompiler {
     );
   }
 
-  _optimizerHints() {
-    let hints = this.grouped.optimizerHints || [];
+  _hintComments() {
+    let hints = this.grouped.hintComments || [];
     hints = hints.map((hint) => compact(hint.value).join(' '));
     hints = compact(hints).join(' ');
     return hints ? `/*+ ${hints} */ ` : ''
@@ -210,7 +210,7 @@ class QueryCompiler {
   columns() {
     let distinctClause = '';
     if (this.onlyUnions()) return '';
-    const hints = this._optimizerHints()
+    const hints = this._hintComments()
     const columns = this.grouped.columns || [];
     let i = -1,
       sql = [];

--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -203,10 +203,7 @@ class QueryCompiler {
     let hints = this.grouped.optimizerHints || [];
     hints = hints.map((hint) => compact(hint.value).join(' '));
     hints = compact(hints).join(' ');
-    if (hints) {
-      return `/*+ ${hints} */ `
-    }
-    return ''
+    return hints ? `/*+ ${hints} */ ` : ''
   }
 
   // Compiles the columns in the query, specifying if an item was distinct.

--- a/test/integration/query/selects.js
+++ b/test/integration/query/selects.js
@@ -150,7 +150,7 @@ module.exports = function (knex) {
         });
     });
 
-    it('#4199 - adheres to optimizer hints', async function () {
+    it('#4199 - adheres to hint comments', async function () {
       const expectedErrors = {
         mysql: {
           code: 'ER_QUERY_TIMEOUT',
@@ -172,16 +172,16 @@ module.exports = function (knex) {
         baseQuery.clone()
       ).to.eventually.be.fulfilled.and.to.have.lengthOf(2)
       await expect(
-        baseQuery.clone().optimizerHint('max_execution_time(10)')
+        baseQuery.clone().hintComment('max_execution_time(10)')
       ).to.eventually.be.rejected.and.to.deep.include(expectedErrors[knex.client.driverName])
     });
 
-    it('#4199 - ignores invalid optimizer hints', async function () {
+    it('#4199 - ignores invalid hint comments', async function () {
       return knex
         .select('id')
         .orderBy('id')
         .from('accounts')
-        .optimizerHint('invalid()')
+        .hintComment('invalid()')
         .testSql(function (tester) {
           tester(
             'mysql',

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -9259,7 +9259,7 @@ describe('QueryBuilder', () => {
     testsql(
       qb()
         .from('testtable')
-        .optimizerHint('hint1()', 'hint2()')
+        .optimizerHint(['hint1()', 'hint2()'])
         .optimizerHint('hint3()'),
       {
         mysql: {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -752,7 +752,7 @@ describe('QueryBuilder', () => {
         })
         .join('tableJoin', 'id', 'id')
         .select(['id'])
-        .optimizerHint('hint()')
+        .hintComment('hint()')
         .where('id', '<', 10)
         .groupBy('id')
         .groupBy('id', 'desc')
@@ -771,7 +771,7 @@ describe('QueryBuilder', () => {
         .clear('columns')
         .select(['id'])
         .clear('select')
-        .clear('optimizerHints')
+        .clear('hintComments')
         .clear('where')
         .clear('group')
         .clear('order')
@@ -9225,11 +9225,11 @@ describe('QueryBuilder', () => {
     });
   });
 
-  it('#4199 - allows an optimizer hint', () => {
+  it('#4199 - allows an hint comment', () => {
     testsql(
       qb()
         .from('testtable')
-        .optimizerHint('hint()'),
+        .hintComment('hint()'),
       {
         mysql: {
           sql: 'select /*+ hint() */ * from `testtable`',
@@ -9255,12 +9255,12 @@ describe('QueryBuilder', () => {
     )
   });
 
-  it('#4199 - allows multiple optimizer hints', () => {
+  it('#4199 - allows multiple hint comments', () => {
     testsql(
       qb()
         .from('testtable')
-        .optimizerHint(['hint1()', 'hint2()'])
-        .optimizerHint('hint3()'),
+        .hintComment(['hint1()', 'hint2()'])
+        .hintComment('hint3()'),
       {
         mysql: {
           sql: 'select /*+ hint1() hint2() hint3() */ * from `testtable`',
@@ -9286,15 +9286,15 @@ describe('QueryBuilder', () => {
     )
   });
 
-  it('#4199 - allows optimizer hints in subqueries', () => {
+  it('#4199 - allows hint comments in subqueries', () => {
     testsql(
       qb()
         .select({
           c1: 'c1',
-          c2: qb().select('c2').from('t2').optimizerHint('hint2()').limit(1),
+          c2: qb().select('c2').from('t2').hintComment('hint2()').limit(1),
         })
         .from('t1')
-        .optimizerHint('hint1()'),
+        .hintComment('hint1()'),
       {
         mysql: {
           sql: 'select /*+ hint1() */ `c1` as `c1`, (select /*+ hint2() */ `c2` from `t2` limit ?) as `c2` from `t1`',
@@ -9320,12 +9320,12 @@ describe('QueryBuilder', () => {
     )
   });
 
-  it('#4199 - allows optimizer hints in unions', () => {
+  it('#4199 - allows hint comments in unions', () => {
     testsql(
       qb()
         .from('t1')
-        .optimizerHint('hint1()')
-        .unionAll(qb().from('t2').optimizerHint('hint2()')),
+        .hintComment('hint1()')
+        .unionAll(qb().from('t2').hintComment('hint2()')),
       {
         mysql: {
           sql: 'select /*+ hint1() */ * from `t1` union all select /*+ hint2() */ * from `t2`',
@@ -9351,34 +9351,34 @@ describe('QueryBuilder', () => {
     )
   });
 
-  it('#4199 - forbids "/*", "*/" and "?" in optimizer hints', () => {
+  it('#4199 - forbids "/*", "*/" and "?" in hint comments', () => {
     expect(() => {
-      qb().from('testtable').optimizerHint('hint() /*').toString();
+      qb().from('testtable').hintComment('hint() /*').toString();
     }).to.throw(
-      'Optimizer hint cannot include "/*" or "*/"'
+      'Hint comment cannot include "/*" or "*/"'
     );
     expect(() => {
-      qb().from('testtable').optimizerHint('hint() */').toString();
+      qb().from('testtable').hintComment('hint() */').toString();
     }).to.throw(
-      'Optimizer hint cannot include "/*" or "*/"'
+      'Hint comment cannot include "/*" or "*/"'
     );
     expect(() => {
-      qb().from('testtable').optimizerHint('hint(?)').toString();
+      qb().from('testtable').hintComment('hint(?)').toString();
     }).to.throw(
-      'Optimizer hint cannot include "?"'
+      'Hint comment cannot include "?"'
     );
   });
 
-  it('#4199 - forbids non-strings as optimizer hints', () => {
+  it('#4199 - forbids non-strings as hint comments', () => {
     expect(() => {
-      qb().from('testtable').optimizerHint(47).toString();
+      qb().from('testtable').hintComment(47).toString();
     }).to.throw(
-      'Optimizer hint must be a string'
+      'Hint comment must be a string'
     );
     expect(() => {
-      qb().from('testtable').optimizerHint(raw('hint(?)', [47])).toString();
+      qb().from('testtable').hintComment(raw('hint(?)', [47])).toString();
     }).to.throw(
-      'Optimizer hint must be a string'
+      'Hint comment must be a string'
     );
   });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1002,7 +1002,7 @@ export declare namespace Knex {
   }
 
   interface OptimizerHint<TRecord extends {} = any, TResult extends {} = any> {
-    (...hints: string[]): QueryBuilder<TRecord, TResult>;
+    (hint: string): QueryBuilder<TRecord, TResult>;
     (hints: readonly string[]): QueryBuilder<TRecord, TResult>;
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -472,13 +472,14 @@ export declare namespace Knex {
   //
   // QueryInterface
   //
-  type ClearStatements = "with" | "select" | "columns" | "where" | "union" | "join" | "group" | "order" | "having" | "limit" | "offset" | "counter" | "counters";
+  type ClearStatements = "with" | "select" | "columns" | "optimizerHints" | "where" | "union" | "join" | "group" | "order" | "having" | "limit" | "offset" | "counter" | "counters";
 
   interface QueryInterface<TRecord extends {} = any, TResult = any> {
     select: Select<TRecord, TResult>;
     as: As<TRecord, TResult>;
     columns: Select<TRecord, TResult>;
     column: Select<TRecord, TResult>;
+    optimizerHint: OptimizerHint<TRecord, TResult>;
     from: Table<TRecord, TResult>;
     into: Table<TRecord, TResult>;
     table: Table<TRecord, TResult>;
@@ -998,6 +999,11 @@ export declare namespace Knex {
     <TResult2 = ArrayIfAlready<TResult, any>, TInnerRecord = any, TInnerResult = any>(
       subQueryBuilders: readonly QueryBuilder<TInnerRecord, TInnerResult>[]
     ): QueryBuilder<TRecord, TResult2>;
+  }
+
+  interface OptimizerHint<TRecord extends {} = any, TResult extends {} = any> {
+    (...hints: string[]): QueryBuilder<TRecord, TResult>;
+    (hints: readonly string[]): QueryBuilder<TRecord, TResult>;
   }
 
   interface Table<TRecord extends {} = any, TResult extends {} = any> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -472,14 +472,14 @@ export declare namespace Knex {
   //
   // QueryInterface
   //
-  type ClearStatements = "with" | "select" | "columns" | "optimizerHints" | "where" | "union" | "join" | "group" | "order" | "having" | "limit" | "offset" | "counter" | "counters";
+  type ClearStatements = "with" | "select" | "columns" | "hintComments" | "where" | "union" | "join" | "group" | "order" | "having" | "limit" | "offset" | "counter" | "counters";
 
   interface QueryInterface<TRecord extends {} = any, TResult = any> {
     select: Select<TRecord, TResult>;
     as: As<TRecord, TResult>;
     columns: Select<TRecord, TResult>;
     column: Select<TRecord, TResult>;
-    optimizerHint: OptimizerHint<TRecord, TResult>;
+    hintComment: HintComment<TRecord, TResult>;
     from: Table<TRecord, TResult>;
     into: Table<TRecord, TResult>;
     table: Table<TRecord, TResult>;
@@ -1001,7 +1001,7 @@ export declare namespace Knex {
     ): QueryBuilder<TRecord, TResult2>;
   }
 
-  interface OptimizerHint<TRecord extends {} = any, TResult extends {} = any> {
+  interface HintComment<TRecord extends {} = any, TResult extends {} = any> {
     (hint: string): QueryBuilder<TRecord, TResult>;
     (hints: readonly string[]): QueryBuilder<TRecord, TResult>;
   }


### PR DESCRIPTION
Implements #4199

Optimizer hints using comment `/*+` syntax support in dialects:
- MySQL: Supported and working.
- Postgres: Not supported in vanilla Postgres. Supported in some extensions like in EDB Postgres Advanced Server, where the [syntax is the same](https://www.enterprisedb.com/edb-docs/d/edb-postgres-advanced-server/user-guides/database-compatibility-for-oracle-developers-guide/11/Database_Compatibility_for_Oracle_Developers_Guide.1.038.html
) as in MySQL. Not tested as I don't have access to EDB Postgres Advanced Server.
- Oracle: Supported. The [syntax is the same](https://docs.oracle.com/cd/B13789_01/server.101/b10752/hintsref.htm) as in MySQL. Not tested as I don't have access to Oracle DB.
- MSSQL: Not supported.
- Sqlite3: Not supported.

It is still good to keep the hints implementation even for dialects that don't support them as there may be proxy interpreters / middlewares supporting similar hints syntax.