### PR TITLE
Improve join and conflict types

### DIFF
--- a/test-tsd/types.test-d.ts
+++ b/test-tsd/types.test-d.ts
@@ -99,3 +99,16 @@ expectAssignable<QueryBuilder>(
     .merge({ x: 'x' })
     .debug(true)
 );
+
+expectType<
+  QueryBuilder<
+    User,
+    DeferredKeySelection<User, 'id', true, {}, true, {}, never>[]
+  >
+>(
+  knexInstance
+    .table<User>('users')
+    .insert({ id: 10, active: true })
+    .onConflict('id')
+    .ignore()
+);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,7 +4,7 @@
 //                 Matt R. Wilson <https://github.com/mastermatt>
 //                 Satana Charuwichitratana <https://github.com/micksatana>
 //                 Shrey Jain <https://github.com/shreyjain1994>
-// TypeScript Version: 3.7
+// TypeScript Version: 4.1
 
 import tarn = require('tarn');
 import events = require('events');
@@ -1063,14 +1063,15 @@ export declare namespace Knex {
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-      >(
+    >(
       raw: Raw
     ): QueryBuilder<TRecord2, TResult2>;
     <
       TTable extends TableNames,
-      TRecord2 = ResolveTableType<TRecord> & ResolveTableType<TableType<TTable>>,
+      TRecord2 = ResolveTableType<TRecord> &
+        ResolveTableType<TableType<TTable>>,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-      >(
+    >(
       tableName: TTable,
       clause: JoinCallback
     ): QueryBuilder<TRecord2, TResult2>;
@@ -1078,7 +1079,7 @@ export declare namespace Knex {
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-      >(
+    >(
       tableName: TableDescriptor | AliasDict | QueryCallback,
       clause: JoinCallback
     ): QueryBuilder<TRecord2, TResult2>;
@@ -1086,7 +1087,7 @@ export declare namespace Knex {
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-      >(
+    >(
       tableName: TableDescriptor | AliasDict | QueryCallback,
       columns: { [key: string]: string | number | boolean | Raw }
     ): QueryBuilder<TRecord2, TResult2>;
@@ -1094,16 +1095,42 @@ export declare namespace Knex {
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-      >(
+    >(
       tableName: TableDescriptor | AliasDict | QueryCallback,
       raw: Raw
     ): QueryBuilder<TRecord2, TResult2>;
     <
-      TTable extends TableNames,
-      TRecord2 = ResolveTableType<TRecord> & ResolveTableType<TableType<TTable>>,
+      TTable1 extends TableNames,
+      TTable2 extends TableNames,
+      TKey1 extends StrKey<ResolveTableType<TableType<TTable1>>> & StrKey<TRecord1>,
+      TKey2 extends StrKey<ResolveTableType<TableType<TTable2>>>,
+      TRecord1 = ResolveTableType<TRecord>,
+      TRecord2 = TRecord1 & ResolveTableType<TableType<TTable2>>,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-      >(
-      tableName: TTable,
+    >(
+      tableName: TTable2,
+      column1: `${TTable1}.${TKey1}`,
+      column2: `${TTable2}.${TKey2}`
+    ): QueryBuilder<TRecord2, TResult2>;
+    <
+      TTable1 extends TableNames,
+      TTable2 extends TableNames,
+      TKey1 extends StrKey<ResolveTableType<TableType<TTable1>>> & StrKey<TRecord1>,
+      TKey2 extends StrKey<ResolveTableType<TableType<TTable2>>>,
+      TRecord1 = ResolveTableType<TRecord>,
+      TRecord2 = TRecord1 & ResolveTableType<TableType<TTable2>>,
+      TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
+    >(
+      tableName: TTable2,
+      column1: `${TTable2}.${TKey2}`,
+      column2: `${TTable1}.${TKey1}`
+    ): QueryBuilder<TRecord2, TResult2>;
+    <
+      TJoinTargetRecord extends {} = any,
+      TRecord2 extends {} = TRecord & TJoinTargetRecord,
+      TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
+    >(
+      tableName: TableDescriptor | AliasDict | QueryCallback,
       column1: string,
       column2: string
     ): QueryBuilder<TRecord2, TResult2>;
@@ -1111,35 +1138,44 @@ export declare namespace Knex {
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-      >(
-      tableName: TableDescriptor | AliasDict | QueryCallback,
-      column1: string,
-      column2: string
-    ): QueryBuilder<TRecord2, TResult2>;
-    <
-      TJoinTargetRecord extends {} = any,
-      TRecord2 extends {} = TRecord & TJoinTargetRecord,
-      TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-      >(
+    >(
       tableName: TableDescriptor | AliasDict | QueryCallback,
       column1: string,
       raw: Raw
     ): QueryBuilder<TRecord2, TResult2>;
     <
-      TTable extends TableNames,
-      TRecord2 = ResolveTableType<TRecord> & ResolveTableType<TableType<TTable>>,
+      TTable1 extends TableNames,
+      TTable2 extends TableNames,
+      TKey1 extends StrKey<ResolveTableType<TableType<TTable1>>> & StrKey<TRecord1>,
+      TKey2 extends StrKey<ResolveTableType<TableType<TTable2>>>,
+      TRecord1 = ResolveTableType<TRecord>,
+      TRecord2 = TRecord1 & ResolveTableType<TableType<TTable2>>,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-      >(
-      tableName: TTable,
-      column1: string,
+    >(
+      tableName: TTable2,
+      column1: `${TTable1}.${TKey1}`,
       operator: string,
-      column2: string
+      column2: `${TTable2}.${TKey2}`
+    ): QueryBuilder<TRecord2, TResult2>;
+    <
+      TTable1 extends TableNames,
+      TTable2 extends TableNames,
+      TKey1 extends StrKey<ResolveTableType<TableType<TTable1>>> & StrKey<TRecord1>,
+      TKey2 extends StrKey<ResolveTableType<TableType<TTable2>>>,
+      TRecord1 = ResolveTableType<TRecord>,
+      TRecord2 = TRecord1 & ResolveTableType<TableType<TTable2>>,
+      TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
+    >(
+      tableName: TTable2,
+      column1: `${TTable2}.${TKey2}`,
+      operator: string,
+      column2: `${TTable1}.${TKey1}`,
     ): QueryBuilder<TRecord2, TResult2>;
     <
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-      >(
+    >(
       tableName: TableDescriptor | AliasDict | QueryCallback,
       column1: string,
       operator: string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -823,7 +823,7 @@ export declare namespace Knex {
     ): QueryBuilder<TRecord, TResult2>;
 
     onConflict<
-      TKey extends StrKey<TRecord>,
+      TKey extends StrKey<ResolveTableType<TRecord>>,
       TResult2 = DeferredIndex.Augment<
         UnwrapArrayMember<TResult>,
         TRecord,
@@ -833,7 +833,7 @@ export declare namespace Knex {
       column: TKey
     ): OnConflictQueryBuilder<TRecord, TResult2>;
     onConflict<
-      TKey extends StrKey<TRecord>,
+      TKey extends StrKey<ResolveTableType<TRecord>>,
       TResult2 = DeferredKeySelection.SetSingle<
         DeferredKeySelection.Augment<UnwrapArrayMember<TResult>, TRecord, TKey>,
         false

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -466,7 +466,7 @@ export declare namespace Knex {
 
   interface OnConflictQueryBuilder<TRecord, TResult> {
     ignore(): QueryBuilder<TRecord, TResult>;
-    merge(data?: DbRecord<TRecord>): QueryBuilder<TRecord, TResult>;
+    merge(data?: DbRecord<ResolveTableType<TRecord, 'update'>>): QueryBuilder<TRecord, TResult>;
   }
 
   //

--- a/types/test.ts
+++ b/types/test.ts
@@ -1458,42 +1458,42 @@ const main = async () => {
   // $ExpectType any[]
   await knexInstance('users').innerJoin(
     'departments',
-    'users.departmentid',
+    'users.departmentId',
     'departments.id'
   );
 
   // $ExpectType any[]
   await knexInstance<User>('users').innerJoin(
     'departments',
-    'users.departmentid',
+    'users.departmentId',
     'departments.id'
   );
 
   // $ExpectType any[]
   await knexInstance('users').innerJoin<Department>(
     'departments',
-    'users.departmentid',
+    'users.departmentId',
     'departments.id'
   );
 
   // $ExpectType (User & Department)[]
   await knexInstance<User>('users').innerJoin<Department>(
     'departments',
-    'users.departmentid',
+    'users.departmentId',
     'departments.id'
   );
 
   // $ExpectType (User & Department)[]
   await knexInstance('users_inferred').innerJoin(
     'departments_inferred',
-    'users_inferred.departmentid',
+    'users_inferred.departmentId',
     'departments_inferred.id'
   );
 
   // $ExpectType (User & Department)[]
   await knexInstance('users_composite').innerJoin(
     'departments_composite',
-    'users_composite.departmentid',
+    'users_composite.departmentId',
     'departments_composite.id'
   );
 
@@ -1501,7 +1501,7 @@ const main = async () => {
   await knexInstance<User>('users')
     .innerJoin<Department>(
       'departments',
-      'users.departmentid',
+      'users.departmentId',
       'departments.id'
     )
     .innerJoin<Article>('articles', 'articles.authorId', 'users.id');
@@ -1510,7 +1510,7 @@ const main = async () => {
   await knexInstance('users_inferred')
     .innerJoin(
       'departments_inferred',
-      'users_inferred.departmentid',
+      'users_inferred.departmentId',
       'departments_inferred.id'
     )
     .innerJoin('articles_inferred', 'articles_inferred.authorId', 'users_inferred.id');
@@ -1519,25 +1519,25 @@ const main = async () => {
   await knexInstance('users_composite')
     .innerJoin(
       'departments_composite',
-      'users_composite.departmentid',
+      'users_composite.departmentId',
       'departments_composite.id'
     )
     .innerJoin('articles_composite', 'articles_composite.authorId', 'users_composite.id');
 
   // $ExpectType any[]
   await knexInstance<User>('users')
-    .innerJoin('departments', 'users.departmentid', 'departments.id')
+    .innerJoin('departments', 'users.departmentId', 'departments.id')
     .innerJoin<Article>('articles', 'articles.authorId', 'users.id');
 
   // $ExpectType any[]
   await knexInstance('users_inferred')
-    .innerJoin('departments', 'users_inferred.departmentid', 'departments.id')
+    .innerJoin('departments', 'users_inferred.departmentId', 'departments.id')
     .innerJoin('articles_inferred', 'articles_inferred.authorId', 'users.id');
 
   // $ExpectType (User & Department)[]
   await knexInstance<User>('users').innerJoin<Department>(
     'departments',
-    'users.departmentid',
+    'users.departmentId',
     '=',
     'departments.id'
   );
@@ -1545,7 +1545,7 @@ const main = async () => {
   // $ExpectType (User & Department)[]
   await knexInstance('users_inferred').innerJoin(
     'departments_inferred',
-    'users_inferred.departmentid',
+    'users_inferred.departmentId',
     '=',
     'departments_inferred.id'
   );
@@ -1553,14 +1553,14 @@ const main = async () => {
   // $ExpectType (User & Department)[]
   await knexInstance('users_composite').innerJoin(
     'departments_composite',
-    'users_composite.departmentid',
+    'users_composite.departmentId',
     '=',
     'departments_composite.id'
   );
 
   // $ExpectType { username: any; }[]
   (await knexInstance<User>('users')
-    .innerJoin('departments', 'users.departmentid', 'departments.id'))
+    .innerJoin('departments', 'users.departmentId', 'departments.id'))
     .map(function(joined) {
       return {
         username: joined.name,
@@ -1571,7 +1571,7 @@ const main = async () => {
   (await knexInstance<User>('users')
     .innerJoin<Department>(
       'departments',
-      'users.departmentid',
+      'users.departmentId',
       'departments.id'
     ))
     .map(function(joined) {
@@ -1584,7 +1584,7 @@ const main = async () => {
   (await knexInstance('users_inferred')
     .innerJoin(
       'departments_inferred',
-      'users_inferred.departmentid',
+      'users_inferred.departmentId',
       'departments_inferred.id'
     ))
     .map(function(joined) {
@@ -1597,7 +1597,7 @@ const main = async () => {
   (await knexInstance('users_composite')
     .innerJoin(
       'departments_composite',
-      'users_composite.departmentid',
+      'users_composite.departmentId',
       'departments_composite.id'
     ))
     .map(function(joined) {
@@ -1610,7 +1610,7 @@ const main = async () => {
   (await knexInstance<User>('users')
     .innerJoin<Department>(
       'departments',
-      'users.departmentid',
+      'users.departmentId',
       'departments.id'
     )
     .select('*'))
@@ -1624,7 +1624,7 @@ const main = async () => {
   (await knexInstance('users_inferred')
     .innerJoin(
       'departments_inferred',
-      'users_inferred.departmentid',
+      'users_inferred.departmentId',
       'departments_inferred.id'
     )
     .select('*'))
@@ -1638,7 +1638,7 @@ const main = async () => {
   (await knexInstance('users_composite')
     .innerJoin<Department>(
       'departments_composite',
-      'users_composite.departmentid',
+      'users_composite.departmentId',
       'departments_composite.id'
     )
     .select('*'))
@@ -1652,7 +1652,7 @@ const main = async () => {
   (await knexInstance<User>('users')
     .innerJoin<Department>(
       'departments',
-      'users.departmentid',
+      'users.departmentId',
       'departments.id'
     )
     .select())
@@ -1666,7 +1666,7 @@ const main = async () => {
   (await knexInstance('users_inferred')
     .innerJoin(
       'departments_inferred',
-      'users_inferred.departmentid',
+      'users_inferred.departmentId',
       'departments_inferred.id'
     )
     .select())
@@ -1680,7 +1680,7 @@ const main = async () => {
   (await knexInstance('users_composite')
     .innerJoin(
       'departments_composite',
-      'users_composite.departmentid',
+      'users_composite.departmentId',
       'departments_composite.id'
     )
     .select())
@@ -1694,7 +1694,7 @@ const main = async () => {
   (await knexInstance<User>('users')
     .innerJoin<Department>(
       'departments',
-      'users.departmentid',
+      'users.departmentId',
       'departments.id'
     )
     .select('name', 'age'))
@@ -1708,7 +1708,7 @@ const main = async () => {
   (await knexInstance('users_inferred')
     .innerJoin(
       'departments_inferred',
-      'users_inferred.departmentid',
+      'users_inferred.departmentId',
       'departments_inferred.id'
     )
     .select('name', 'age'))
@@ -1722,7 +1722,7 @@ const main = async () => {
   (await knexInstance('users_composite')
     .innerJoin(
       'departments_composite',
-      'users_composite.departmentid',
+      'users_composite.departmentId',
       'departments_composite.id'
     )
     .select('name', 'age'))
@@ -1736,7 +1736,7 @@ const main = async () => {
   (await knexInstance<User>('users')
     .innerJoin<Department>(
       'departments',
-      'users.departmentid',
+      'users.departmentId',
       'departments.id'
     )
     .select('users.name', 'age'))
@@ -1750,7 +1750,7 @@ const main = async () => {
   (await knexInstance('users_inferred')
     .innerJoin(
       'departments_inferred',
-      'users_inferred.departmentid',
+      'users_inferred.departmentId',
       'departments_inferred.id'
     )
     .select('users_inferred.name', 'age'))
@@ -1764,7 +1764,7 @@ const main = async () => {
   (await knexInstance('users_composite')
     .innerJoin(
       'departments_composite',
-      'users_composite.departmentid',
+      'users_composite.departmentId',
       'departments_composite.id'
     )
     .select('users_composite.name', 'age'))
@@ -1798,7 +1798,7 @@ const main = async () => {
   await knexInstance<User>('users')
     .innerJoin<Department>(
       'departments',
-      'users.departmentid',
+      'users.departmentId',
       'departments.id'
     )
     .select('users.id', 'departments.id');


### PR DESCRIPTION
With TypeScript 4.1, literal types can be constructed. This enables better type checking where it wasn't possible before.

What I did:
- Increase minimum TypeScript version to 4.1 to support template literal types
- Type join arguments
- Type onConflict (+ merge and ignore)