### PR TITLE
MSSQL hotfix for error handling in cloud

### DIFF
--- a/lib/dialects/mssql/transaction.js
+++ b/lib/dialects/mssql/transaction.js
@@ -124,7 +124,11 @@ class Transaction_MSSQL extends Transaction {
         return;
       }
       if (error) {
-        err.originalError = error;
+        try {
+          err.originalError = error;
+        } catch (_err) {
+          // This is to handle https://github.com/knex/knex/issues/4128
+        }
       }
       this._rejecter(err);
     });


### PR DESCRIPTION
Restore hotfix from #4128

It's unclear if it's still needed, but it'd be better to drop it later to avoid additional potential breakages for people updating to the next major.