### PR TITLE
mssql: add all mssql options to Knex.ConnectionConfig

### DIFF
--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -37,7 +37,7 @@ class Client_MSSQL extends Client {
       authentication: {
         type: settings.type || 'default',
         options: {
-          userName: settings.user,
+          userName: settings.userName || settings.user,
           password: settings.password,
           domain: settings.domain,
           token: settings.token,
@@ -47,7 +47,7 @@ class Client_MSSQL extends Client {
           msiEndpoint: settings.msiEndpoint,
         },
       },
-      server: settings.host || settings.server,
+      server: settings.server || settings.host,
       options: {
         database: settings.database,
         encrypt: settings.encrypt || false,

--- a/test-tsd/mssql-config.test-d.ts
+++ b/test-tsd/mssql-config.test-d.ts
@@ -2,63 +2,63 @@ import { expectAssignable, expectType } from 'tsd';
 
 import { Knex } from '../types';
 
-expectType<Knex.MsSqlAzureActiveDirectoryAccessTokenAuthenticationConfig>({
+const azureActiveDirectoryConfig: Knex.MsSqlAzureActiveDirectoryAccessTokenAuthenticationConfig = {
   type: 'azure-active-directory-access-token',
     token: 'test',
     server: 'test',
     database: 'test'
-} as Knex.MsSqlAzureActiveDirectoryAccessTokenAuthenticationConfig);
+}
 
-expectType<Knex.MsSqlAzureActiveDirectoryMsiAppServiceAuthenticationConfig>({
+const azureActiveDirectoryMsiConfig: Knex.MsSqlAzureActiveDirectoryMsiAppServiceAuthenticationConfig = {
   type: 'azure-active-directory-msi-app-service',
   database: '',
   server: '',
   clientId: '',
   msiEndpoint: '',
   msiSecret: ''
-} as Knex.MsSqlAzureActiveDirectoryMsiAppServiceAuthenticationConfig);
+}
 
-expectType<Knex.MsSqlAzureActiveDirectoryMsiVmAuthenticationConfig>({
+const azureActiveDirectoryMsiVmConfig: Knex.MsSqlAzureActiveDirectoryMsiVmAuthenticationConfig = {
   type: 'azure-active-directory-msi-vm',
   database: '',
   server: '',
   clientId: '',
   msiEndpoint: 'test',
-} as Knex.MsSqlAzureActiveDirectoryMsiVmAuthenticationConfig);
+}
 
-expectType<Knex.MsSqlAzureActiveDirectoryPasswordAuthenticationConfig>({
+const azureActiveDirectoryPasswordConfig: Knex.MsSqlAzureActiveDirectoryPasswordAuthenticationConfig = {
   type: 'azure-active-directory-password',
   database: '',
   server: '',
   domain: '',
   password: '',
   userName: '',
-} as Knex.MsSqlAzureActiveDirectoryPasswordAuthenticationConfig)
+}
 
-expectType<Knex.MsSqlAzureActiveDirectoryServicePrincipalSecretConfig>({
+const azureActiveDirectoryPrincipalConfig: Knex.MsSqlAzureActiveDirectoryServicePrincipalSecretConfig = {
   clientId: '',
   clientSecret: '',
   database: '',
   server: '',
   tenantId: '',
   type: 'azure-active-directory-service-principal-secret',
-} as Knex.MsSqlAzureActiveDirectoryServicePrincipalSecretConfig);
+}
 
-expectType<Knex.MsSqlDefaultAuthenticationConfig>({
+const defaultConfig: Knex.MsSqlDefaultAuthenticationConfig = {
   type: 'default',
   database: '',
   server: '',
   userName: '',
   password: '',
-} as Knex.MsSqlDefaultAuthenticationConfig)
+}
 
 // Assert that no type property works and assumes default
-expectType<Knex.MsSqlConnectionConfig>({
+const connectionConfig: Knex.MsSqlConnectionConfig = {
   server: '',
   database: '',
   userName: '',
   password: ''
-} as Knex.MsSqlConnectionConfig);
+};
 
 expectAssignable<Knex.MsSqlConnectionConfigBase>({
   server: '',

--- a/test-tsd/mssql-config.test-d.ts
+++ b/test-tsd/mssql-config.test-d.ts
@@ -1,0 +1,66 @@
+import { expectAssignable, expectType } from 'tsd';
+
+import { Knex } from '../types';
+
+expectType<Knex.MsSqlAzureActiveDirectoryAccessTokenAuthenticationConfig>({
+  type: 'azure-active-directory-access-token',
+    token: 'test',
+    server: 'test',
+    database: 'test'
+} as Knex.MsSqlAzureActiveDirectoryAccessTokenAuthenticationConfig);
+
+expectType<Knex.MsSqlAzureActiveDirectoryMsiAppServiceAuthenticationConfig>({
+  type: 'azure-active-directory-msi-app-service',
+  database: '',
+  server: '',
+  clientId: '',
+  msiEndpoint: '',
+  msiSecret: ''
+} as Knex.MsSqlAzureActiveDirectoryMsiAppServiceAuthenticationConfig);
+
+expectType<Knex.MsSqlAzureActiveDirectoryMsiVmAuthenticationConfig>({
+  type: 'azure-active-directory-msi-vm',
+  database: '',
+  server: '',
+  clientId: '',
+  msiEndpoint: 'test',
+} as Knex.MsSqlAzureActiveDirectoryMsiVmAuthenticationConfig);
+
+expectType<Knex.MsSqlAzureActiveDirectoryPasswordAuthenticationConfig>({
+  type: 'azure-active-directory-password',
+  database: '',
+  server: '',
+  domain: '',
+  password: '',
+  userName: '',
+} as Knex.MsSqlAzureActiveDirectoryPasswordAuthenticationConfig)
+
+expectType<Knex.MsSqlAzureActiveDirectoryServicePrincipalSecretConfig>({
+  clientId: '',
+  clientSecret: '',
+  database: '',
+  server: '',
+  tenantId: '',
+  type: 'azure-active-directory-service-principal-secret',
+} as Knex.MsSqlAzureActiveDirectoryServicePrincipalSecretConfig);
+
+expectType<Knex.MsSqlDefaultAuthenticationConfig>({
+  type: 'default',
+  database: '',
+  server: '',
+  userName: '',
+  password: '',
+} as Knex.MsSqlDefaultAuthenticationConfig)
+
+// Assert that no type property works and assumes default
+expectType<Knex.MsSqlConnectionConfig>({
+  server: '',
+  database: '',
+  userName: '',
+  password: ''
+} as Knex.MsSqlConnectionConfig);
+
+expectAssignable<Knex.MsSqlConnectionConfigBase>({
+  server: '',
+  database: '',
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1941,7 +1941,7 @@ interface MsSqlDefaultAuthenticationConfig extends MsSqlConnectionConfigBase {
   /**
    * User name to use for sql server login.
    */
-  userName?: string;
+  user?: string;
   /**
    * Password to use for sql server login.
    */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1927,8 +1927,137 @@ export declare namespace Knex {
     requestTimeout?: number;
   }
 
-  // Config object for mssql: see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mssql/index.d.ts
-  interface MsSqlConnectionConfig {
+  type MsSqlAuthenticationTypeOptions =
+    | 'default'
+    | 'ntlm'
+    | 'azure-active-directory-password'
+    | 'azure-active-directory-access-token'
+    | 'azure-active-directory-msi-vm'
+    | 'azure-active-directory-msi-app-service'
+    | 'azure-active-directory-service-principal-secret';
+
+interface MsSqlDefaultAuthenticationConfig extends MsSqlConnectionConfigBase {
+  type?: 'default' | never;
+  /**
+   * User name to use for sql server login.
+   */
+  userName?: string;
+  /**
+   * Password to use for sql server login.
+   */
+  password?: string;
+}
+
+interface MsSqlAzureActiveDirectoryMsiAppServiceAuthenticationConfig
+  extends MsSqlConnectionConfigBase {
+  type: 'azure-active-directory-msi-app-service';
+  /**
+   * If you user want to connect to an Azure app service using a specific client account
+   * they need to provide `clientId` asscoiate to their created idnetity.
+   *
+   * This is optional for retrieve token from azure web app service
+   */
+  clientId?: string;
+  /**
+   * A msi app service environment need to provide `msiEndpoint` for retriving the accesstoken.
+   */
+  msiEndpoint?: string;
+  /**
+   * A msi app service environment need to provide `msiSecret` for retriving the accesstoken.
+   */
+  msiSecret?: string;
+}
+
+interface MsSqlAzureActiveDirectoryMsiVmAuthenticationConfig
+  extends MsSqlConnectionConfigBase {
+  type: 'azure-active-directory-msi-vm';
+  /**
+   * If you user want to connect to an Azure app service using a specific client account
+   * they need to provide `clientId` asscoiate to their created idnetity.
+   *
+   * This is optional for retrieve token from azure web app service
+   */
+  clientId?: string;
+  /**
+   * A user need to provide `msiEndpoint` for retriving the accesstoken.
+   */
+  msiEndpoint?: string;
+}
+
+interface MsSqlAzureActiveDirectoryAccessTokenAuthenticationConfig
+  extends MsSqlConnectionConfigBase {
+  type: 'azure-active-directory-access-token';
+  /**
+   * A user-provided access token
+   */
+  token: string;
+}
+interface MsSqlAzureActiveDirectoryPasswordAuthenticationConfig
+  extends MsSqlConnectionConfigBase {
+  type: 'azure-active-directory-password';
+  /**
+   * A user need to provide `userName` asscoiate to their account.
+   */
+  userName: string;
+  /**
+   * A user need to provide `password` asscoiate to their account.
+   */
+  password: string;
+
+  /**
+   * Optional parameter for specific Azure tenant ID
+   */
+  domain: string;
+}
+
+interface MsSqlAzureActiveDirectoryServicePrincipalSecretConfig
+  extends MsSqlConnectionConfigBase {
+  type: 'azure-active-directory-service-principal-secret';
+  /**
+   * Application (`client`) ID from your registered Azure application
+   */
+  clientId: string;
+  /**
+   * The created `client secret` for this registered Azure application
+   */
+  clientSecret: string;
+  /**
+   * Directory (`tenant`) ID from your registered Azure application
+   */
+  tenantId: string;
+}
+
+interface MsSqlNtlmAuthenticationConfig extends MsSqlConnectionConfigBase {
+  type: 'ntlm';
+  /**
+   * User name from your windows account.
+   */
+  userName: string;
+  /**
+   * Password from your windows account.
+   */
+  password: string;
+  /**
+   * Once you set domain for ntlm authentication type, driver will connect to SQL Server using domain login.
+   *
+   * This is necessary for forming a connection using ntlm type
+   */
+  domain: string;
+}
+
+type MsSqlConnectionConfig =
+  | MsSqlDefaultAuthenticationConfig
+  | MsSqlNtlmAuthenticationConfig
+  | MsSqlAzureActiveDirectoryAccessTokenAuthenticationConfig
+  | MsSqlAzureActiveDirectoryMsiAppServiceAuthenticationConfig
+  | MsSqlAzureActiveDirectoryMsiVmAuthenticationConfig
+  | MsSqlAzureActiveDirectoryPasswordAuthenticationConfig
+  | MsSqlAzureActiveDirectoryServicePrincipalSecretConfig;
+
+  // Config object for tedious: see http://tediousjs.github.io/tedious/api-connection.html
+interface MsSqlConnectionConfigBase {
+    type?: MsSqlAuthenticationTypeOptions;
+
     driver?: string;
     user?: string;
     password?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1938,14 +1938,6 @@ export declare namespace Knex {
 
 interface MsSqlDefaultAuthenticationConfig extends MsSqlConnectionConfigBase {
   type?: 'default' | never;
-  /**
-   * User name to use for sql server login.
-   */
-  user?: string;
-  /**
-   * Password to use for sql server login.
-   */
-  password?: string;
 }
 
 interface MsSqlAzureActiveDirectoryMsiAppServiceAuthenticationConfig
@@ -1996,18 +1988,11 @@ interface MsSqlAzureActiveDirectoryPasswordAuthenticationConfig
   extends MsSqlConnectionConfigBase {
   type: 'azure-active-directory-password';
   /**
-   * A user need to provide `userName` asscoiate to their account.
-   */
-  userName: string;
-  /**
-   * A user need to provide `password` asscoiate to their account.
-   */
-  password: string;
-
-  /**
    * Optional parameter for specific Azure tenant ID
    */
   domain: string;
+  userName: string;
+  password: string;
 }
 
 interface MsSqlAzureActiveDirectoryServicePrincipalSecretConfig
@@ -2030,19 +2015,13 @@ interface MsSqlAzureActiveDirectoryServicePrincipalSecretConfig
 interface MsSqlNtlmAuthenticationConfig extends MsSqlConnectionConfigBase {
   type: 'ntlm';
   /**
-   * User name from your windows account.
-   */
-  userName: string;
-  /**
-   * Password from your windows account.
-   */
-  password: string;
-  /**
    * Once you set domain for ntlm authentication type, driver will connect to SQL Server using domain login.
    *
    * This is necessary for forming a connection using ntlm type
    */
   domain: string;
+  userName: string;
+  password: string;
 }
 
 type MsSqlConnectionConfig =
@@ -2059,9 +2038,9 @@ interface MsSqlConnectionConfigBase {
     type?: MsSqlAuthenticationTypeOptions;
 
     driver?: string;
-    user?: string;
+    userName?: string; // equivalent to knex "user"
     password?: string;
-    server: string;
+    server: string; // equivalent to knex "host"
     port?: number;
     domain?: string;
     database: string;


### PR DESCRIPTION
This patch introduces typings for all the available connection options in `mssql` with the tedious driver.

It includes tsd tests to assert type overloading of the `MsSqlConnectionConfig` union type.