### PR TITLE
mssql: schema builder - add predictable constraint names for default values

### DIFF
--- a/lib/dialects/mssql/schema/mssql-columncompiler.js
+++ b/lib/dialects/mssql/schema/mssql-columncompiler.js
@@ -2,6 +2,7 @@
 // -------
 const ColumnCompiler = require('../../../schema/columncompiler');
 const { toNumber } = require('../../../util/helpers');
+const { formatDefault } = require('../../../formatter/formatterUtils');
 
 class ColumnCompiler_MSSQL extends ColumnCompiler {
   constructor(client, tableCompiler, columnBuilder) {
@@ -61,6 +62,22 @@ class ColumnCompiler_MSSQL extends ColumnCompiler {
   after(column) {
     this.client.logger.warn('Column after modifier not available for MSSQL');
     return '';
+  }
+
+  defaultTo(value, { constraintName } = {}) {
+    const formatedValue = formatDefault(value, this.type, this.client);
+    constraintName =
+      typeof constraintName !== 'undefined'
+        ? constraintName
+        : `${
+            this.tableCompiler.tableNameRaw
+          }_${this.getColumnName()}_default`.toLowerCase();
+    if (!constraintName) {
+      return `DEFAULT ${formatedValue}`;
+    }
+    return `CONSTRAINT ${this.formatter.wrap(
+      constraintName
+    )} DEFAULT ${formatedValue}`;
   }
 
   comment(comment) {

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -473,7 +473,7 @@ module.exports = (knex) => {
               'create index "test_table_one_logins_index" on "test_table_one" ("logins")',
             ]);
             tester('mssql', [
-              "CREATE TABLE [test_table_one] ([id] bigint identity(1,1) not null primary key, [first_name] nvarchar(255), [last_name] nvarchar(255), [email] nvarchar(255) null, [logins] int default '1', [balance] float default '0', [about] nvarchar(max), [created_at] datetime2, [updated_at] datetime2)",
+              "CREATE TABLE [test_table_one] ([id] bigint identity(1,1) not null primary key, [first_name] nvarchar(255), [last_name] nvarchar(255), [email] nvarchar(255) null, [logins] int CONSTRAINT [test_table_one_logins_default] DEFAULT '1', [balance] float CONSTRAINT [test_table_one_balance_default] DEFAULT '0', [about] nvarchar(max), [created_at] datetime2, [updated_at] datetime2)",
               'CREATE INDEX [test_table_one_first_name_index] ON [test_table_one] ([first_name])',
               'CREATE UNIQUE INDEX [test_table_one_email_unique] ON [test_table_one] ([email]) WHERE [email] IS NOT NULL',
               'CREATE INDEX [test_table_one_logins_index] ON [test_table_one] ([logins])',
@@ -539,7 +539,7 @@ module.exports = (knex) => {
               'alter table "test_table_three" add constraint "test_table_three_pkey" primary key ("main")',
             ]);
             tester('mssql', [
-              "CREATE TABLE [test_table_three] ([main] int not null, [paragraph] nvarchar(max) default 'Lorem ipsum Qui quis qui in.', [metadata] nvarchar(max) default '{\"a\":10}', CONSTRAINT [test_table_three_pkey] PRIMARY KEY ([main]))",
+              "CREATE TABLE [test_table_three] ([main] int not null, [paragraph] nvarchar(max) CONSTRAINT [test_table_three_paragraph_default] DEFAULT 'Lorem ipsum Qui quis qui in.', [metadata] nvarchar(max) CONSTRAINT [test_table_three_metadata_default] DEFAULT '{\"a\":10}', CONSTRAINT [test_table_three_pkey] PRIMARY KEY ([main]))",
             ]);
           })
           .then(() =>
@@ -827,7 +827,7 @@ module.exports = (knex) => {
               "create table \"bool_test\" (\"one\" number(1, 0) check (\"one\" in ('0', '1')), \"two\" number(1, 0) default '0' check (\"two\" in ('0', '1')), \"three\" number(1, 0) default '1' check (\"three\" in ('0', '1')), \"four\" number(1, 0) default '1' check (\"four\" in ('0', '1')), \"five\" number(1, 0) default '0' check (\"five\" in ('0', '1')))",
             ]);
             tester('mssql', [
-              "CREATE TABLE [bool_test] ([one] bit, [two] bit default '0', [three] bit default '1', [four] bit default '1', [five] bit default '0')",
+              "CREATE TABLE [bool_test] ([one] bit, [two] bit CONSTRAINT [bool_test_two_default] DEFAULT '0', [three] bit CONSTRAINT [bool_test_three_default] DEFAULT '1', [four] bit CONSTRAINT [bool_test_four_default] DEFAULT '1', [five] bit CONSTRAINT [bool_test_five_default] DEFAULT '0')",
             ]);
           })
           .then(() => knex.insert({ one: false }).into('bool_test')));

--- a/test/integration2/dialects/mssql.js
+++ b/test/integration2/dialects/mssql.js
@@ -1,0 +1,85 @@
+const { expect } = require('chai');
+const { getAllDbs, getKnexForDb } = require('../util/knex-instance-provider');
+
+async function fetchDefaultConstraintName(knex, table, column) {
+  const [result] = await knex.schema.raw(`
+    SELECT default_constraints.name
+    FROM sys.all_columns
+    INNER JOIN sys.tables
+        ON all_columns.object_id = tables.object_id
+    INNER JOIN sys.schemas
+        ON tables.schema_id = schemas.schema_id
+    INNER JOIN sys.default_constraints
+        ON all_columns.default_object_id = default_constraints.object_id
+    WHERE schemas.name = 'dbo'
+      AND tables.name = '${table}'
+      AND all_columns.name = '${column}'
+  `);
+  return result ? result.name : null;
+}
+
+describe('MSSQL dialect', () => {
+  describe('Connection configuration', () => {
+    getAllDbs()
+      .filter((db) => db.startsWith('mssql'))
+      .forEach((db) => {
+        describe(db, () => {
+          let knex;
+          before(async () => {
+            knex = getKnexForDb(db);
+          });
+
+          beforeEach(async () => {
+            await knex.schema.createTable('test', function () {
+              this.increments('id').primary();
+            });
+          });
+
+          after(async () => {
+            await knex.destroy();
+          });
+
+          afterEach(async () => {
+            await knex.schema.dropTable('test');
+          });
+
+          it('names default constraint', async () => {
+            await knex.schema.alterTable('test', function () {
+              this.string('name').defaultTo('knex');
+            });
+            const result = await fetchDefaultConstraintName(
+              knex,
+              'test',
+              'name'
+            );
+            expect(result).to.equal('test_name_default');
+          });
+          it('names default constraint with supplied name', async () => {
+            const constraintName = 'DF_test_name';
+            await knex.schema.alterTable('test', function () {
+              this.string('name').defaultTo('knex', { constraintName });
+            });
+            const result = await fetchDefaultConstraintName(
+              knex,
+              'test',
+              'name'
+            );
+            expect(result).to.equal('DF_test_name');
+          });
+          it("doesn't name default constraint", async () => {
+            const constraintName = '';
+            await knex.schema.alterTable('test', function () {
+              this.string('name').defaultTo('knex', { constraintName });
+            });
+            const result = await fetchDefaultConstraintName(
+              knex,
+              'test',
+              'name'
+            );
+            // this is the default patten used by mssql if no constraint is defined
+            expect(result).to.match(/^DF__test__name__[0-9A-Z]+$/);
+          });
+        });
+      });
+  });
+});

--- a/test/unit/schema-builder/mssql.js
+++ b/test/unit/schema-builder/mssql.js
@@ -5,15 +5,15 @@ const sinon = require('sinon');
 const MSSQL_Client = require('../../../lib/dialects/mssql');
 const client = new MSSQL_Client({ client: 'mssql' });
 
-describe('MSSQL SchemaBuilder', function () {
+describe('MSSQL SchemaBuilder', function() {
   let tableSql;
   const equal = require('assert').equal;
 
-  it('throws when charset and collate are specified', function () {
+  it('throws when charset and collate are specified', function() {
     expect(() => {
       tableSql = client
         .schemaBuilder()
-        .createTable('users', function (table) {
+        .createTable('users', function(table) {
           table.increments('id');
           table.string('email');
           table.charset('utf8');
@@ -23,10 +23,10 @@ describe('MSSQL SchemaBuilder', function () {
     }).to.throw('Knex only supports charset statement with mysql');
   });
 
-  it('basic create table', function () {
+  it('basic create table', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.increments('id');
         this.string('email');
       })
@@ -38,8 +38,8 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test basic create table with incrementing without primary key', function () {
-    tableSql = client.schemaBuilder().createTable('users', function (table) {
+  it('test basic create table with incrementing without primary key', function() {
+    tableSql = client.schemaBuilder().createTable('users', function(table) {
       table.increments('id', { primaryKey: false });
     });
 
@@ -52,15 +52,21 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test drop table', function () {
-    tableSql = client.schemaBuilder().dropTable('users').toSQL();
+  it('test drop table', function() {
+    tableSql = client
+      .schemaBuilder()
+      .dropTable('users')
+      .toSQL();
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal('DROP TABLE [users]');
   });
 
-  it('test drop table if exists', function () {
-    tableSql = client.schemaBuilder().dropTableIfExists('users').toSQL();
+  it('test drop table if exists', function() {
+    tableSql = client
+      .schemaBuilder()
+      .dropTableIfExists('users')
+      .toSQL();
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
@@ -68,10 +74,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test drop column', function () {
+  it('test drop column', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.dropColumn('foo');
       })
       .toSQL();
@@ -83,10 +89,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[1].sql).to.equal('ALTER TABLE [users] DROP COLUMN [foo]');
   });
 
-  it('drops multiple columns with an array', function () {
+  it('drops multiple columns with an array', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.dropColumn(['foo', 'bar']);
       })
       .toSQL();
@@ -103,10 +109,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('drops multiple columns as multiple arguments', function () {
+  it('drops multiple columns as multiple arguments', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.dropColumn('foo', 'bar');
       })
       .toSQL();
@@ -123,10 +129,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test drop primary', function () {
+  it('test drop primary', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.dropPrimary('testconstraintname');
       })
       .toSQL();
@@ -137,10 +143,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test drop unique', function () {
+  it('test drop unique', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.dropUnique('foo');
       })
       .toSQL();
@@ -151,10 +157,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('should alter columns with the alter flag', function () {
+  it('should alter columns with the alter flag', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.string('foo').alter();
         this.string('bar');
       })
@@ -169,10 +175,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('should alter multiple columns over multiple queries', function () {
+  it('should alter multiple columns over multiple queries', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.string('foo').alter();
         this.string('bar').alter();
       })
@@ -187,10 +193,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test drop unique, custom', function () {
+  it('test drop unique, custom', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.dropUnique(null, 'foo');
       })
       .toSQL();
@@ -199,10 +205,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('DROP INDEX [foo] ON [users]');
   });
 
-  it('test drop index', function () {
+  it('test drop index', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.dropIndex('foo');
       })
       .toSQL();
@@ -211,10 +217,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('DROP INDEX [users_foo_index] ON [users]');
   });
 
-  it('test drop index, custom', function () {
+  it('test drop index, custom', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.dropIndex(null, 'foo');
       })
       .toSQL();
@@ -223,10 +229,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('DROP INDEX [foo] ON [users]');
   });
 
-  it('test drop foreign', function () {
+  it('test drop foreign', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.dropForeign('foo');
       })
       .toSQL();
@@ -237,10 +243,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test drop foreign, custom', function () {
+  it('test drop foreign, custom', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.dropForeign(null, 'foo');
       })
       .toSQL();
@@ -251,10 +257,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test drop timestamps', function () {
+  it('test drop timestamps', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.dropTimestamps();
       })
       .toSQL();
@@ -271,8 +277,11 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test rename table', function () {
-    tableSql = client.schemaBuilder().renameTable('users', 'foo').toSQL();
+  it('test rename table', function() {
+    tableSql = client
+      .schemaBuilder()
+      .renameTable('users', 'foo')
+      .toSQL();
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal('exec sp_rename ?, ?');
@@ -280,8 +289,11 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].bindings[1]).to.equal('foo');
   });
 
-  it('test has table', function () {
-    tableSql = client.schemaBuilder().hasTable('users').toSQL();
+  it('test has table', function() {
+    tableSql = client
+      .schemaBuilder()
+      .hasTable('users')
+      .toSQL();
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
@@ -290,7 +302,7 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].bindings[0]).to.equal('[users]');
   });
 
-  it('test has table with schema', function () {
+  it('test has table with schema', function() {
     tableSql = client
       .schemaBuilder()
       .withSchema('schema')
@@ -304,7 +316,7 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].bindings[0]).to.equal('[schema].[users]');
   });
 
-  it('test rename table with schema', function () {
+  it('test rename table with schema', function() {
     tableSql = client
       .schemaBuilder()
       .withSchema('schema')
@@ -317,8 +329,11 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].bindings[1]).to.equal('foo');
   });
 
-  it('test has column', function () {
-    tableSql = client.schemaBuilder().hasColumn('users', 'foo').toSQL();
+  it('test has column', function() {
+    tableSql = client
+      .schemaBuilder()
+      .hasColumn('users', 'foo')
+      .toSQL();
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
@@ -328,7 +343,7 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].bindings[1]).to.equal('[users]');
   });
 
-  it('test has column with schema', function () {
+  it('test has column with schema', function() {
     tableSql = client
       .schemaBuilder()
       .withSchema('schema')
@@ -343,10 +358,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].bindings[1]).to.equal('[schema].[users]');
   });
 
-  it('test adding primary key', function () {
+  it('test adding primary key', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.primary('foo', 'bar');
       })
       .toSQL();
@@ -357,10 +372,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding unique key', function () {
+  it('test adding unique key', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.unique('foo', 'bar');
       })
       .toSQL();
@@ -371,10 +386,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding index', function () {
+  it('test adding index', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.index(['foo', 'bar'], 'baz');
       })
       .toSQL();
@@ -385,11 +400,13 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding foreign key', function () {
+  it('test adding foreign key', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
-        this.foreign('foo_id').references('id').on('orders');
+      .table('users', function() {
+        this.foreign('foo_id')
+          .references('id')
+          .on('orders');
       })
       .toSQL();
 
@@ -400,8 +417,10 @@ describe('MSSQL SchemaBuilder', function () {
 
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
-        this.integer('foo_id').references('id').on('orders');
+      .table('users', function() {
+        this.integer('foo_id')
+          .references('id')
+          .on('orders');
       })
       .toSQL();
 
@@ -412,11 +431,13 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('adding foreign key with specific identifier', function () {
+  it('adding foreign key with specific identifier', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
-        this.foreign('foo_id', 'fk_foo').references('id').on('orders');
+      .table('users', function() {
+        this.foreign('foo_id', 'fk_foo')
+          .references('id')
+          .on('orders');
       })
       .toSQL();
 
@@ -427,7 +448,7 @@ describe('MSSQL SchemaBuilder', function () {
 
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.integer('foo_id')
           .references('id')
           .on('orders')
@@ -442,10 +463,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('adds foreign key with onUpdate and onDelete', function () {
+  it('adds foreign key with onUpdate and onDelete', function() {
     tableSql = client
       .schemaBuilder()
-      .createTable('person', function (table) {
+      .createTable('person', function(table) {
         table
           .integer('user_id')
           .notNull()
@@ -465,10 +486,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding incrementing id', function () {
+  it('test adding incrementing id', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.increments('id');
       })
       .toSQL();
@@ -479,10 +500,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding big incrementing id', function () {
+  it('test adding big incrementing id', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.bigIncrements('id');
       })
       .toSQL();
@@ -493,10 +514,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding big incrementing id without primary key', function () {
+  it('test adding big incrementing id without primary key', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.bigIncrements('id', { primaryKey: false });
       })
       .toSQL();
@@ -507,10 +528,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding column after another column', function () {
+  it('test adding column after another column', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.string('name').after('foo');
       })
       .toSQL();
@@ -521,10 +542,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding column on the first place', function () {
+  it('test adding column on the first place', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.string('first_name').first();
       })
       .toSQL();
@@ -535,10 +556,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding string', function () {
+  it('test adding string', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.string('foo');
       })
       .toSQL();
@@ -549,10 +570,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('uses the varchar column constraint', function () {
+  it('uses the varchar column constraint', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.string('foo', 100);
       })
       .toSQL();
@@ -563,23 +584,25 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('chains notNull and defaultTo', function () {
+  it('chains notNull and defaultTo', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
-        this.string('foo', 100).notNull().defaultTo('bar');
+      .table('users', function() {
+        this.string('foo', 100)
+          .notNull()
+          .defaultTo('bar');
       })
       .toSQL();
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
-      "ALTER TABLE [users] ADD [foo] nvarchar(100) not null default 'bar'"
+      "ALTER TABLE [users] ADD [foo] nvarchar(100) not null CONSTRAINT [users_foo_default] DEFAULT 'bar'"
     );
   });
 
-  it('allows for raw values in the default field', function () {
+  it('allows for raw values in the default field', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.string('foo', 100)
           .nullable()
           .defaultTo(client.raw('CURRENT TIMESTAMP'));
@@ -588,14 +611,40 @@ describe('MSSQL SchemaBuilder', function () {
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
-      'ALTER TABLE [users] ADD [foo] nvarchar(100) null default CURRENT TIMESTAMP'
+      'ALTER TABLE [users] ADD [foo] nvarchar(100) null CONSTRAINT [users_foo_default] DEFAULT CURRENT TIMESTAMP'
     );
   });
 
-  it('test adding text', function () {
+  it('allows custom named default constraints', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
+        this.integer('foo').defaultTo('test', { constraintName: 'DF_foo' });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      "ALTER TABLE [users] ADD [foo] int CONSTRAINT [DF_foo] DEFAULT 'test'"
+    );
+  });
+
+  it("doesn't name constraints when opt-out", function() {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function() {
+        this.integer('foo').defaultTo('test', { constraintName: '' });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      "ALTER TABLE [users] ADD [foo] int DEFAULT 'test'"
+    );
+  });
+
+  it('test adding text', function() {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function() {
         this.text('foo');
       })
       .toSQL();
@@ -606,10 +655,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding big integer', function () {
+  it('test adding big integer', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.bigInteger('foo');
       })
       .toSQL();
@@ -618,10 +667,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] bigint');
   });
 
-  it('test adding integer', function () {
+  it('test adding integer', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.integer('foo');
       })
       .toSQL();
@@ -630,10 +679,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] int');
   });
 
-  it('test adding medium integer', function () {
+  it('test adding medium integer', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.mediumint('foo');
       })
       .toSQL();
@@ -642,10 +691,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] int');
   });
 
-  it('test adding small integer', function () {
+  it('test adding small integer', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.smallint('foo');
       })
       .toSQL();
@@ -654,10 +703,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] smallint');
   });
 
-  it('test adding tiny integer', function () {
+  it('test adding tiny integer', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.tinyint('foo');
       })
       .toSQL();
@@ -666,10 +715,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] tinyint');
   });
 
-  it('test adding float', function () {
+  it('test adding float', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.float('foo', 5, 2);
       })
       .toSQL();
@@ -678,10 +727,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] float');
   });
 
-  it('test adding double', function () {
+  it('test adding double', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.double('foo');
       })
       .toSQL();
@@ -690,10 +739,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] float');
   });
 
-  it('test adding double specifying precision', function () {
+  it('test adding double specifying precision', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.double('foo', 15, 8);
       })
       .toSQL();
@@ -702,10 +751,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] float');
   });
 
-  it('test adding decimal', function () {
+  it('test adding decimal', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.decimal('foo', 5, 2);
       })
       .toSQL();
@@ -716,43 +765,43 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding decimal, no precision', function () {
+  it('test adding decimal, no precision', function() {
     expect(() => {
       tableSql = client
         .schemaBuilder()
-        .table('users', function () {
+        .table('users', function() {
           this.decimal('foo', null);
         })
         .toSQL();
     }).to.throw('Specifying no precision on decimal columns is not supported');
   });
 
-  it('set comment to undefined', function () {
-    expect(function () {
+  it('set comment to undefined', function() {
+    expect(function() {
       client
         .schemaBuilder()
-        .table('user', function (t) {
+        .table('user', function(t) {
           t.comment();
         })
         .toSQL();
     }).to.throw(TypeError);
   });
 
-  it('set comment to null', function () {
-    expect(function () {
+  it('set comment to null', function() {
+    expect(function() {
       client
         .schemaBuilder()
-        .table('user', function (t) {
+        .table('user', function(t) {
           t.comment(null);
         })
         .toSQL();
     }).to.throw(TypeError);
   });
 
-  it('test adding boolean', function () {
+  it('test adding boolean', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.boolean('foo');
       })
       .toSQL();
@@ -761,10 +810,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] bit');
   });
 
-  it('test adding enum', function () {
+  it('test adding enum', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.enum('foo', ['bar', 'baz']);
       })
       .toSQL();
@@ -775,10 +824,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding date', function () {
+  it('test adding date', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.date('foo');
       })
       .toSQL();
@@ -787,10 +836,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] date');
   });
 
-  it('test adding date time', function () {
+  it('test adding date time', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.dateTime('foo');
       })
       .toSQL();
@@ -799,10 +848,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] datetime2');
   });
 
-  it('test adding time', function () {
+  it('test adding time', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.time('foo');
       })
       .toSQL();
@@ -811,10 +860,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] time');
   });
 
-  it('test adding time stamp', function () {
+  it('test adding time stamp', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.timestamp('foo');
       })
       .toSQL();
@@ -823,10 +872,10 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('ALTER TABLE [users] ADD [foo] datetime2');
   });
 
-  it('test adding time stamp with timezone', function () {
+  it('test adding time stamp with timezone', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.timestamp('foo', {
           useTz: true,
         });
@@ -839,10 +888,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding time stamps', function () {
+  it('test adding time stamps', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.timestamps();
       })
       .toSQL();
@@ -853,10 +902,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding binary', function () {
+  it('test adding binary', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.binary('foo');
       })
       .toSQL();
@@ -867,10 +916,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding decimal', function () {
+  it('test adding decimal', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.decimal('foo', 2, 6);
       })
       .toSQL();
@@ -881,10 +930,10 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('test adding multiple columns, #1348', function () {
+  it('test adding multiple columns, #1348', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function () {
+      .table('users', function() {
         this.integer('foo');
         this.integer('baa');
       })
@@ -896,24 +945,24 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('is possible to set raw statements in defaultTo, #146', function () {
+  it('is possible to set raw statements in defaultTo, #146', function() {
     tableSql = client
       .schemaBuilder()
-      .createTable('default_raw_test', function (t) {
+      .createTable('default_raw_test', function(t) {
         t.timestamp('created_at').defaultTo(client.raw('GETDATE()'));
       })
       .toSQL();
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
-      'CREATE TABLE [default_raw_test] ([created_at] datetime2 default GETDATE())'
+      'CREATE TABLE [default_raw_test] ([created_at] datetime2 CONSTRAINT [default_raw_test_created_at_default] DEFAULT GETDATE())'
     );
   });
 
-  it('allows dropping a unique compound index', function () {
+  it('allows dropping a unique compound index', function() {
     tableSql = client
       .schemaBuilder()
-      .table('composite_key_test', function (t) {
+      .table('composite_key_test', function(t) {
         t.dropUnique(['column_a', 'column_b']);
       })
       .toSQL();
@@ -924,24 +973,24 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  it('allows default as alias for defaultTo', function () {
+  it('allows default as alias for defaultTo', function() {
     tableSql = client
       .schemaBuilder()
-      .createTable('default_raw_test', function (t) {
+      .createTable('default_raw_test', function(t) {
         t.timestamp('created_at').default(client.raw('GETDATE()'));
       })
       .toSQL();
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
-      'CREATE TABLE [default_raw_test] ([created_at] datetime2 default GETDATE())'
+      'CREATE TABLE [default_raw_test] ([created_at] datetime2 CONSTRAINT [default_raw_test_created_at_default] DEFAULT GETDATE())'
     );
   });
 
-  it('#1430 - .primary & .dropPrimary takes columns and constraintName', function () {
+  it('#1430 - .primary & .dropPrimary takes columns and constraintName', function() {
     tableSql = client
       .schemaBuilder()
-      .table('users', function (t) {
+      .table('users', function(t) {
         t.primary(['test1', 'test2'], 'testconstraintname');
       })
       .toSQL();
@@ -951,7 +1000,7 @@ describe('MSSQL SchemaBuilder', function () {
 
     tableSql = client
       .schemaBuilder()
-      .createTable('users', function (t) {
+      .createTable('users', function(t) {
         t.string('test').primary('testconstraintname');
       })
       .toSQL();
@@ -961,32 +1010,32 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
-  describe('queryContext', function () {
+  describe('queryContext', function() {
     let spy;
     let originalWrapIdentifier;
 
-    before(function () {
+    before(function() {
       spy = sinon.spy();
       originalWrapIdentifier = client.config.wrapIdentifier;
-      client.config.wrapIdentifier = function (value, wrap, queryContext) {
+      client.config.wrapIdentifier = function(value, wrap, queryContext) {
         spy(value, queryContext);
         return wrap(value);
       };
     });
 
-    beforeEach(function () {
+    beforeEach(function() {
       spy.resetHistory();
     });
 
-    after(function () {
+    after(function() {
       client.config.wrapIdentifier = originalWrapIdentifier;
     });
 
-    it('SchemaCompiler passes queryContext to wrapIdentifier via TableCompiler', function () {
+    it('SchemaCompiler passes queryContext to wrapIdentifier via TableCompiler', function() {
       client
         .schemaBuilder()
         .queryContext('table context')
-        .createTable('users', function (table) {
+        .createTable('users', function(table) {
           table.increments('id');
           table.string('email');
         })
@@ -998,10 +1047,10 @@ describe('MSSQL SchemaBuilder', function () {
       expect(spy.thirdCall.args).to.deep.equal(['users', 'table context']);
     });
 
-    it('TableCompiler passes queryContext to wrapIdentifier', function () {
+    it('TableCompiler passes queryContext to wrapIdentifier', function() {
       client
         .schemaBuilder()
-        .createTable('users', function (table) {
+        .createTable('users', function(table) {
           table.increments('id').queryContext('id context');
           table.string('email').queryContext('email context');
         })
@@ -1013,11 +1062,11 @@ describe('MSSQL SchemaBuilder', function () {
       expect(spy.thirdCall.args).to.deep.equal(['users', undefined]);
     });
 
-    it('TableCompiler allows overwriting queryContext from SchemaCompiler', function () {
+    it('TableCompiler allows overwriting queryContext from SchemaCompiler', function() {
       client
         .schemaBuilder()
         .queryContext('schema context')
-        .createTable('users', function (table) {
+        .createTable('users', function(table) {
           table.queryContext('table context');
           table.increments('id');
           table.string('email');
@@ -1030,11 +1079,11 @@ describe('MSSQL SchemaBuilder', function () {
       expect(spy.thirdCall.args).to.deep.equal(['users', 'table context']);
     });
 
-    it('ColumnCompiler allows overwriting queryContext from TableCompiler', function () {
+    it('ColumnCompiler allows overwriting queryContext from TableCompiler', function() {
       client
         .schemaBuilder()
         .queryContext('schema context')
-        .createTable('users', function (table) {
+        .createTable('users', function(table) {
           table.queryContext('table context');
           table.increments('id').queryContext('id context');
           table.string('email').queryContext('email context');

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1833,7 +1833,7 @@ export declare namespace Knex {
     references(columnName: string): ReferencingColumnBuilder;
     onDelete(command: string): ColumnBuilder;
     onUpdate(command: string): ColumnBuilder;
-    defaultTo(value: Value | null): ColumnBuilder;
+    defaultTo(value: Value | null, options?: DefaultToOptions): ColumnBuilder;
     unsigned(): ColumnBuilder;
     notNullable(): ColumnBuilder;
     nullable(): ColumnBuilder;
@@ -2307,6 +2307,11 @@ interface MsSqlConnectionConfigBase {
     existingType?: boolean;
     schemaName?: string;
     enumName: string;
+  }
+
+  interface DefaultToOptions {
+    // only supported by mssql driver
+    constraintName?: string;
   }
 
   //


### PR DESCRIPTION
In SQL server, default values are stored as `CONSTRAINTS` against the table. if no constraint name is provided and just the short syntax of `DEFAULT xxx` is used, then SQL server creates a "random" constraint name. This makes writing predictable schema migrations tricky as the `DEFAULT` constraint needs to be dropped before it can be updated/changed.

The constraint names follow the format `${tableName}_${columnName}_${default}` (lowercased) which follows the convention of other constraints like default index names.

Usage:

```js
knex.schema.alterTable('table', (table) => {
  // new behaviour - will produce a default constraint named table_myint_default
  table.integer('myInt').defaultTo(1);
  // create a custom named constraint
  table.integer('myInt').defaultTo(1, 'DF_table_myInt');
  // no constraint name (SQL generates a random one, current behaviour
  table.integer('myInt').defaultTo(1, '');
});
```

Potential issues:

This *might* be considered a breaking change, but I don't think it is. The produced SQL is different but the end effect to users is the same. A constraint name they don't know the name of needs to be looked up before being able to remove it, this is typically done with a query or stored procedure. Even if users with this library rolled back migrations and then ran them again, their logic would still work as the constraint name would never have been known (due to it's random nature at the moment).

To do / help wanted:

- [x] Update docs around use of this new second parameter in `.defaultTo(value, constraintName)` for mssql
- [x] Add mssql specific test in integration suite covering custom named constraints / unnamed constraints
- [x] Update typings??