### PR TITLE
Respect KNEX_TEST, support omitting sqlite3 from DB, and reduce outside mssql test db config

### DIFF
--- a/test/integration2/util/knex-instance-provider.js
+++ b/test/integration2/util/knex-instance-provider.js
@@ -1,5 +1,7 @@
 const { promisify } = require('util');
 const knex = require('../../../lib');
+const testConfig =
+  (process.env.KNEX_TEST && require(process.env.KNEX_TEST)) || {};
 
 const Db = {
   PostgresSQL: 'postgres',
@@ -52,7 +54,7 @@ const seeds = {
 const testConfigs = {
   mysql: {
     client: 'mysql',
-    connection: {
+    connection: testConfig.mysql || {
       port: 23306,
       database: 'knex_test',
       host: 'localhost',
@@ -67,7 +69,7 @@ const testConfigs = {
 
   mysql2: {
     client: 'mysql2',
-    connection: {
+    connection: testConfig.mysql || {
       port: 23306,
       database: 'knex_test',
       host: 'localhost',
@@ -82,7 +84,7 @@ const testConfigs = {
 
   postgres: {
     client: 'postgres',
-    connection: {
+    connection: testConfig.postgres || {
       adapter: 'postgresql',
       port: 25432,
       host: 'localhost',
@@ -97,7 +99,7 @@ const testConfigs = {
 
   sqlite3: {
     client: 'sqlite3',
-    connection: ':memory:',
+    connection: testConfig.sqlite3 || ':memory:',
     pool: poolSqlite,
     migrations,
     seeds,
@@ -105,7 +107,7 @@ const testConfigs = {
 
   mssql: {
     client: 'mssql',
-    connection: {
+    connection: testConfig.mssql || {
       user: 'sa',
       password: 'S0meVeryHardPassword',
       server: 'localhost',
@@ -119,7 +121,7 @@ const testConfigs = {
 
   oracledb: {
     client: 'oracledb',
-    connection: {
+    connection: testConfig.oracledb || {
       user: 'system',
       password: 'Oracle18',
       connectString: 'localhost:21521/XE',

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -366,11 +366,14 @@ describe('knex', () => {
   });
 
   describe('transaction', () => {
-    it('transaction of a copy with userParams retains userparams', async function () {
+    before(function skipSuiteIfSqliteConfigAbsent() {
+      // This is the case when the |DB| environment parameter does not include |sqlite|.
       if (!sqliteConfig) {
         return this.skip();
       }
+    });
 
+    it('transaction of a copy with userParams retains userparams', async function () {
       const knex = Knex(sqliteConfig);
 
       const knexWithParams = knex.withUserParams({ userParam: '451' });
@@ -599,10 +602,6 @@ describe('knex', () => {
     });
 
     it('creating transaction copy with user params should throw an error', async function () {
-      if (!sqliteConfig) {
-        return this.skip();
-      }
-
       const knex = Knex(sqliteConfig);
 
       await knex.transaction(async (trx) => {
@@ -639,6 +638,13 @@ describe('knex', () => {
   });
 
   describe('extend query builder', () => {
+    before(function skipSuiteIfSqliteConfigAbsent() {
+      // This is the case when the |DB| environment parameter does not include |sqlite|.
+      if (!sqliteConfig) {
+        return this.skip();
+      }
+    });
+
     let connection;
     beforeEach(() => {
       connection = new sqlite3.Database(':memory:');


### PR DESCRIPTION
This PR contains several changes that simplify getting a green test run in a fresh checkout by eliminating some unexpected behavior around KNEX_TEST and DB config.

Before, if DB omitted sqlite3, several of the CLI tests would fail, because only some of them conditionally skipped when sqlite3 config was not available. Now, all of those tests skip when sqlite3 tests are not selected.

Before, some of the DB integration tests did not use the config supplied in KNEX_TEST. Now, all run by test:db do.

Before, the mssql transaction isolation tests required, not just a test DB, but also a test DB with snapshot isolation already enabled. This led to test failures due to having a test DB without that config already set up. Now, that test suite ensures snapshot isolation is enabled upfront before running its tests.

There is no documentation PR; the main intent of this PR is to align test suite behavior with the existing documentation around how the DB and KNEX_TEST environment variables affect test running.