### PR TITLE
Recreate indices when altering a table in SQLite

### DIFF
--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -9,6 +9,7 @@ const fromPairs = require('lodash/fromPairs');
 const isEmpty = require('lodash/isEmpty');
 const negate = require('lodash/negate');
 const omit = require('lodash/omit');
+const identity = require('lodash/identity');
 const { nanonum } = require('../../../util/nanoid');
 const { COMMA_NO_PAREN_REGEX } = require('../../../constants');
 const {
@@ -19,6 +20,8 @@ const {
   renameTable,
   getTableSql,
 } = require('./internal/sqlite-ddl-operations');
+const { parseCreateIndex } = require('./internal/parser');
+const { compileCreateIndex } = require('./internal/compiler');
 
 // So altering the schema in SQLite3 is a major pain.
 // We have our own object to deal with the renaming and altering the types
@@ -31,14 +34,13 @@ class SQLite3_DDL {
     this.tableNameRaw = this.tableCompiler.tableNameRaw;
     this.alteredName = `_knex_temp_alter${nanonum(3)}`;
     this.connection = connection;
-    this.formatter =
-      client && client.config && client.config.wrapIdentifier
-        ? client.config.wrapIdentifier
-        : (value) => value;
+    this.formatter = (value) =>
+      this.client.customWrapIdentifier(value, identity);
+    this.wrap = (value) => this.client.wrapIdentifierImpl(value);
   }
 
   tableName() {
-    return this.formatter(this.tableNameRaw, (value) => value);
+    return this.formatter(this.tableNameRaw);
   }
 
   async getColumn(column) {
@@ -56,8 +58,10 @@ class SQLite3_DDL {
   }
 
   getTableSql() {
+    const tableName = this.tableName();
+
     this.trx.disableProcessing();
-    return this.trx.raw(getTableSql(this.tableName())).then((result) => {
+    return this.trx.raw(getTableSql(tableName)).then((result) => {
       this.trx.enableProcessing();
       return {
         createTable: result.filter((create) => create.type === 'table')[0].sql,
@@ -240,7 +244,7 @@ class SQLite3_DDL {
         this.trx = trx;
         return Promise.all(columns.map((column) => this.getColumn(column)))
           .then(() => this.getTableSql())
-          .then(({ createTable }) => {
+          .then(({ createTable, createIndices }) => {
             let newSql = createTable.slice();
             columns.forEach((column) => {
               const a = this.client.wrapIdentifier(column);
@@ -254,7 +258,26 @@ class SQLite3_DDL {
                 fromPairs(columns.map((column) => [column, column]))
               )
             );
-            return this.alter(newSql, (row) => omit(row, ...mappedColumns));
+
+            const newIndices = [];
+            for (const createIndex of createIndices) {
+              const parsedIndex = parseCreateIndex(createIndex);
+
+              parsedIndex.columns = parsedIndex.columns.filter(
+                (newColumn) =>
+                  !columns.some((column) =>
+                    newColumn.name.includes(this.formatter(column))
+                  )
+              );
+
+              if (parsedIndex.columns.length > 0) {
+                newIndices.push(compileCreateIndex(parsedIndex, this.wrap));
+              }
+            }
+
+            return this.alter(newSql, newIndices, (row) =>
+              omit(row, ...mappedColumns)
+            );
           });
       },
       { connection: this.connection }
@@ -266,7 +289,7 @@ class SQLite3_DDL {
       async (trx) => {
         this.trx = trx;
 
-        const { createTable } = await this.getTableSql();
+        const { createTable, createIndices } = await this.getTableSql();
 
         const oneLineSql = createTable.replace(/\s+/g, ' ');
         const matched = oneLineSql.match(/^CREATE TABLE\s+(\S+)\s*\((.*)\)/);
@@ -303,7 +326,7 @@ class SQLite3_DDL {
 
         const newSql = oneLineSql.replace(defs, updatedDefs);
 
-        return this.alter(newSql, (row) => {
+        return this.alter(newSql, createIndices, (row) => {
           return row;
         });
       },
@@ -316,7 +339,7 @@ class SQLite3_DDL {
       async (trx) => {
         this.trx = trx;
 
-        const { createTable } = await this.getTableSql();
+        const { createTable, createIndices } = await this.getTableSql();
 
         const oneLineSql = createTable.replace(/\s+/g, ' ');
         const matched = oneLineSql.match(/^CREATE TABLE\s+(\S+)\s*\((.*)\)/);
@@ -348,7 +371,7 @@ class SQLite3_DDL {
 
         const newSql = oneLineSql.replace(defs, updatedDefs);
 
-        return this.alter(newSql, (row) => {
+        return this.alter(newSql, createIndices, (row) => {
           return row;
         });
       },
@@ -361,7 +384,7 @@ class SQLite3_DDL {
       async (trx) => {
         this.trx = trx;
 
-        const { createTable } = await this.getTableSql();
+        const { createTable, createIndices } = await this.getTableSql();
 
         const oneLineSql = createTable.replace(/\s+/g, ' ');
         const matched = oneLineSql.match(/^CREATE TABLE\s+(\S+)\s*\((.*)\)/);
@@ -391,7 +414,7 @@ class SQLite3_DDL {
           newColumnDefinitions
         );
 
-        return this.alter(newSQL, (row) => {
+        return this.alter(newSQL, createIndices, (row) => {
           return row;
         });
       },
@@ -404,7 +427,7 @@ class SQLite3_DDL {
       async (trx) => {
         this.trx = trx;
 
-        const { createTable } = await this.getTableSql();
+        const { createTable, createIndices } = await this.getTableSql();
 
         const oneLineSql = createTable.replace(/\s+/g, ' ');
         const matched = oneLineSql.match(/^CREATE TABLE\s+(\S+)\s*\((.*)\)/);
@@ -443,9 +466,13 @@ class SQLite3_DDL {
           newColumnDefinitions.join(', ')
         );
 
-        return await this.generateAlterCommands(newSQL, (row) => {
-          return row;
-        });
+        return await this.generateAlterCommands(
+          newSQL,
+          createIndices,
+          (row) => {
+            return row;
+          }
+        );
       },
       { connection: this.connection }
     );
@@ -458,21 +485,28 @@ class SQLite3_DDL {
    * It'll be helpful to refactor this file heavily to combine/optimize some of these calls
    */
 
-  alter(newSql, mapRow) {
-    return Promise.resolve()
-      .then(() => this.createNewTable(newSql))
-      .then(() => this.copyData(mapRow))
-      .then(() => this.dropOriginal())
-      .then(() => this.renameTable());
+  async alter(newSql, createIndices, mapRow) {
+    await this.createNewTable(newSql);
+    await this.copyData(mapRow);
+    await this.dropOriginal();
+    await this.renameTable();
+
+    for (const createIndex of createIndices) {
+      await this.trx.raw(createIndex);
+    }
   }
 
-  async generateAlterCommands(newSql, mapRow) {
+  async generateAlterCommands(newSql, createIndices, mapRow) {
     const result = [];
 
     result.push(createNewTable(newSql, this.tableName(), this.alteredName));
     result.push(copyAllData(this.tableName(), this.alteredName));
     result.push(dropOriginal(this.tableName()));
     result.push(renameTable(this.alteredName, this.tableName()));
+
+    for (const createIndex of createIndices) {
+      result.push(createIndex);
+    }
 
     return result;
   }

--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -59,7 +59,12 @@ class SQLite3_DDL {
     this.trx.disableProcessing();
     return this.trx.raw(getTableSql(this.tableName())).then((result) => {
       this.trx.enableProcessing();
-      return result;
+      return {
+        createTable: result.filter((create) => create.type === 'table')[0].sql,
+        createIndices: result
+          .filter((create) => create.type === 'index')
+          .map((create) => create.sql),
+      };
     });
   }
 
@@ -235,14 +240,13 @@ class SQLite3_DDL {
         this.trx = trx;
         return Promise.all(columns.map((column) => this.getColumn(column)))
           .then(() => this.getTableSql())
-          .then((sql) => {
-            const createTable = sql[0];
-            let newSql = createTable.sql;
+          .then(({ createTable }) => {
+            let newSql = createTable.slice();
             columns.forEach((column) => {
               const a = this.client.wrapIdentifier(column);
               newSql = this._doReplace(newSql, a, '');
             });
-            if (sql === newSql) {
+            if (createTable === newSql) {
               throw new Error('Unable to find the column to change');
             }
             const mappedColumns = Object.keys(
@@ -262,11 +266,9 @@ class SQLite3_DDL {
       async (trx) => {
         this.trx = trx;
 
-        const sql = await this.getTableSql();
+        const { createTable } = await this.getTableSql();
 
-        const createTable = sql[0];
-
-        const oneLineSql = createTable.sql.replace(/\s+/g, ' ');
+        const oneLineSql = createTable.replace(/\s+/g, ' ');
         const matched = oneLineSql.match(/^CREATE TABLE\s+(\S+)\s*\((.*)\)/);
 
         const defs = matched[2];
@@ -314,11 +316,9 @@ class SQLite3_DDL {
       async (trx) => {
         this.trx = trx;
 
-        const sql = await this.getTableSql();
+        const { createTable } = await this.getTableSql();
 
-        const createTable = sql[0];
-
-        const oneLineSql = createTable.sql.replace(/\s+/g, ' ');
+        const oneLineSql = createTable.replace(/\s+/g, ' ');
         const matched = oneLineSql.match(/^CREATE TABLE\s+(\S+)\s*\((.*)\)/);
 
         const defs = matched[2];
@@ -361,11 +361,10 @@ class SQLite3_DDL {
       async (trx) => {
         this.trx = trx;
 
-        const tableInfo = (await this.getTableSql())[0];
-        const currentSQL = tableInfo.sql;
+        const { createTable } = await this.getTableSql();
 
-        const oneLineSQL = currentSQL.replace(/\s+/g, ' ');
-        const matched = oneLineSQL.match(/^CREATE TABLE\s+(\S+)\s*\((.*)\)/);
+        const oneLineSql = createTable.replace(/\s+/g, ' ');
+        const matched = oneLineSql.match(/^CREATE TABLE\s+(\S+)\s*\((.*)\)/);
 
         const columnDefinitions = matched[2];
 
@@ -387,7 +386,7 @@ class SQLite3_DDL {
           constraintDef,
         ].join(', ');
 
-        const newSQL = oneLineSQL.replace(
+        const newSQL = oneLineSql.replace(
           columnDefinitions,
           newColumnDefinitions
         );
@@ -405,11 +404,10 @@ class SQLite3_DDL {
       async (trx) => {
         this.trx = trx;
 
-        const tableInfo = (await this.getTableSql())[0];
-        const currentSQL = tableInfo.sql;
+        const { createTable } = await this.getTableSql();
 
-        const oneLineSQL = currentSQL.replace(/\s+/g, ' ');
-        const matched = oneLineSQL.match(/^CREATE TABLE\s+(\S+)\s*\((.*)\)/);
+        const oneLineSql = createTable.replace(/\s+/g, ' ');
+        const matched = oneLineSql.match(/^CREATE TABLE\s+(\S+)\s*\((.*)\)/);
 
         const columnDefinitions = matched[2];
 
@@ -440,7 +438,7 @@ class SQLite3_DDL {
 
         newColumnDefinitions.push(newForeignSQL);
 
-        const newSQL = oneLineSQL.replace(
+        const newSQL = oneLineSql.replace(
           columnDefinitions,
           newColumnDefinitions.join(', ')
         );

--- a/lib/dialects/sqlite3/schema/internal/compiler.js
+++ b/lib/dialects/sqlite3/schema/internal/compiler.js
@@ -1,0 +1,19 @@
+function compileCreateIndex(ast, wrap = (v) => v) {
+  const columns = ast.columns
+    .map((column) => {
+      return `${!column.expression ? wrap(column.name) : column.name}${
+        column.collation ? ` COLLATE ${column.collation}` : ''
+      }${column.order ? ` ${column.order}` : ''}`;
+    })
+    .join(', ');
+
+  return `CREATE${ast.unique ? ' UNIQUE' : ''} INDEX${
+    ast.exists ? ' IF NOT EXISTS' : ''
+  } ${ast.schema ? `${wrap(ast.schema)}.` : ''}${wrap(ast.index)} on ${wrap(
+    ast.table
+  )} (${columns})${ast.where ? ` where ${ast.where}` : ''}`;
+}
+
+module.exports = {
+  compileCreateIndex,
+};

--- a/lib/dialects/sqlite3/schema/internal/parser.js
+++ b/lib/dialects/sqlite3/schema/internal/parser.js
@@ -1,0 +1,58 @@
+const { COMMA_NO_PAREN_REGEX } = require('../../../../constants');
+
+const IDENTIFIER = /^(?<open>"|`|\[)?(?<identifier>(?<=").*(?=")|(?<=`).*(?=`)|(?<=\[).*(?=\])|(?<=^)\w+(?=$))(?<close>"|`|\])?$/i;
+
+function parseCreateIndex(sql) {
+  const normalized = sql.replace(/\s+/g, ' ');
+
+  const createIndexStatement = parse(
+    normalized,
+    /^CREATE(?<unique> UNIQUE)? INDEX(?<exists> IF NOT EXISTS)? (?:(?<schema>[^.]+)\.)?(?<index>[^.]+) ON (?<table>.+?) ?\((?<columns>.+)\)(?: WHERE (?<where>.+))?$/i
+  );
+
+  const unique = createIndexStatement.unique !== undefined;
+  const exists = createIndexStatement.exists !== undefined;
+  const schema = createIndexStatement.schema
+    ? parse(createIndexStatement.schema, IDENTIFIER).identifier
+    : null;
+  const index = parse(createIndexStatement.index, IDENTIFIER).identifier;
+  const table = parse(createIndexStatement.table, IDENTIFIER).identifier;
+  const where = createIndexStatement.where || null;
+
+  const columns = createIndexStatement.columns
+    .split(COMMA_NO_PAREN_REGEX)
+    .map((column) => {
+      const normalized = column.trim();
+
+      const indexedColumn = parse(
+        normalized,
+        /^(?<name>.+?)(?: COLLATE (?<collation>\w+))?(?: (?<order>ASC|DESC))?$/i
+      );
+
+      const expression = !IDENTIFIER.test(indexedColumn.name);
+      const name = !expression
+        ? parse(indexedColumn.name, IDENTIFIER).identifier
+        : indexedColumn.name;
+      const collation = indexedColumn.collation || null;
+      const order = indexedColumn.order
+        ? indexedColumn.order.toUpperCase()
+        : null;
+
+      return { name, expression, collation, order };
+    });
+
+  return { unique, exists, schema, index, table, columns, where };
+}
+
+function parse(sql, regex) {
+  const result = sql.match(regex);
+
+  if (result === null) {
+    throw new Error('Parsing SQL command failed');
+  }
+  return result.groups;
+}
+
+module.exports = {
+  parseCreateIndex,
+};

--- a/lib/dialects/sqlite3/schema/internal/sqlite-ddl-operations.js
+++ b/lib/dialects/sqlite3/schema/internal/sqlite-ddl-operations.js
@@ -36,7 +36,7 @@ function renameTable(tableName, alteredName) {
 }
 
 function getTableSql(tableName) {
-  return `SELECT name, sql FROM sqlite_master WHERE type="table" AND name="${tableName}"`;
+  return `SELECT type, sql FROM sqlite_master WHERE (type="table" OR (type="index" AND sql IS NOT NULL)) AND tbl_name="${tableName}"`;
 }
 
 module.exports = {

--- a/test/integration2/schema/index.spec.js
+++ b/test/integration2/schema/index.spec.js
@@ -1,0 +1,292 @@
+const { expect } = require('chai');
+const {
+  Db,
+  getAllDbs,
+  getKnexForDb,
+} = require('../util/knex-instance-provider');
+
+const QUERY_TABLE_ONE_INDICES =
+  'SELECT type, name, tbl_name, sql FROM sqlite_master WHERE type="index" AND tbl_name="index_table_one"';
+const QUERY_TABLE_TWO_INDICES =
+  'SELECT type, name, tbl_name, sql FROM sqlite_master WHERE type="index" AND tbl_name="index_table_two"';
+
+describe('Schema', () => {
+  describe('Index', () => {
+    getAllDbs()
+      .filter((db) => db === Db.SQLite)
+      .forEach((db) => {
+        describe(db, () => {
+          let knex;
+          before(() => {
+            knex = getKnexForDb(db);
+          });
+
+          after(() => {
+            return knex.destroy();
+          });
+
+          beforeEach(async () => {
+            await knex.schema
+              .createTable('index_table_one', (table) => {
+                table.string('id').primary();
+                table
+                  .integer('id_three')
+                  .unsigned()
+                  .notNullable()
+                  .references('id')
+                  .inTable('index_table_three');
+
+                table.integer('column_one');
+                table.integer('column_two');
+                table.integer('column_three');
+                table.integer('column_four');
+
+                table.index('column_one');
+                table.index('column_two');
+                table.index(['column_two', 'column_three']);
+              })
+              .createTable('index_table_two', (table) => {
+                table.string('no_id');
+                table.integer('no_id_three').unsigned().notNullable();
+
+                table.integer('column_one');
+                table.integer('column_two');
+                table.integer('column_three');
+                table.integer('column_four');
+
+                table.unique('column_one');
+                table.unique('column_two');
+                table.unique(['column_two', 'column_three']);
+              })
+              .createTable('index_table_three', (table) => {
+                table.increments().primary();
+              });
+
+            await knex('index_table_three').insert({});
+            await knex('index_table_one').insert([
+              {
+                id: 'one',
+                id_three: 1,
+                column_one: 1,
+                column_two: 1,
+                column_three: 1,
+                column_four: 3,
+              },
+              {
+                id: 'two',
+                id_three: 1,
+                column_one: 1,
+                column_two: 1,
+                column_three: 1,
+                column_four: 4,
+              },
+            ]);
+            await knex('index_table_two').insert([
+              {
+                no_id: 'one',
+                no_id_three: 1,
+                column_one: 1,
+                column_two: 1,
+                column_three: 1,
+                column_four: 3,
+              },
+              {
+                no_id: 'two',
+                no_id_three: 1,
+                column_one: 2,
+                column_two: 2,
+                column_three: 2,
+                column_four: 4,
+              },
+            ]);
+          });
+
+          afterEach(async () => {
+            await knex.schema
+              .dropTable('index_table_one')
+              .dropTable('index_table_two')
+              .dropTable('index_table_three');
+          });
+
+          describe('dropColumn', () => {
+            it('recreates indices after dropping a column without an index', async () => {
+              const indicesOneBefore = await knex.raw(QUERY_TABLE_ONE_INDICES);
+              const indicesTwoBefore = await knex.raw(QUERY_TABLE_TWO_INDICES);
+
+              await knex.schema.alterTable('index_table_one', (table) => {
+                table.dropColumn('column_four');
+              });
+              await knex.schema.alterTable('index_table_two', (table) => {
+                table.dropColumn('column_four');
+              });
+
+              const indicesOneAfter = await knex.raw(QUERY_TABLE_ONE_INDICES);
+              const indicesTwoAfter = await knex.raw(QUERY_TABLE_TWO_INDICES);
+
+              expect(indicesOneAfter).to.deep.have.same.members(
+                indicesOneBefore
+              );
+              expect(indicesTwoAfter).to.deep.have.same.members(
+                indicesTwoBefore
+              );
+            });
+
+            it('drops indices when the corresponding column is dropped', async () => {
+              const indicesOneBefore = await knex.raw(QUERY_TABLE_ONE_INDICES);
+              const indicesTwoBefore = await knex.raw(QUERY_TABLE_TWO_INDICES);
+              const indicesOneBeforeWithoutIndex = indicesOneBefore.filter(
+                (index) => index.name !== 'index_table_one_column_one_index'
+              );
+              const indicesTwoBeforeWithoutIndex = indicesTwoBefore.filter(
+                (index) => index.name !== 'index_table_two_column_one_unique'
+              );
+
+              await knex.schema.alterTable('index_table_one', (table) => {
+                table.dropColumn('column_one');
+              });
+              await knex.schema.alterTable('index_table_two', (table) => {
+                table.dropColumn('column_one');
+              });
+
+              const indicesOneAfter = await knex.raw(QUERY_TABLE_ONE_INDICES);
+              const indicesTwoAfter = await knex.raw(QUERY_TABLE_TWO_INDICES);
+
+              expect(indicesOneAfter).to.deep.have.same.members(
+                indicesOneBeforeWithoutIndex
+              );
+              expect(indicesTwoAfter).to.deep.have.same.members(
+                indicesTwoBeforeWithoutIndex
+              );
+            });
+
+            it('alters composite indices when one of the corresponding columns is dropped', async () => {
+              const indicesOneBeforeWithoutIndex = [
+                {
+                  type: 'index',
+                  name: 'sqlite_autoindex_index_table_one_1',
+                  tbl_name: 'index_table_one',
+                  sql: null,
+                },
+                {
+                  type: 'index',
+                  name: 'index_table_one_column_one_index',
+                  tbl_name: 'index_table_one',
+                  sql:
+                    'CREATE INDEX `index_table_one_column_one_index` on `index_table_one` (`column_one`)',
+                },
+                {
+                  type: 'index',
+                  name: 'index_table_one_column_two_column_three_index',
+                  tbl_name: 'index_table_one',
+                  sql:
+                    'CREATE INDEX `index_table_one_column_two_column_three_index` on `index_table_one` (`column_three`)',
+                },
+              ];
+              const indicesTwoBeforeWithoutIndex = [
+                {
+                  type: 'index',
+                  name: 'index_table_two_column_one_unique',
+                  tbl_name: 'index_table_two',
+                  sql:
+                    'CREATE UNIQUE INDEX `index_table_two_column_one_unique` on `index_table_two` (`column_one`)',
+                },
+                {
+                  type: 'index',
+                  name: 'index_table_two_column_two_column_three_unique',
+                  tbl_name: 'index_table_two',
+                  sql:
+                    'CREATE UNIQUE INDEX `index_table_two_column_two_column_three_unique` on `index_table_two` (`column_three`)',
+                },
+              ];
+
+              await knex.schema.alterTable('index_table_one', (table) => {
+                table.dropColumn('column_two');
+              });
+              await knex.schema.alterTable('index_table_two', (table) => {
+                table.dropColumn('column_two');
+              });
+
+              const indicesOneAfter = await knex.raw(QUERY_TABLE_ONE_INDICES);
+              const indicesTwoAfter = await knex.raw(QUERY_TABLE_TWO_INDICES);
+
+              expect(indicesOneAfter).to.deep.have.same.members(
+                indicesOneBeforeWithoutIndex
+              );
+              expect(indicesTwoAfter).to.deep.have.same.members(
+                indicesTwoBeforeWithoutIndex
+              );
+            });
+          });
+
+          describe('dropForeign', () => {
+            it('recreates indices after dropping a foreign key', async () => {
+              const indicesBefore = await knex.raw(QUERY_TABLE_ONE_INDICES);
+
+              await knex.schema.alterTable('index_table_one', (table) => {
+                table.dropForeign('id_three');
+              });
+
+              const indicesAfter = await knex.raw(QUERY_TABLE_ONE_INDICES);
+
+              expect(indicesAfter).to.deep.have.same.members(indicesBefore);
+            });
+          });
+
+          describe('dropPrimary', () => {
+            it('recreates indices after dropping a primary key', async () => {
+              const indicesBefore = await knex.raw(QUERY_TABLE_ONE_INDICES);
+              const indicesBeforeWithoutPrimary = indicesBefore.filter(
+                (index) => index.sql !== null
+              );
+
+              await knex.schema.alterTable('index_table_one', (table) => {
+                table.dropPrimary('id');
+              });
+
+              const indicesAfter = await knex.raw(QUERY_TABLE_ONE_INDICES);
+
+              expect(indicesAfter).to.deep.have.same.members(
+                indicesBeforeWithoutPrimary
+              );
+            });
+          });
+
+          describe('foreign', () => {
+            it('recreates indices after adding a foreign key', async () => {
+              const indicesBefore = await knex.raw(QUERY_TABLE_TWO_INDICES);
+
+              await knex.schema.alterTable('index_table_two', (table) => {
+                table
+                  .foreign('no_id_three')
+                  .references('id')
+                  .inTable('index_table_three');
+              });
+
+              const indicesAfter = await knex.raw(QUERY_TABLE_TWO_INDICES);
+
+              expect(indicesAfter).to.deep.have.same.members(indicesBefore);
+            });
+          });
+
+          describe('primary', () => {
+            it('recreates indices after adding a primary key', async () => {
+              const indicesBefore = await knex.raw(QUERY_TABLE_TWO_INDICES);
+
+              await knex.schema.alterTable('index_table_two', (table) => {
+                table.primary('no_id');
+              });
+
+              const indicesAfter = await knex.raw(QUERY_TABLE_TWO_INDICES);
+              const indicesAfterWithoutPrimary = indicesAfter.filter(
+                (index) => index.sql !== null
+              );
+
+              expect(indicesAfterWithoutPrimary).to.deep.have.same.members(
+                indicesBefore
+              );
+            });
+          });
+        });
+      });
+  });
+});


### PR DESCRIPTION
I tried to separate the parsing and the altering logic as much as possible.

When querying `sqlite_master` for create index statements, it seems like only the first part of those statements is in uppercase. It would be nice if the casing was consistent but when I tried to uppercase the index creation statements in the SQLite TableCompiler, nearly all tests failed with cryptic errors.