### PR TITLE
Add typedefinitions for havingNotIn

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -562,6 +562,9 @@ export declare namespace Knex {
     havingNotBetween: HavingRange<TRecord, TResult>;
     orHavingBetween: HavingRange<TRecord, TResult>;
     havingBetween: HavingRange<TRecord, TResult>;
+    havingNotIn: HavingRange<TRecord, TResult>;
+    andHavingNotIn: HavingRange<TRecord, TResult>;
+    orHavingNotIn: HavingRange<TRecord, TResult>;
 
     // Clear
     clearSelect(): QueryBuilder<


### PR DESCRIPTION
Added typedefinitions for `havingNotIn`, `andHavingNotIn` and `orHavingNotIn` as they were missing per this [issue](https://github.com/knex/knex/issues/3854)