### PR TITLE
mssql: column: json from text to nvarchar(max)

### DIFF
--- a/lib/dialects/mssql/schema/mssql-columncompiler.js
+++ b/lib/dialects/mssql/schema/mssql-columncompiler.js
@@ -83,6 +83,7 @@ ColumnCompiler_MSSQL.prototype.smallint = 'smallint';
 ColumnCompiler_MSSQL.prototype.text = 'nvarchar(max)';
 ColumnCompiler_MSSQL.prototype.mediumtext = 'nvarchar(max)';
 ColumnCompiler_MSSQL.prototype.longtext = 'nvarchar(max)';
+ColumnCompiler_MSSQL.prototype.json = 'nvarchar(max)';
 
 // TODO: mssql supports check constraints as of SQL Server 2008
 // so make enu here more like postgres

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -539,7 +539,7 @@ module.exports = (knex) => {
               'alter table "test_table_three" add constraint "test_table_three_pkey" primary key ("main")',
             ]);
             tester('mssql', [
-              "CREATE TABLE [test_table_three] ([main] int not null, [paragraph] nvarchar(max) default 'Lorem ipsum Qui quis qui in.', [metadata] text default '{\"a\":10}', CONSTRAINT [test_table_three_pkey] PRIMARY KEY ([main]))",
+              "CREATE TABLE [test_table_three] ([main] int not null, [paragraph] nvarchar(max) default 'Lorem ipsum Qui quis qui in.', [metadata] nvarchar(max) default '{\"a\":10}', CONSTRAINT [test_table_three_pkey] PRIMARY KEY ([main]))",
             ]);
           })
           .then(() =>


### PR DESCRIPTION
This patch changes the `json` column type in the MSSQL dialect from `text` to `nvarchar(max)` to bring it in-line with JSON requirements for storage.

## Rationale
* According to [MSDN](https://docs.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?redirectedfrom=MSDN&view=sql-server-ver15) the `text` and `ntext` types are deprecated and will be removed in future versions of SQL Server.
* As `text` types are unconditionally stored in LOB storage there may be performance implications for small JSON data.
* The JSON spec [RFC4627](https://www.ietf.org/rfc/rfc4627.txt) requires a UTF-8 strings but `text` stores non-unicode data, which will corrupt otherwise spec-conforming documents with unicode characters in it.

Tests have been updated to acknowledge the new type.
