### PR TITLE
mssql: don't raise query-error twice

### DIFF
--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -113,10 +113,6 @@ class Client_MSSQL extends Client {
 
   queryBuilder() {
     const b = new QueryBuilder(this);
-    const base = this;
-    b.on('query-error', function () {
-      base.emit('query-error', ...arguments);
-    });
     return b;
   }
 

--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -122,7 +122,11 @@ class Runner {
 
     const runner = this;
     const queryContext = this.builder.queryContext();
-    obj.context = queryContext;
+    // query-error events are emitted before the queryPromise continuations.
+    // pass queryContext into client.query so it can be raised properly.
+    if (obj !== null && typeof obj === 'object') {
+      obj.queryContext = queryContext;
+    }
     let queryPromise = this.client.query(this.connection, obj);
 
     if (obj.timeout) {

--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -121,8 +121,9 @@ class Runner {
     this.builder.emit('query', Object.assign({ __knexUid, __knexTxId }, obj));
 
     const runner = this;
-    let queryPromise = this.client.query(this.connection, obj);
     const queryContext = this.builder.queryContext();
+    obj.context = queryContext;
+    let queryPromise = this.client.query(this.connection, obj);
 
     if (obj.timeout) {
       queryPromise = timeout(queryPromise, obj.timeout);


### PR DESCRIPTION
This patch slightly reworks how the query context gets passed from the runner into the dialects.  The query object now has a `context` parameter with the query context to be raised on `query-error` events, this avoids having to re-bubble `query-error` events from the builder instance in the `mssql` dialect.  Test surface has not changed as it gets the same outcome.