### PR TITLE
fix mssql alter column must have its own query

### DIFF
--- a/lib/dialects/mssql/schema/mssql-tablecompiler.js
+++ b/lib/dialects/mssql/schema/mssql-tablecompiler.js
@@ -52,6 +52,21 @@ class TableCompiler_MSSQL extends TableCompiler {
     }
   }
 
+  alterColumns(columns, colBuilder) {
+    // in SQL server only one column can be altered at a time
+    columns.sql.forEach((sql) => {
+      this.pushQuery({
+        sql:
+          (this.lowerCase ? 'alter table ' : 'ALTER TABLE ') +
+          this.tableName() +
+          ' ' +
+          (this.lowerCase ? this.alterColumnPrefix.toLowerCase() : this.alterColumnPrefix) +
+          sql,
+        bindings: columns.bindings,
+      })
+    });
+  }
+
   // Compiles column drop.  Multiple columns need only one DROP clause (not one DROP per column) so core dropColumn doesn't work.  #1348
   dropColumn() {
     const _this2 = this;

--- a/test/unit/schema-builder/mssql.js
+++ b/test/unit/schema-builder/mssql.js
@@ -169,6 +169,24 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
+  it('should alter multiple columns over multiple queries', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function () {
+        this.string('foo').alter();
+        this.string('bar').alter();
+      })
+      .toSQL();
+
+    equal(2, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'ALTER TABLE [users] ALTER COLUMN [foo] nvarchar(255)'
+    );
+    expect(tableSql[1].sql).to.equal(
+      'ALTER TABLE [users] ALTER COLUMN [bar] nvarchar(255)'
+    );
+  });
+
   it('test drop unique, custom', function () {
     tableSql = client
       .schemaBuilder()

--- a/test/unit/schema-builder/mssql.js
+++ b/test/unit/schema-builder/mssql.js
@@ -165,7 +165,7 @@ describe('MSSQL SchemaBuilder', function () {
       'ALTER TABLE [users] ADD [bar] nvarchar(255)'
     );
     expect(tableSql[1].sql).to.equal(
-      'ALTER TABLE [users] alter column [foo] nvarchar(255)'
+      'ALTER TABLE [users] ALTER COLUMN [foo] nvarchar(255)'
     );
   });
 


### PR DESCRIPTION
fixes #4316

As a side effect of my change, the `alter column` casing now respects the `lowerCase` flag on all alter commands