### PR TITLE
Added merge strategy to allow selecting columns to upsert.

### DIFF
--- a/lib/dialects/mysql/query/mysql-querycompiler.js
+++ b/lib/dialects/mysql/query/mysql-querycompiler.js
@@ -53,8 +53,7 @@ class QueryCompiler_MySQL extends QueryCompiler {
           .map((column) => `${column} = values(${column})`)
           .join(', ')
       );
-    }
-    if (updates && typeof updates === 'object') {
+    } else if (updates && typeof updates === 'object') {
       const updateData = this._prepUpdate(updates);
       return sql + updateData.join(',');
     } else {

--- a/lib/dialects/mysql/query/mysql-querycompiler.js
+++ b/lib/dialects/mysql/query/mysql-querycompiler.js
@@ -39,9 +39,22 @@ class QueryCompiler_MySQL extends QueryCompiler {
     return sql;
   }
 
+  // Compiles merge for onConflict, allowing for different merge strategies
   _merge(updates, insert) {
     const sql = ' on duplicate key update ';
-    if (updates) {
+    if (updates && Array.isArray(updates)) {
+      // update subset of columns
+      return (
+        sql +
+        updates
+          .map((column) =>
+            wrapAsIdentifier(column, this.formatter.builder, this.client)
+          )
+          .map((column) => `${column} = values(${column})`)
+          .join(', ')
+      );
+    }
+    if (updates && typeof updates === 'object') {
       const updateData = this._prepUpdate(updates);
       return sql + updateData.join(',');
     } else {

--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -97,7 +97,7 @@ class QueryCompiler_PG extends QueryCompiler {
         .join(', ');
 
       return sql;
-    } else if (updates) {
+    } else if (updates && typeof updates === 'object') {
       const updateData = this._prepUpdate(updates);
       if (typeof updateData === 'string') {
         sql += updateData;

--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -83,7 +83,21 @@ class QueryCompiler_PG extends QueryCompiler {
     let sql = ` on conflict (${this.formatter.columnize(
       columns
     )}) do update set `;
-    if (updates) {
+    if (updates && Array.isArray(updates)) {
+      sql += updates
+        .map((column) =>
+          wrapString(
+            column.split('.').pop(),
+            this.formatter.builder,
+            this.client,
+            this.formatter
+          )
+        )
+        .map((column) => `${column} = excluded.${column}`)
+        .join(', ');
+
+      return sql;
+    } else if (updates) {
       const updateData = this._prepUpdate(updates);
       if (typeof updateData === 'string') {
         sql += updateData;

--- a/lib/dialects/sqlite3/query/sqlite-querycompiler.js
+++ b/lib/dialects/sqlite3/query/sqlite-querycompiler.js
@@ -132,7 +132,21 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
     let sql = ` on conflict (${this.formatter.columnize(
       columns
     )}) do update set `;
-    if (updates) {
+    if (updates && Array.isArray(updates)) {
+      sql += updates
+        .map((column) =>
+          wrapString(
+            column.split('.').pop(),
+            this.formatter.builder,
+            this.client,
+            this.formatter
+          )
+        )
+        .map((column) => `${column} = excluded.${column}`)
+        .join(', ');
+
+      return sql;
+    } else if (updates && typeof updates === 'object') {
       const updateData = this._prepUpdate(updates);
       if (typeof updateData === 'string') {
         sql += updateData;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "db:stop": "docker-compose -f scripts/docker-compose.yml down",
     "db:start:postgres": "docker-compose -f scripts/docker-compose.yml up --build -d postgres && docker-compose -f scripts/docker-compose.yml up waitpostgres",
     "db:stop:postgres": "docker-compose -f scripts/docker-compose.yml down",
+    "db:start:mysql": "docker-compose -f scripts/docker-compose.yml up --build -d mysql && docker-compose -f scripts/docker-compose.yml up waitmysql",
+    "db:stop:mysql": "docker-compose -f scripts/docker-compose.yml down",
     "stress:init": "docker-compose -f scripts/stress-test/docker-compose.yml up --no-start && docker-compose -f scripts/stress-test/docker-compose.yml start",
     "stress:test": "node scripts/stress-test/knex-stress-test.js | grep -A 5 -B 60 -- '- STATS '",
     "stress:destroy": "docker-compose -f scripts/stress-test/docker-compose.yml stop"

--- a/test-tsd/types.test-d.ts
+++ b/test-tsd/types.test-d.ts
@@ -99,3 +99,12 @@ expectAssignable<QueryBuilder>(
     .merge({ x: 'x' })
     .debug(true)
 );
+
+expectAssignable<QueryBuilder>(
+  knexInstance
+    .insert({ id: 10, active: true })
+    .into('table')
+    .onConflict(['id'])
+    .merge(['active', 'id'])
+    .debug(true)
+);

--- a/test/integration/query/inserts.js
+++ b/test/integration/query/inserts.js
@@ -1779,6 +1779,11 @@ module.exports = function (knex) {
               'insert into "upsert_tests" ("email", "name") values (?, ?) on conflict ("email") do update set "name" = excluded."name" returning "email"',
               ['mergedest@example.com', 'SHOULD BE USED']
             );
+            tester(
+              'sqlite3',
+              'insert into `upsert_tests` (`email`, `name`) values (?, ?) on conflict (`email`) do update set `name` = excluded.`name`',
+              ['mergedest@example.com', 'SHOULD BE USED']
+            );
           });
       } catch (err) {
         if (/oracle|mssql/i.test(knex.client.driverName)) {

--- a/test/integration/query/inserts.js
+++ b/test/integration/query/inserts.js
@@ -1599,7 +1599,7 @@ module.exports = function (knex) {
       expect(rows[0].name).to.equal('BEFORE');
     });
 
-    it('updates columns with raw value when inserting a duplicate key to unique column and merge is specified', async function () {
+    it('updates all columns with raw value when inserting a duplicate key to unique column and merge is specified', async function () {
       if (isRedshift(knex)) {
         return this.skip();
       }
@@ -1666,7 +1666,7 @@ module.exports = function (knex) {
       expect(rows[0].name).to.equal('SOURCE');
     });
 
-    it('updates columns with raw value when inserting a duplicate key to unique column and merge with updates is specified', async function () {
+    it('updates columns with raw value when inserting a duplicate key to unique column and merge with update data is specified', async function () {
       if (isRedshift(knex)) {
         return this.skip();
       }
@@ -1732,6 +1732,69 @@ module.exports = function (knex) {
         .select();
       expect(rows.length).to.equal(1);
       expect(rows[0].name).to.equal('SOURCE');
+    });
+
+    it('updates specified columns with insert value when inserting a duplicate key to unique column and merge with update columns is specified', async function () {
+      if (isRedshift(knex)) {
+        return this.skip();
+      }
+
+      // Setup table for testing knex.raw with
+      await knex.schema.dropTableIfExists('upsert_value_source');
+      await knex.schema.createTable('upsert_value_source', (table) => {
+        table.string('name');
+      });
+      await knex('upsert_value_source').insert([{ name: 'SOURCE' }]);
+
+      // Setup: Create table with unique email column
+      await knex.schema.dropTableIfExists('upsert_tests');
+      await knex.schema.createTable('upsert_tests', (table) => {
+        table.string('name');
+        table.string('email');
+        table.unique('email');
+      });
+
+      // Setup: Create row to conflict against
+      await knex('upsert_tests').insert([
+        { email: 'mergedest@example.com', name: 'DEST' },
+      ]);
+
+      // Perform insert..merge (upsert)
+      try {
+        await knex('upsert_tests')
+          .insert(
+            { email: 'mergedest@example.com', name: 'SHOULD BE USED' },
+            'email'
+          )
+          .onConflict('email')
+          .merge(['name'])
+          .testSql(function (tester) {
+            tester(
+              'mysql',
+              'insert into `upsert_tests` (`email`, `name`) values (?, ?) on duplicate key update `name` = values(`name`)',
+              ['mergedest@example.com', 'SHOULD BE USED']
+            );
+            tester(
+              'pg',
+              'insert into "upsert_tests" ("email", "name") values (?, ?) on conflict ("email") do update set "name" = excluded."name" returning "email"',
+              ['mergedest@example.com', 'SHOULD BE USED']
+            );
+          });
+      } catch (err) {
+        if (/oracle|mssql/i.test(knex.client.driverName)) {
+          expect(err).to.be.an('error');
+          if (err.message.includes('.onConflict() is not supported for'))
+            return;
+        }
+        throw err;
+      }
+
+      // Check that row HAS been updated
+      const rows = await knex('upsert_tests')
+        .where({ email: 'mergedest@example.com' })
+        .select();
+      expect(rows.length).to.equal(1);
+      expect(rows[0].name).to.equal('SHOULD BE USED');
     });
 
     it('updates and inserts columns when inserting multiple rows merge is specified', async function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -466,7 +466,8 @@ export declare namespace Knex {
 
   interface OnConflictQueryBuilder<TRecord, TResult> {
     ignore(): QueryBuilder<TRecord, TResult>;
-    merge(data?: DbRecord<TRecord>): QueryBuilder<TRecord, TResult>;
+    merge(mergeColumns?: (keyof TRecord)[]): QueryBuilder<TRecord, TResult>;
+    merge(data?: Extract<DbRecord<TRecord>, object>): QueryBuilder<TRecord, TResult>;
   }
 
   //


### PR DESCRIPTION
Fixes #4209 
Maybe fixes #4106

New syntax on merge:

```
knex('upsert_tests')
          .insert(
            { email: 'mergedest@example.com', name: 'SHOULD BE USED', age: 12 },
          )
          .onConflict('email')
          .merge(['name', 'age'])
```
Will update only the name and age fields.
Also works for multi-inserts.