### PR TITLE
Primary keys improvements

### DIFF
--- a/lib/dialects/mssql/schema/mssql-columncompiler.js
+++ b/lib/dialects/mssql/schema/mssql-columncompiler.js
@@ -73,10 +73,10 @@ class ColumnCompiler_MSSQL extends ColumnCompiler {
   }
 }
 
-ColumnCompiler_MSSQL.prototype.increments =
-  'int identity(1,1) not null primary key';
-ColumnCompiler_MSSQL.prototype.bigincrements =
-  'bigint identity(1,1) not null primary key';
+ColumnCompiler_MSSQL.prototype.increments = ({ primaryKey = true } = {}) =>
+  'int identity(1,1) not null' + (primaryKey ? ' primary key' : '');
+ColumnCompiler_MSSQL.prototype.bigincrements = ({ primaryKey = true } = {}) =>
+  'bigint identity(1,1) not null' + (primaryKey ? ' primary key' : '');
 ColumnCompiler_MSSQL.prototype.bigint = 'bigint';
 ColumnCompiler_MSSQL.prototype.mediumint = 'int';
 ColumnCompiler_MSSQL.prototype.smallint = 'smallint';

--- a/lib/dialects/mysql/schema/mysql-columncompiler.js
+++ b/lib/dialects/mysql/schema/mysql-columncompiler.js
@@ -154,10 +154,11 @@ class ColumnCompiler_MySQL extends ColumnCompiler {
   }
 }
 
-ColumnCompiler_MySQL.prototype.increments =
-  'int unsigned not null auto_increment primary key';
-ColumnCompiler_MySQL.prototype.bigincrements =
-  'bigint unsigned not null auto_increment primary key';
+ColumnCompiler_MySQL.prototype.increments = ({ primaryKey = true } = {}) =>
+  'int unsigned not null auto_increment' + (primaryKey ? ' primary key' : '');
+ColumnCompiler_MySQL.prototype.bigincrements = ({ primaryKey = true } = {}) =>
+  'bigint unsigned not null auto_increment' +
+  (primaryKey ? ' primary key' : '');
 ColumnCompiler_MySQL.prototype.bigint = 'bigint';
 ColumnCompiler_MySQL.prototype.mediumint = 'mediumint';
 ColumnCompiler_MySQL.prototype.smallint = 'smallint';

--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -92,6 +92,10 @@ class TableCompiler_MySQL extends TableCompiler {
               if (column.Default !== void 0 && column.Default !== null) {
                 sql += ` DEFAULT '${column.Default}'`;
               }
+              // Add back the auto increment if the column had it, fix issue #2767
+              if (column.Extra == 'auto_increment') {
+                sql += ` AUTO_INCREMENT`;
+              }
 
               return runner.query({
                 sql,

--- a/lib/dialects/oracle/schema/oracle-columncompiler.js
+++ b/lib/dialects/oracle/schema/oracle-columncompiler.js
@@ -15,14 +15,14 @@ class ColumnCompiler_Oracle extends ColumnCompiler {
     this.modifiers = ['defaultTo', 'checkIn', 'nullable', 'comment'];
   }
 
-  increments() {
+  increments({ primaryKey = true } = {}) {
     createAutoIncrementTriggerAndSequence(this);
-    return 'integer not null primary key';
+    return 'integer not null' + (primaryKey ? ' primary key' : '');
   }
 
-  bigincrements() {
+  bigincrements({ primaryKey = true } = {}) {
     createAutoIncrementTriggerAndSequence(this);
-    return 'number(20, 0) not null primary key';
+    return 'number(20, 0) not null' + (primaryKey ? ' primary key' : '');
   }
 
   floating(precision) {

--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -108,13 +108,15 @@ class ColumnCompiler_PG extends ColumnCompiler {
   }
 }
 
-ColumnCompiler_PG.prototype.bigincrements = 'bigserial primary key';
+ColumnCompiler_PG.prototype.bigincrements = ({ primaryKey = true } = {}) =>
+  'bigserial' + (primaryKey ? ' primary key' : '');
+ColumnCompiler_PG.prototype.increments = ({ primaryKey = true } = {}) =>
+  'serial' + (primaryKey ? ' primary key' : '');
 ColumnCompiler_PG.prototype.bigint = 'bigint';
 ColumnCompiler_PG.prototype.binary = 'bytea';
 ColumnCompiler_PG.prototype.bool = 'boolean';
 ColumnCompiler_PG.prototype.double = 'double precision';
 ColumnCompiler_PG.prototype.floating = 'real';
-ColumnCompiler_PG.prototype.increments = 'serial primary key';
 ColumnCompiler_PG.prototype.smallint = 'smallint';
 ColumnCompiler_PG.prototype.tinyint = 'smallint';
 ColumnCompiler_PG.prototype.uuid = 'uuid';

--- a/lib/dialects/redshift/schema/redshift-columncompiler.js
+++ b/lib/dialects/redshift/schema/redshift-columncompiler.js
@@ -37,14 +37,16 @@ class ColumnCompiler_Redshift extends ColumnCompiler_PG {
   }
 }
 
-ColumnCompiler_Redshift.prototype.bigincrements =
-  'bigint identity(1,1) primary key not null';
+ColumnCompiler_Redshift.prototype.increments = ({ primaryKey = true } = {}) =>
+  'integer identity(1,1)' + (primaryKey ? ' primary key' : '') + ' not null';
+ColumnCompiler_Redshift.prototype.bigincrements = ({
+  primaryKey = true,
+} = {}) =>
+  'bigint identity(1,1)' + (primaryKey ? ' primary key' : '') + ' not null';
 ColumnCompiler_Redshift.prototype.binary = 'varchar(max)';
 ColumnCompiler_Redshift.prototype.blob = 'varchar(max)';
 ColumnCompiler_Redshift.prototype.enu = 'varchar(255)';
 ColumnCompiler_Redshift.prototype.enum = 'varchar(255)';
-ColumnCompiler_Redshift.prototype.increments =
-  'integer identity(1,1) primary key not null';
 ColumnCompiler_Redshift.prototype.json = 'varchar(max)';
 ColumnCompiler_Redshift.prototype.jsonb = 'varchar(max)';
 ColumnCompiler_Redshift.prototype.longblob = 'varchar(max)';

--- a/lib/schema/columncompiler.js
+++ b/lib/schema/columncompiler.js
@@ -158,10 +158,10 @@ ColumnCompiler.prototype.timestamp = 'timestamp';
 ColumnCompiler.prototype.enu = 'varchar';
 ColumnCompiler.prototype.bit = ColumnCompiler.prototype.json = 'text';
 ColumnCompiler.prototype.uuid = 'char(36)';
-ColumnCompiler.prototype.increments =
-  'integer not null primary key autoincrement';
-ColumnCompiler.prototype.bigincrements =
-  'integer not null primary key autoincrement';
+ColumnCompiler.prototype.increments = ({ primaryKey = true } = {}) =>
+  'integer not null' + (primaryKey ? ' primary key' : '') + ' autoincrement';
+ColumnCompiler.prototype.bigincrements = ({ primaryKey = true } = {}) =>
+  'integer not null' + (primaryKey ? ' primary key' : '') + ' autoincrement';
 ColumnCompiler.prototype.integer = ColumnCompiler.prototype.smallint = ColumnCompiler.prototype.mediumint =
   'integer';
 ColumnCompiler.prototype.biginteger = 'bigint';

--- a/test/integration/query/trigger-inserts.js
+++ b/test/integration/query/trigger-inserts.js
@@ -56,7 +56,7 @@ module.exports = function (knex) {
           await knex.raw(`
                     CREATE TRIGGER [${triggerName}] ON [${secondaryTable}]
                     AFTER INSERT
-                    AS 
+                    AS
                     BEGIN
                         SET NOCOUNT ON;
 
@@ -880,8 +880,9 @@ module.exports = function (knex) {
           });
       });
 
-      it('should handle empty inserts', function () {
-        return knex.schema
+      it('should handle empty inserts', async function () {
+        await knex.schema.dropTableIfExists('trigger_retest_insert');
+        return await knex.schema
           .createTable('trigger_retest_insert', function (qb) {
             qb.increments().primary();
             qb.string('string').defaultTo('hello');
@@ -936,8 +937,9 @@ module.exports = function (knex) {
           });
       });
 
-      it('should handle empty arrays inserts', function () {
-        return knex.schema
+      it('should handle empty arrays inserts', async function () {
+        await knex.schema.dropTableIfExists('trigger_retest_insert2');
+        return await knex.schema
           .createTable('trigger_retest_insert2', function (qb) {
             qb.increments().primary();
             qb.string('string').defaultTo('hello');

--- a/test/unit/schema-builder/mssql.js
+++ b/test/unit/schema-builder/mssql.js
@@ -38,6 +38,20 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
+  it('test basic create table with incrementing without primary key', function () {
+    tableSql = client.schemaBuilder().createTable('users', function (table) {
+      table.increments('id', { primaryKey: false });
+    });
+
+    equal(1, tableSql.toSQL().length);
+    expect(tableSql.toSQL()[0].sql).to.equal(
+      'CREATE TABLE [users] ([id] int identity(1,1) not null)'
+    );
+    expect(tableSql.toQuery()).to.equal(
+      'CREATE TABLE [users] ([id] int identity(1,1) not null)'
+    );
+  });
+
   it('test drop table', function () {
     tableSql = client.schemaBuilder().dropTable('users').toSQL();
 
@@ -458,6 +472,20 @@ describe('MSSQL SchemaBuilder', function () {
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
       'ALTER TABLE [users] ADD [id] bigint identity(1,1) not null primary key'
+    );
+  });
+
+  it('test adding big incrementing id without primary key', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function () {
+        this.bigIncrements('id', { primaryKey: false });
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'ALTER TABLE [users] ADD [id] bigint identity(1,1) not null'
     );
   });
 

--- a/test/unit/schema-builder/mysql.js
+++ b/test/unit/schema-builder/mysql.js
@@ -34,6 +34,21 @@ module.exports = function (dialect) {
       );
     });
 
+    it('test basic create table with incrementing without primary key', function () {
+      tableSql = client
+        .schemaBuilder()
+        .createTable('users', function (table) {
+          table.increments('id');
+          table.increments('other_id', { primaryKey: false });
+        })
+        .toSQL();
+
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'create table `users` (`id` int unsigned not null auto_increment primary key, `other_id` int unsigned not null auto_increment)'
+      );
+    });
+
     it('test basic create table with charset and collate', function () {
       tableSql = client.schemaBuilder().createTable('users', function (table) {
         table.increments('id');
@@ -421,6 +436,20 @@ module.exports = function (dialect) {
       equal(1, tableSql.length);
       expect(tableSql[0].sql).to.equal(
         'alter table `users` add `id` bigint unsigned not null auto_increment primary key'
+      );
+    });
+
+    it('test adding big incrementing id without primary key', function () {
+      tableSql = client
+        .schemaBuilder()
+        .table('users', function () {
+          this.bigIncrements('id', { primaryKey: false });
+        })
+        .toSQL();
+
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'alter table `users` add `id` bigint unsigned not null auto_increment'
       );
     });
 

--- a/test/unit/schema-builder/oracle.js
+++ b/test/unit/schema-builder/oracle.js
@@ -41,6 +41,19 @@ describe('Oracle SchemaBuilder', function () {
     );
   });
 
+  it('test basic create table with incrementing without primary key', function () {
+    tableSql = client
+      .schemaBuilder()
+      .createTableIfNotExists('users', function (table) {
+        table.increments('id', { primaryKey: false });
+      });
+
+    equal(2, tableSql.toSQL().length);
+    expect(tableSql.toSQL()[0].sql).to.equal(
+      'begin execute immediate \'create table "users" ("id" integer not null)\'; exception when others then if sqlcode != -955 then raise; end if; end;'
+    );
+  });
+
   it('test drop table', function () {
     tableSql = client.schemaBuilder().dropTable('users').toSQL();
 
@@ -393,6 +406,20 @@ describe('Oracle SchemaBuilder', function () {
     );
     expect(tableSql[1].sql).to.equal(
       'DECLARE PK_NAME VARCHAR(200); BEGIN  EXECUTE IMMEDIATE (\'CREATE SEQUENCE "users_seq"\');  SELECT cols.column_name INTO PK_NAME  FROM all_constraints cons, all_cons_columns cols  WHERE cons.constraint_type = \'P\'  AND cons.constraint_name = cols.constraint_name  AND cons.owner = cols.owner  AND cols.table_name = \'users\';  execute immediate (\'create or replace trigger "users_autoinc_trg"  BEFORE INSERT on "users"  for each row  declare  checking number := 1;  begin    if (:new."\' || PK_NAME || \'" is null) then      while checking >= 1 loop        select "users_seq".nextval into :new."\' || PK_NAME || \'" from dual;        select count("\' || PK_NAME || \'") into checking from "users"        where "\' || PK_NAME || \'" = :new."\' || PK_NAME || \'";      end loop;    end if;  end;\'); END;'
+    );
+  });
+
+  it('test adding big incrementing id without primary key', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function () {
+        this.bigIncrements('id', { primaryKey: false });
+      })
+      .toSQL();
+
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add "id" number(20, 0) not null'
     );
   });
 

--- a/test/unit/schema-builder/oracledb.js
+++ b/test/unit/schema-builder/oracledb.js
@@ -42,6 +42,19 @@ describe('OracleDb SchemaBuilder', function () {
     );
   });
 
+  it('test basic create table with incrementing without primary key', function () {
+    tableSql = client
+      .schemaBuilder()
+      .createTableIfNotExists('users', function (table) {
+        table.increments('id', { primaryKey: false });
+      });
+
+    equal(2, tableSql.toSQL().length);
+    expect(tableSql.toSQL()[0].sql).to.equal(
+      'begin execute immediate \'create table "users" ("id" integer not null)\'; exception when others then if sqlcode != -955 then raise; end if; end;'
+    );
+  });
+
   it('test drop table', function () {
     tableSql = client.schemaBuilder().dropTable('users').toSQL();
 
@@ -376,6 +389,20 @@ describe('OracleDb SchemaBuilder', function () {
     );
     expect(tableSql[1].sql).to.equal(
       'DECLARE PK_NAME VARCHAR(200); BEGIN  EXECUTE IMMEDIATE (\'CREATE SEQUENCE "users_seq"\');  SELECT cols.column_name INTO PK_NAME  FROM all_constraints cons, all_cons_columns cols  WHERE cons.constraint_type = \'P\'  AND cons.constraint_name = cols.constraint_name  AND cons.owner = cols.owner  AND cols.table_name = \'users\';  execute immediate (\'create or replace trigger "users_autoinc_trg"  BEFORE INSERT on "users"  for each row  declare  checking number := 1;  begin    if (:new."\' || PK_NAME || \'" is null) then      while checking >= 1 loop        select "users_seq".nextval into :new."\' || PK_NAME || \'" from dual;        select count("\' || PK_NAME || \'") into checking from "users"        where "\' || PK_NAME || \'" = :new."\' || PK_NAME || \'";      end loop;    end if;  end;\'); END;'
+    );
+  });
+
+  it('test adding big incrementing id without primary key', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function () {
+        this.bigIncrements('id', { primaryKey: false });
+      })
+      .toSQL();
+
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add "id" number(20, 0) not null'
     );
   });
 

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -619,6 +619,19 @@ describe('PostgreSQL SchemaBuilder', function () {
     );
   });
 
+  it('adding incrementing id without primary key', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.increments('id', { primaryKey: false });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "id" serial'
+    );
+  });
+
   it('adding big incrementing id', function () {
     tableSql = client
       .schemaBuilder()
@@ -629,6 +642,19 @@ describe('PostgreSQL SchemaBuilder', function () {
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
       'alter table "users" add column "id" bigserial primary key'
+    );
+  });
+
+  it('adding big incrementing id without primary key', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.bigIncrements('id', { primaryKey: false });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "id" bigserial'
     );
   });
 

--- a/test/unit/schema-builder/sqlite3.js
+++ b/test/unit/schema-builder/sqlite3.js
@@ -42,6 +42,22 @@ describe('SQLite SchemaBuilder', function () {
     );
   });
 
+  it('basic create table without primary key', function () {
+    tableSql = client
+      .schemaBuilder()
+      .createTable('users', function (table) {
+        table.increments('id');
+        table.increments('other_id', { primaryKey: false });
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    equal(
+      tableSql[0].sql,
+      'create table "users" ("id" integer not null primary key autoincrement, "other_id" integer not null autoincrement)'
+    );
+  });
+
   it('basic alter table', function () {
     tableSql = client
       .schemaBuilder()
@@ -356,6 +372,21 @@ describe('SQLite SchemaBuilder', function () {
     equal(
       tableSql[0].sql,
       'alter table `users` add column `id` integer not null primary key autoincrement'
+    );
+  });
+
+  it('adding big incrementing id without primary key', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.bigIncrements('id', { primaryKey: false });
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    equal(
+      tableSql[0].sql,
+      'alter table "users" add column "id" integer not null autoincrement'
     );
   });
 

--- a/test/unit/schema-builder/sqlite3.js
+++ b/test/unit/schema-builder/sqlite3.js
@@ -54,7 +54,7 @@ describe('SQLite SchemaBuilder', function () {
     equal(1, tableSql.length);
     equal(
       tableSql[0].sql,
-      'create table "users" ("id" integer not null primary key autoincrement, "other_id" integer not null autoincrement)'
+      'create table `users` (`id` integer not null primary key autoincrement, `other_id` integer not null autoincrement)'
     );
   });
 
@@ -386,7 +386,7 @@ describe('SQLite SchemaBuilder', function () {
     equal(1, tableSql.length);
     equal(
       tableSql[0].sql,
-      'alter table "users" add column "id" integer not null autoincrement'
+      'alter table `users` add column `id` integer not null autoincrement'
     );
   });
 


### PR DESCRIPTION
Including changes for:

## Improve mySQL rename column to keep auto increment

Auto increment is removed when column is renamed in mySQL.
It has to be specified again so it is kept.

Fixed issue knex#2767

## Implementing new option primaryKey: False for the increments and bigIncrements types.

Usage:

```js
t.increments('id', { primaryKey: false }) => Not primary key
t.increments('id') => Primary key as currently
```

Rebasing of knex#2011