### PR TITLE
Fix issue with schema usage with joins on a subquery

### DIFF
--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -213,7 +213,10 @@ class Builder extends EventEmitter {
   // function(table, first, operator, second)
   join(table, first) {
     let join;
-    const { schema } = this._single;
+    const schema =
+      table instanceof Builder || typeof table === 'function'
+        ? undefined
+        : this._single.schema;
     const joinType = this._joinType();
     if (typeof first === 'function') {
       join = new JoinClause(table, joinType, schema);
@@ -221,11 +224,7 @@ class Builder extends EventEmitter {
     } else if (joinType === 'raw') {
       join = new JoinClause(this.client.raw(table, first), 'raw');
     } else {
-      join = new JoinClause(
-        table,
-        joinType,
-        table instanceof Builder ? undefined : schema
-      );
+      join = new JoinClause(table, joinType, schema);
       if (arguments.length > 1) {
         join.on.apply(join, toArray(arguments).slice(1));
       }

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -10274,6 +10274,59 @@ describe('QueryBuilder', () => {
     );
   });
 
+  it('should join on a subquery with custom conditions and schema', () => {
+    testsql(
+      qb()
+        .withSchema('schema')
+        .select()
+        .from('foo')
+        .join(qb().select(['f_id']).from('baz').as('bar'), (j) =>
+          j.on('bar.f_id', 'foo.id')
+        ),
+      {
+        mysql:
+          'select * from `schema`.`foo` inner join (select `f_id` from `baz`) as `bar` on `bar`.`f_id` = `foo`.`id`',
+        mssql:
+          'select * from [schema].[foo] inner join (select [f_id] from [baz]) as [bar] on [bar].[f_id] = [foo].[id]',
+        oracledb:
+          'select * from "schema"."foo" inner join (select "f_id" from "baz") "bar" on "bar"."f_id" = "foo"."id"',
+        pg:
+          'select * from "schema"."foo" inner join (select "f_id" from "baz") as "bar" on "bar"."f_id" = "foo"."id"',
+        'pg-redshift':
+          'select * from "schema"."foo" inner join (select "f_id" from "baz") as "bar" on "bar"."f_id" = "foo"."id"',
+        sqlite3:
+          'select * from `schema`.`foo` inner join (select `f_id` from `baz`) as `bar` on `bar`.`f_id` = `foo`.`id`',
+      }
+    );
+  });
+
+  it('should join on a subquery defined as a function with custom conditions and schema', () => {
+    testsql(
+      qb()
+        .withSchema('schema')
+        .select()
+        .from('foo')
+        .join(
+          (q) => q.select(['f_id']).from('baz').as('bar'),
+          (j) => j.on('bar.f_id', 'foo.id')
+        ),
+      {
+        mysql:
+          'select * from `schema`.`foo` inner join (select `f_id` from `baz`) as `bar` on `bar`.`f_id` = `foo`.`id`',
+        mssql:
+          'select * from [schema].[foo] inner join (select [f_id] from [baz]) as [bar] on [bar].[f_id] = [foo].[id]',
+        oracledb:
+          'select * from "schema"."foo" inner join (select "f_id" from "baz") "bar" on "bar"."f_id" = "foo"."id"',
+        pg:
+          'select * from "schema"."foo" inner join (select "f_id" from "baz") as "bar" on "bar"."f_id" = "foo"."id"',
+        'pg-redshift':
+          'select * from "schema"."foo" inner join (select "f_id" from "baz") as "bar" on "bar"."f_id" = "foo"."id"',
+        sqlite3:
+          'select * from `schema`.`foo` inner join (select `f_id` from `baz`) as `bar` on `bar`.`f_id` = `foo`.`id`',
+      }
+    );
+  });
+
   it('join with onVal andOnVal orOnVal', () => {
     testsql(
       qb()


### PR DESCRIPTION
Fixes issue: #2607 

**Case 1**:

`.withSchema` usage with join on a subquery (as a `Builder`) using a function as the join condition

```javascript
qb()
  .withSchema('schema')
  .select()
  .from('foo')
  .join(qb()
    .select(['f_id'])
    .from('baz')
    .as('bar'), j => j.on('bar.f_id', 'foo.id')
```

Expected result:
```sql
select * from "schema"."foo" inner join (select "f_id" from "baz") as "bar" on "bar"."f_id" = "foo"."id"
```

Actual result:
```sql
select * from "schema"."foo" inner join "schema"."select ""f_id"" from ""baz""" on "bar"."f_id" = "foo"."id"
```

**Case 2**:

`.withSchema` usage with join on a subquery (as a `function`)

```javascript
qb()
  .withSchema('schema')
  .select()
  .from('foo')
  .join(q => q
    .select(['f_id'])
    .from('baz')
    .as('bar'), 'bar.f_id', 'foo.id')
```

Expected result:
```sql
select * from "schema"."foo" inner join (select "f_id" from "baz") as "bar" on "bar"."f_id" = "foo"."id"
```

Actual result:

```sql
select * from "schema"."foo" inner join "schema"."q => q"."select(['f_id'])"."from('baz')"."as('bar')" on "bar"."f_id" = "foo"."id"
```
