### PR TITLE
events: introduce queryContext on query-error

### DIFF
--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -122,6 +122,7 @@ class Runner {
 
     const runner = this;
     let queryPromise = this.client.query(this.connection, obj);
+    const queryContext = this.builder.queryContext();
 
     if (obj.timeout) {
       queryPromise = timeout(queryPromise, obj.timeout);
@@ -133,7 +134,6 @@ class Runner {
     return queryPromise
       .then((resp) => this.client.processResponse(resp, runner))
       .then((processedResponse) => {
-        const queryContext = this.builder.queryContext();
         const postProcessedResponse = this.client.postProcessResponse(
           processedResponse,
           queryContext
@@ -203,7 +203,7 @@ class Runner {
         this.builder.emit(
           'query-error',
           error,
-          Object.assign({ __knexUid, __knexTxId }, obj)
+          Object.assign({ __knexUid, __knexTxId, queryContext }, obj)
         );
         throw error;
       });

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -736,7 +736,8 @@ describe('knex', () => {
 
       try {
         await knex.from('banana');
-      } catch {}
+        // eslint-disable-next-line no-empty
+      } catch (_e) {}
 
       expect(spy).to.be.calledOnce;
       const [[error, errorArgs]] = spy.args;


### PR DESCRIPTION
This patch introduces support for submitting the `queryContext` on `query-error` events.  

Because of the async nature of some drivers, the root callsite of responses is usually `TCP._onRead`.  Query builders created in the context of an Express request or another mechanism get lost in error events attached to the query builders.  Being able to access the `queryContext` in case of an error is a low-overhead way of relating a query error back to something more high level, enabling meaningful error reporting.

The patch is covered by a unit test.