### PR TITLE
Include 'name' property in MigratorConfig

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2264,6 +2264,7 @@ interface MsSqlConnectionConfigBase {
     sortDirsSeparately?: boolean;
     loadExtensions?: readonly string[];
     migrationSource?: MigrationSource<unknown>;
+    name?: string;
   }
 
   interface Migrator {


### PR DESCRIPTION
PR #3416 added the ability to specify a filename for the up and down commands, but that parameter was left out of the MigratorConfig interface, causing compilation errors for those using that property and typescript.