### PR TITLE
Add support for altering columns to SQLite

### DIFF
--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -20,8 +20,11 @@ const {
   renameTable,
   getTableSql,
 } = require('./internal/sqlite-ddl-operations');
-const { parseCreateIndex } = require('./internal/parser');
-const { compileCreateIndex } = require('./internal/compiler');
+const { parseCreateTable, parseCreateIndex } = require('./internal/parser');
+const {
+  compileCreateTable,
+  compileCreateIndex,
+} = require('./internal/compiler');
 
 // So altering the schema in SQLite3 is a major pain.
 // We have our own object to deal with the renaming and altering the types
@@ -236,6 +239,52 @@ class SQLite3_DDL {
     return oneLineSql
       .replace(/\(.*\)/, () => `(${args.join(', ')})`)
       .replace(/,\s*([,)])/, '$1');
+  }
+
+  async alterColumn(columns) {
+    return this.client.transaction(
+      async (trx) => {
+        this.trx = trx;
+
+        const { createTable, createIndices } = await this.getTableSql();
+
+        const parsedTable = parseCreateTable(createTable);
+
+        parsedTable.columns = parsedTable.columns.map((column) => {
+          const newColumnInfo = columns.find((c) => c.name === column.name);
+
+          if (newColumnInfo) {
+            column.type = newColumnInfo.type;
+
+            column.constraints.default =
+              newColumnInfo.defaultTo !== null
+                ? {
+                    name: null,
+                    value: newColumnInfo.defaultTo,
+                    expression: false,
+                  }
+                : null;
+
+            column.constraints.not = newColumnInfo.notNull
+              ? { name: null, conflict: null }
+              : null;
+          }
+
+          return column;
+        });
+
+        const newTable = compileCreateTable(parsedTable, this.wrap);
+
+        return await this.generateAlterCommands(
+          newTable,
+          createIndices,
+          (row) => {
+            return row;
+          }
+        );
+      },
+      { connection: this.connection }
+    );
   }
 
   async dropColumn(columns) {

--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -265,8 +265,9 @@ class SQLite3_DDL {
 
               parsedIndex.columns = parsedIndex.columns.filter(
                 (newColumn) =>
-                  !columns.some((column) =>
-                    newColumn.name.includes(this.formatter(column))
+                  newColumn.expression ||
+                  !columns.some(
+                    (column) => newColumn.name === this.formatter(column)
                   )
               );
 

--- a/lib/dialects/sqlite3/schema/internal/compiler.js
+++ b/lib/dialects/sqlite3/schema/internal/compiler.js
@@ -1,5 +1,229 @@
+function compileCreateTable(ast, wrap = (v) => v) {
+  return createTable(ast, wrap);
+}
+
 function compileCreateIndex(ast, wrap = (v) => v) {
   return createIndex(ast, wrap);
+}
+
+function createTable(ast, wrap) {
+  return `CREATE${temporary(ast, wrap)} TABLE${exists(ast, wrap)} ${schema(
+    ast,
+    wrap
+  )}${table(ast, wrap)} (${columnDefinitionList(
+    ast,
+    wrap
+  )}${tableConstraintList(ast, wrap)})${rowid(ast, wrap)}`;
+}
+
+function temporary(ast, wrap) {
+  return ast.temporary ? ' TEMP' : '';
+}
+
+function rowid(ast, wrap) {
+  return ast.rowid ? ' WITHOUT ROWID' : '';
+}
+
+function columnDefinitionList(ast, wrap) {
+  return ast.columns.map((column) => columnDefinition(column, wrap)).join(', ');
+}
+
+function columnDefinition(ast, wrap) {
+  return `${identifier(ast.name, wrap)}${typeName(
+    ast,
+    wrap
+  )}${columnConstraintList(ast.constraints, wrap)}`;
+}
+
+function typeName(ast, wrap) {
+  return ast.type !== null ? ` ${ast.type}` : '';
+}
+
+function columnConstraintList(ast, wrap) {
+  return `${primaryColumnConstraint(ast, wrap)}${notColumnConstraint(
+    ast,
+    wrap
+  )}${uniqueColumnConstraint(ast, wrap)}${checkColumnConstraint(
+    ast,
+    wrap
+  )}${defaultColumnConstraint(ast, wrap)}${collateColumnConstraint(
+    ast,
+    wrap
+  )}${referencesColumnConstraint(ast, wrap)}${asColumnConstraint(ast, wrap)}`;
+}
+
+function primaryColumnConstraint(ast, wrap) {
+  return ast.primary !== null
+    ? ` ${constraintName(ast.primary, wrap)}PRIMARY KEY${order(
+        ast.primary,
+        wrap
+      )}${conflictClause(ast.primary, wrap)}${autoincrement(ast.primary, wrap)}`
+    : '';
+}
+
+function autoincrement(ast, wrap) {
+  return ast.autoincrement ? ' AUTOINCREMENT' : '';
+}
+
+function notColumnConstraint(ast, wrap) {
+  return ast.not !== null
+    ? ` ${constraintName(ast.not, wrap)}NOT NULL${conflictClause(
+        ast.not,
+        wrap
+      )}`
+    : '';
+}
+
+function uniqueColumnConstraint(ast, wrap) {
+  return ast.unique !== null
+    ? ` ${constraintName(ast.unique, wrap)}UNIQUE${conflictClause(
+        ast.unique,
+        wrap
+      )}`
+    : '';
+}
+
+function checkColumnConstraint(ast, wrap) {
+  return ast.check !== null
+    ? ` ${constraintName(ast.check, wrap)}CHECK (${expression(
+        ast.check.expression,
+        wrap
+      )})`
+    : '';
+}
+
+function defaultColumnConstraint(ast, wrap) {
+  return ast.default !== null
+    ? ` ${constraintName(ast.default, wrap)}DEFAULT ${
+        !ast.default.expression
+          ? ast.default.value
+          : `(${expression(ast.default.value, wrap)})`
+      }`
+    : '';
+}
+
+function collateColumnConstraint(ast, wrap) {
+  return ast.collate !== null
+    ? ` ${constraintName(ast.collate, wrap)}COLLATE ${ast.collate.collation}`
+    : '';
+}
+
+function referencesColumnConstraint(ast, wrap) {
+  return ast.references !== null
+    ? ` ${constraintName(ast.references, wrap)}${foreignKeyClause(
+        ast.references,
+        wrap
+      )}`
+    : '';
+}
+
+function asColumnConstraint(ast, wrap) {
+  return ast.as !== null
+    ? ` ${constraintName(ast.as, wrap)}${
+        ast.as.generated ? 'GENERATED ALWAYS ' : ''
+      }AS (${expression(ast.as.expression, wrap)})${
+        ast.as.mode !== null ? ` ${ast.as.mode}` : ''
+      }`
+    : '';
+}
+
+function tableConstraintList(ast, wrap) {
+  return ast.constraints.reduce(
+    (constraintList, constraint) =>
+      `${constraintList}, ${tableConstraint(constraint, wrap)}`,
+    ''
+  );
+}
+
+function tableConstraint(ast, wrap) {
+  switch (ast.type) {
+    case 'PRIMARY KEY':
+      return primaryTableConstraint(ast, wrap);
+    case 'UNIQUE':
+      return uniqueTableConstraint(ast, wrap);
+    case 'CHECK':
+      return checkTableConstraint(ast, wrap);
+    case 'FOREIGN KEY':
+      return foreignTableConstraint(ast, wrap);
+  }
+}
+
+function primaryTableConstraint(ast, wrap) {
+  return `${constraintName(ast, wrap)}PRIMARY KEY (${indexedColumnList(
+    ast,
+    wrap
+  )})${conflictClause(ast, wrap)}`;
+}
+
+function uniqueTableConstraint(ast, wrap) {
+  return `${constraintName(ast, wrap)}UNIQUE (${indexedColumnList(
+    ast,
+    wrap
+  )})${conflictClause(ast, wrap)}`;
+}
+
+function conflictClause(ast, wrap) {
+  return ast.conflict !== null ? ` ON CONFLICT ${ast.conflict}` : '';
+}
+
+function checkTableConstraint(ast, wrap) {
+  return `${constraintName(ast, wrap)}CHECK (${expression(
+    ast.expression,
+    wrap
+  )})`;
+}
+
+function foreignTableConstraint(ast, wrap) {
+  return `${constraintName(ast, wrap)}FOREIGN KEY (${columnNameList(
+    ast,
+    wrap
+  )}) ${foreignKeyClause(ast.references, wrap)}`;
+}
+
+function foreignKeyClause(ast, wrap) {
+  return `REFERENCES ${table(ast, wrap)}${columnNameListOptional(
+    ast,
+    wrap
+  )}${deleteUpdateMatchList(ast, wrap)}${deferrable(ast.deferrable, wrap)}`;
+}
+
+function columnNameListOptional(ast, wrap) {
+  return ast.columns.length > 0 ? ` (${columnNameList(ast, wrap)})` : '';
+}
+
+function columnNameList(ast, wrap) {
+  return ast.columns.map((column) => identifier(column, wrap)).join(', ');
+}
+
+function deleteUpdateMatchList(ast, wrap) {
+  return `${deleteReference(ast, wrap)}${updateReference(
+    ast,
+    wrap
+  )}${matchReference(ast, wrap)}`;
+}
+
+function deleteReference(ast, wrap) {
+  return ast.delete !== null ? ` ON DELETE ${ast.delete}` : '';
+}
+
+function updateReference(ast, wrap) {
+  return ast.update !== null ? ` ON UPDATE ${ast.update}` : '';
+}
+
+function matchReference(ast, wrap) {
+  return ast.match !== null ? ` MATCH ${ast.match}` : '';
+}
+
+function deferrable(ast, wrap) {
+  return ast !== null
+    ? ` ${ast.not ? 'NOT ' : ''}DEFERRABLE${
+        ast.initially !== null ? ` INITIALLY ${ast.initially}` : ''
+      }`
+    : '';
+}
+
+function constraintName(ast, wrap) {
+  return ast.name !== null ? `CONSTRAINT ${identifier(ast.name, wrap)} ` : '';
 }
 
 function createIndex(ast, wrap) {
@@ -89,5 +313,6 @@ function identifier(ast, wrap) {
 }
 
 module.exports = {
+  compileCreateTable,
   compileCreateIndex,
 };

--- a/lib/dialects/sqlite3/schema/internal/compiler.js
+++ b/lib/dialects/sqlite3/schema/internal/compiler.js
@@ -1,17 +1,91 @@
 function compileCreateIndex(ast, wrap = (v) => v) {
-  const columns = ast.columns
-    .map((column) => {
-      return `${!column.expression ? wrap(column.name) : column.name}${
-        column.collation ? ` COLLATE ${column.collation}` : ''
-      }${column.order ? ` ${column.order}` : ''}`;
-    })
-    .join(', ');
+  return createIndex(ast, wrap);
+}
 
-  return `CREATE${ast.unique ? ' UNIQUE' : ''} INDEX${
-    ast.exists ? ' IF NOT EXISTS' : ''
-  } ${ast.schema ? `${wrap(ast.schema)}.` : ''}${wrap(ast.index)} on ${wrap(
-    ast.table
-  )} (${columns})${ast.where ? ` where ${ast.where}` : ''}`;
+function createIndex(ast, wrap) {
+  return `CREATE${unique(ast, wrap)} INDEX${exists(ast, wrap)} ${schema(
+    ast,
+    wrap
+  )}${index(ast, wrap)} on ${table(ast, wrap)} (${indexedColumnList(
+    ast,
+    wrap
+  )})${where(ast, wrap)}`;
+}
+
+function unique(ast, wrap) {
+  return ast.unique ? ' UNIQUE' : '';
+}
+
+function exists(ast, wrap) {
+  return ast.exists ? ' IF NOT EXISTS' : '';
+}
+
+function schema(ast, wrap) {
+  return ast.schema !== null ? `${identifier(ast.schema, wrap)}.` : '';
+}
+
+function index(ast, wrap) {
+  return identifier(ast.index, wrap);
+}
+
+function table(ast, wrap) {
+  return identifier(ast.table, wrap);
+}
+
+function where(ast, wrap) {
+  return ast.where !== null ? ` where ${expression(ast.where)}` : '';
+}
+
+function indexedColumnList(ast, wrap) {
+  return ast.columns
+    .map((column) =>
+      !column.expression
+        ? indexedColumn(column, wrap)
+        : indexedColumnExpression(column, wrap)
+    )
+    .join(', ');
+}
+
+function indexedColumn(ast, wrap) {
+  return `${identifier(ast.name, wrap)}${collation(ast, wrap)}${order(
+    ast,
+    wrap
+  )}`;
+}
+
+function indexedColumnExpression(ast, wrap) {
+  return `${indexedExpression(ast.name, wrap)}${collation(ast, wrap)}${order(
+    ast,
+    wrap
+  )}`;
+}
+
+function collation(ast, wrap) {
+  return ast.collation !== null ? ` COLLATE ${ast.collation}` : '';
+}
+
+function order(ast, wrap) {
+  return ast.order !== null ? ` ${ast.order}` : '';
+}
+
+function indexedExpression(ast, wrap) {
+  return expression(ast, wrap);
+}
+
+function expression(ast, wrap) {
+  return ast.reduce(
+    (expr, e) =>
+      Array.isArray(e)
+        ? `${expr}(${expression(e)})`
+        : !expr
+        ? e
+        : `${expr} ${e}`,
+    ''
+  );
+}
+
+function identifier(ast, wrap) {
+  return wrap(ast);
 }
 
 module.exports = {

--- a/lib/dialects/sqlite3/schema/internal/parser-combinator.js
+++ b/lib/dialects/sqlite3/schema/internal/parser-combinator.js
@@ -1,0 +1,161 @@
+// Sequence parser combinator
+function s(sequence, post = (v) => v) {
+  return function ({ index = 0, input }) {
+    let position = index;
+    const ast = [];
+
+    for (const parser of sequence) {
+      const result = parser({ index: position, input });
+
+      if (result.success) {
+        position = result.index;
+        ast.push(result.ast);
+      } else {
+        return result;
+      }
+    }
+
+    return { success: true, ast: post(ast), index: position, input };
+  };
+}
+
+// Alternative parser combinator
+function a(alternative, post = (v) => v) {
+  return function ({ index = 0, input }) {
+    for (const parser of alternative) {
+      const result = parser({ index, input });
+
+      if (result.success) {
+        return {
+          success: true,
+          ast: post(result.ast),
+          index: result.index,
+          input,
+        };
+      }
+    }
+
+    return { success: false, ast: null, index, input };
+  };
+}
+
+// Many parser combinator
+function m(many, post = (v) => v) {
+  return function ({ index = 0, input }) {
+    let result = {};
+    let position = index;
+    const ast = [];
+
+    do {
+      result = many({ index: position, input });
+
+      if (result.success) {
+        position = result.index;
+        ast.push(result.ast);
+      }
+    } while (result.success);
+
+    if (ast.length > 0) {
+      return { success: true, ast: post(ast), index: position, input };
+    } else {
+      return { success: false, ast: null, index: position, input };
+    }
+  };
+}
+
+// Optional parser combinator
+function o(optional, post = (v) => v) {
+  return function ({ index = 0, input }) {
+    const result = optional({ index, input });
+
+    if (result.success) {
+      return {
+        success: true,
+        ast: post(result.ast),
+        index: result.index,
+        input,
+      };
+    } else {
+      return { success: true, ast: post(null), index, input };
+    }
+  };
+}
+
+// Lookahead parser combinator
+function l(lookahead, post = (v) => v) {
+  return function ({ index = 0, input }) {
+    const result = lookahead.do({ index, input });
+
+    if (result.success) {
+      const resultNext = lookahead.next({ index: result.index, input });
+
+      if (resultNext.success) {
+        return {
+          success: true,
+          ast: post(result.ast),
+          index: result.index,
+          input,
+        };
+      }
+    }
+
+    return { success: false, ast: null, index, input };
+  };
+}
+
+// Negative parser combinator
+function n(negative, post = (v) => v) {
+  return function ({ index = 0, input }) {
+    const result = negative.do({ index, input });
+
+    if (result.success) {
+      const resultNot = negative.not({ index, input });
+
+      if (!resultNot.success) {
+        return {
+          success: true,
+          ast: post(result.ast),
+          index: result.index,
+          input,
+        };
+      }
+    }
+
+    return { success: false, ast: null, index, input };
+  };
+}
+
+// Token parser combinator
+function t(token, post = (v) => v.text) {
+  return function ({ index = 0, input }) {
+    const result = input[index];
+
+    if (
+      result !== undefined &&
+      (token.type === undefined || token.type === result.type) &&
+      (token.text === undefined ||
+        token.text.toUpperCase() === result.text.toUpperCase())
+    ) {
+      return {
+        success: true,
+        ast: post(result),
+        index: index + 1,
+        input,
+      };
+    } else {
+      return { success: false, ast: null, index, input };
+    }
+  };
+}
+
+// Empty parser constant
+const e = function ({ index = 0, input }) {
+  return { success: true, ast: null, index, input };
+};
+
+// Finish parser constant
+const f = function ({ index = 0, input }) {
+  return { success: index === input.length, ast: null, index, input };
+};
+
+module.exports = { s, a, m, o, l, n, t, e, f };

--- a/lib/dialects/sqlite3/schema/internal/parser.js
+++ b/lib/dialects/sqlite3/schema/internal/parser.js
@@ -12,6 +12,21 @@ const TOKENS = {
   _ws: /\s+/,
 };
 
+function parseCreateTable(sql) {
+  const result = createTable({ input: tokenize(sql, TOKENS) });
+
+  if (!result.success) {
+    throw new Error(
+      `Parsing CREATE TABLE failed at: [${result.input
+        .slice(result.index)
+        .map((t) => t.text)
+        .join(' ')}]`
+    );
+  }
+
+  return result.ast;
+}
+
 function parseCreateIndex(sql) {
   const result = createIndex({ input: tokenize(sql, TOKENS) });
 
@@ -25,6 +40,396 @@ function parseCreateIndex(sql) {
   }
 
   return result.ast;
+}
+
+function createTable(ctx) {
+  return s(
+    [
+      t({ text: 'CREATE' }, (v) => null),
+      temporary,
+      t({ text: 'TABLE' }, (v) => null),
+      exists,
+      schema,
+      table,
+      t({ text: '(' }, (v) => null),
+      columnDefinitionList,
+      tableConstraintList,
+      t({ text: ')' }, (v) => null),
+      rowid,
+      f,
+    ],
+    (v) => Object.assign({}, ...v.filter((x) => x !== null))
+  )(ctx);
+}
+
+function temporary(ctx) {
+  return a([t({ text: 'TEMP' }), t({ text: 'TEMPORARY' }), e], (v) => ({
+    temporary: v !== null,
+  }))(ctx);
+}
+
+function rowid(ctx) {
+  return o(s([t({ text: 'WITHOUT' }), t({ text: 'ROWID' })]), (v) => ({
+    rowid: v !== null,
+  }))(ctx);
+}
+
+function columnDefinitionList(ctx) {
+  return a([
+    s([columnDefinition, t({ text: ',' }), columnDefinitionList], (v) => ({
+      columns: [v[0]].concat(v[2].columns),
+    })),
+    s([columnDefinition], (v) => ({ columns: [v[0]] })),
+  ])(ctx);
+}
+
+function columnDefinition(ctx) {
+  return s(
+    [s([identifier], (v) => ({ name: v[0] })), typeName, columnConstraintList],
+    (v) => Object.assign({}, ...v)
+  )(ctx);
+}
+
+function typeName(ctx) {
+  return o(
+    s(
+      [
+        m(n({ do: t({ type: 'id' }), not: t({ text: 'GENERATED' }) })),
+        a([
+          s(
+            [
+              t({ text: '(' }),
+              signedNumber,
+              t({ text: ',' }),
+              signedNumber,
+              t({ text: ')' }),
+            ],
+            (v) => `(${v[1]}, ${v[3]})`
+          ),
+          s(
+            [t({ text: '(' }), signedNumber, t({ text: ')' })],
+            (v) => `(${v[1]})`
+          ),
+          e,
+        ]),
+      ],
+      (v) => `${v[0].join(' ')}${v[1] || ''}`
+    ),
+    (v) => ({ type: v })
+  )(ctx);
+}
+
+function columnConstraintList(ctx) {
+  return o(m(columnConstraint), (v) => ({
+    constraints: Object.assign(
+      {
+        primary: null,
+        not: null,
+        unique: null,
+        check: null,
+        default: null,
+        collate: null,
+        references: null,
+        as: null,
+      },
+      ...(v || [])
+    ),
+  }))(ctx);
+}
+
+function columnConstraint(ctx) {
+  return a([
+    primaryColumnConstraint,
+    notColumnConstraint,
+    uniqueColumnConstraint,
+    checkColumnConstraint,
+    defaultColumnConstraint,
+    collateColumnConstraint,
+    referencesColumnConstraint,
+    asColumnConstraint,
+  ])(ctx);
+}
+
+function primaryColumnConstraint(ctx) {
+  return s(
+    [
+      constraintName,
+      t({ text: 'PRIMARY' }, (v) => null),
+      t({ text: 'KEY' }, (v) => null),
+      order,
+      conflictClause,
+      autoincrement,
+    ],
+    (v) => ({ primary: Object.assign({}, ...v.filter((x) => x !== null)) })
+  )(ctx);
+}
+
+function autoincrement(ctx) {
+  return o(t({ text: 'AUTOINCREMENT' }), (v) => ({
+    autoincrement: v !== null,
+  }))(ctx);
+}
+
+function notColumnConstraint(ctx) {
+  return s(
+    [
+      constraintName,
+      t({ text: 'NOT' }, (v) => null),
+      t({ text: 'NULL' }, (v) => null),
+      conflictClause,
+    ],
+    (v) => ({ not: Object.assign({}, ...v.filter((x) => x !== null)) })
+  )(ctx);
+}
+
+function uniqueColumnConstraint(ctx) {
+  return s(
+    [constraintName, t({ text: 'UNIQUE' }, (v) => null), conflictClause],
+    (v) => ({ unique: Object.assign({}, ...v.filter((x) => x !== null)) })
+  )(ctx);
+}
+
+function checkColumnConstraint(ctx) {
+  return s(
+    [
+      constraintName,
+      t({ text: 'CHECK' }, (v) => null),
+      t({ text: '(' }, (v) => null),
+      s([expression], (v) => ({ expression: v[0] })),
+      t({ text: ')' }, (v) => null),
+    ],
+    (v) => ({ check: Object.assign({}, ...v.filter((x) => x !== null)) })
+  )(ctx);
+}
+
+function defaultColumnConstraint(ctx) {
+  return s(
+    [
+      constraintName,
+      t({ text: 'DEFAULT' }, (v) => null),
+      a([
+        s([t({ text: '(' }), expression, t({ text: ')' })], (v) => ({
+          value: v[1],
+          expression: true,
+        })),
+        s([literalValue], (v) => ({ value: v[0], expression: false })),
+        s([signedNumber], (v) => ({ value: v[0], expression: false })),
+      ]),
+    ],
+    (v) => ({ default: Object.assign({}, ...v.filter((x) => x !== null)) })
+  )(ctx);
+}
+
+function collateColumnConstraint(ctx) {
+  return s(
+    [
+      constraintName,
+      t({ text: 'COLLATE' }, (v) => null),
+      t({ type: 'id' }, (v) => ({ collation: v.text })),
+    ],
+    (v) => ({ collate: Object.assign({}, ...v.filter((x) => x !== null)) })
+  )(ctx);
+}
+
+function referencesColumnConstraint(ctx) {
+  return s(
+    [constraintName, s([foreignKeyClause], (v) => v[0].references)],
+    (v) => ({
+      references: Object.assign({}, ...v.filter((x) => x !== null)),
+    })
+  )(ctx);
+}
+
+function asColumnConstraint(ctx) {
+  return s(
+    [
+      constraintName,
+      o(s([t({ text: 'GENERATED' }), t({ text: 'ALWAYS' })]), (v) => ({
+        generated: v !== null,
+      })),
+      t({ text: 'AS' }, (v) => null),
+      t({ text: '(' }, (v) => null),
+      s([expression], (v) => ({ expression: v[0] })),
+      t({ text: ')' }, (v) => null),
+      a([t({ text: 'STORED' }), t({ text: 'VIRTUAL' }), e], (v) => ({
+        mode: v ? v.toUpperCase() : null,
+      })),
+    ],
+    (v) => ({ as: Object.assign({}, ...v.filter((x) => x !== null)) })
+  )(ctx);
+}
+
+function tableConstraintList(ctx) {
+  return o(m(s([t({ text: ',' }), tableConstraint], (v) => v[1])), (v) => ({
+    constraints: v || [],
+  }))(ctx);
+}
+
+function tableConstraint(ctx) {
+  return a([
+    primaryTableConstraint,
+    uniqueTableConstraint,
+    checkTableConstraint,
+    foreignTableConstraint,
+  ])(ctx);
+}
+
+function primaryTableConstraint(ctx) {
+  return s(
+    [
+      constraintName,
+      t({ text: 'PRIMARY' }, (v) => null),
+      t({ text: 'KEY' }, (v) => null),
+      t({ text: '(' }, (v) => null),
+      indexedColumnList,
+      t({ text: ')' }, (v) => null),
+      conflictClause,
+    ],
+    (v) =>
+      Object.assign({ type: 'PRIMARY KEY' }, ...v.filter((x) => x !== null))
+  )(ctx);
+}
+
+function uniqueTableConstraint(ctx) {
+  return s(
+    [
+      constraintName,
+      t({ text: 'UNIQUE' }, (v) => null),
+      t({ text: '(' }, (v) => null),
+      indexedColumnList,
+      t({ text: ')' }, (v) => null),
+      conflictClause,
+    ],
+    (v) => Object.assign({ type: 'UNIQUE' }, ...v.filter((x) => x !== null))
+  )(ctx);
+}
+
+function conflictClause(ctx) {
+  return o(
+    s(
+      [
+        t({ text: 'ON' }),
+        t({ text: 'CONFLICT' }),
+        a([
+          t({ text: 'ROLLBACK' }),
+          t({ text: 'ABORT' }),
+          t({ text: 'FAIL' }),
+          t({ text: 'IGNORE' }),
+          t({ text: 'REPLACE' }),
+        ]),
+      ],
+      (v) => v[2]
+    ),
+    (v) => ({ conflict: v ? v.toUpperCase() : null })
+  )(ctx);
+}
+
+function checkTableConstraint(ctx) {
+  return s(
+    [
+      constraintName,
+      t({ text: 'CHECK' }, (v) => null),
+      t({ text: '(' }, (v) => null),
+      s([expression], (v) => ({ expression: v[0] })),
+      t({ text: ')' }, (v) => null),
+    ],
+    (v) => Object.assign({ type: 'CHECK' }, ...v.filter((x) => x !== null))
+  )(ctx);
+}
+
+function foreignTableConstraint(ctx) {
+  return s(
+    [
+      constraintName,
+      t({ text: 'FOREIGN' }, (v) => null),
+      t({ text: 'KEY' }, (v) => null),
+      t({ text: '(' }, (v) => null),
+      columnNameList,
+      t({ text: ')' }, (v) => null),
+      foreignKeyClause,
+    ],
+    (v) =>
+      Object.assign({ type: 'FOREIGN KEY' }, ...v.filter((x) => x !== null))
+  )(ctx);
+}
+
+function foreignKeyClause(ctx) {
+  return s(
+    [
+      t({ text: 'REFERENCES' }, (v) => null),
+      table,
+      columnNameListOptional,
+      o(m(a([deleteReference, updateReference, matchReference])), (v) =>
+        Object.assign({ delete: null, update: null, match: null }, ...(v || []))
+      ),
+      deferrable,
+    ],
+    (v) => ({ references: Object.assign({}, ...v.filter((x) => x !== null)) })
+  )(ctx);
+}
+
+function columnNameListOptional(ctx) {
+  return o(
+    s([t({ text: '(' }), columnNameList, t({ text: ')' })], (v) => v[1]),
+    (v) => ({ columns: v ? v.columns : [] })
+  )(ctx);
+}
+
+function columnNameList(ctx) {
+  return s(
+    [
+      o(m(s([identifier, t({ text: ',' })], (v) => v[0])), (v) =>
+        v !== null ? v : []
+      ),
+      identifier,
+    ],
+    (v) => ({ columns: v[0].concat([v[1]]) })
+  )(ctx);
+}
+
+function deleteReference(ctx) {
+  return s([t({ text: 'ON' }), t({ text: 'DELETE' }), onAction], (v) => ({
+    delete: v[2],
+  }))(ctx);
+}
+
+function updateReference(ctx) {
+  return s([t({ text: 'ON' }), t({ text: 'UPDATE' }), onAction], (v) => ({
+    update: v[2],
+  }))(ctx);
+}
+
+function matchReference(ctx) {
+  return s(
+    [t({ text: 'MATCH' }), a([t({ type: 'keyword' }), t({ type: 'id' })])],
+    (v) => ({ match: v[1] })
+  )(ctx);
+}
+
+function deferrable(ctx) {
+  return o(
+    s([
+      o(t({ text: 'NOT' })),
+      t({ text: 'DEFERRABLE' }),
+      o(
+        s(
+          [
+            t({ text: 'INITIALLY' }),
+            a([t({ text: 'DEFERRED' }), t({ text: 'IMMEDIATE' })]),
+          ],
+          (v) => v[1].toUpperCase()
+        )
+      ),
+    ]),
+    (v) => ({ deferrable: v ? { not: v[0] !== null, initially: v[2] } : null })
+  )(ctx);
+}
+
+function constraintName(ctx) {
+  return o(
+    s([t({ text: 'CONSTRAINT' }), identifier], (v) => v[1]),
+    (v) => ({ name: v })
+  )(ctx);
 }
 
 function createIndex(ctx) {
@@ -122,7 +527,7 @@ function indexedColumnExpression(ctx) {
 
 function collation(ctx) {
   return o(
-    s([t({ text: 'COLLATE' }), identifier], (v) => v[1]),
+    s([t({ text: 'COLLATE' }), t({ type: 'id' })], (v) => v[1]),
     (v) => ({ collation: v })
   )(ctx);
 }
@@ -184,6 +589,41 @@ function identifier(ctx) {
   )(ctx);
 }
 
+function onAction(ctx) {
+  return a(
+    [
+      s([t({ text: 'SET' }), t({ text: 'NULL' })], (v) => `${v[0]} ${v[1]}`),
+      s([t({ text: 'SET' }), t({ text: 'DEFAULT' })], (v) => `${v[0]} ${v[1]}`),
+      t({ text: 'CASCADE' }),
+      t({ text: 'RESTRICT' }),
+      s([t({ text: 'NO' }), t({ text: 'ACTION' })], (v) => `${v[0]} ${v[1]}`),
+    ],
+    (v) => v.toUpperCase()
+  )(ctx);
+}
+
+function literalValue(ctx) {
+  return a([
+    t({ type: 'numeric' }),
+    t({ type: 'string' }),
+    t({ type: 'blob' }),
+    t({ text: 'NULL' }),
+    t({ text: 'TRUE' }),
+    t({ text: 'FALSE' }),
+    t({ text: 'CURRENT_TIME' }),
+    t({ text: 'CURRENT_DATE' }),
+    t({ text: 'CURRENT_TIMESTAMP' }),
+  ])(ctx);
+}
+
+function signedNumber(ctx) {
+  return s(
+    [a([t({ text: '+' }), t({ text: '-' }), e]), t({ type: 'numeric' })],
+    (v) => `${v[0] || ''}${v[1]}`
+  )(ctx);
+}
+
 module.exports = {
+  parseCreateTable,
   parseCreateIndex,
 };

--- a/lib/dialects/sqlite3/schema/internal/parser.js
+++ b/lib/dialects/sqlite3/schema/internal/parser.js
@@ -1,56 +1,187 @@
-const { COMMA_NO_PAREN_REGEX } = require('../../../../constants');
+const { tokenize } = require('./tokenizer');
+const { s, a, m, o, l, n, t, e, f } = require('./parser-combinator');
 
-const IDENTIFIER = /^(?<open>"|`|\[)?(?<identifier>(?<=").*(?=")|(?<=`).*(?=`)|(?<=\[).*(?=\])|(?<=^)\w+(?=$))(?<close>"|`|\])?$/i;
+const TOKENS = {
+  keyword: /(?:ABORT|ADD|AFTER|ALL|ALTER|ANALYZE|AND|AS|ASC|ATTACH|AUTOINCREMENT|BEFORE|BEGIN|BETWEEN|BY|CASCADE|CASE|CAST|CHECK|COLLATE|COLUMN|COMMIT|CONFLICT|CONSTRAINT|CREATE|CROSS|CURRENT_DATE|CURRENT_TIME|CURRENT_TIMESTAMP|DATABASE|DEFAULT|DEFERRED|DEFERRABLE|DELETE|DESC|DETACH|DISTINCT|DROP|END|EACH|ELSE|ESCAPE|EXCEPT|EXCLUSIVE|EXISTS|EXPLAIN|FAIL|FOR|FOREIGN|FROM|FULL|GLOB|GROUP|HAVING|IF|IGNORE|IMMEDIATE|IN|INDEX|INITIALLY|INNER|INSERT|INSTEAD|INTERSECT|INTO|IS|ISNULL|JOIN|KEY|LEFT|LIKE|LIMIT|MATCH|NATURAL|NOT|NOTNULL|NULL|OF|OFFSET|ON|OR|ORDER|OUTER|PLAN|PRAGMA|PRIMARY|QUERY|RAISE|REFERENCES|REGEXP|REINDEX|RENAME|REPLACE|RESTRICT|RIGHT|ROLLBACK|ROW|SELECT|SET|TABLE|TEMP|TEMPORARY|THEN|TO|TRANSACTION|TRIGGER|UNION|UNIQUE|UPDATE|USING|VACUUM|VALUES|VIEW|VIRTUAL|WHEN|WHERE)(?=\s+|-|\(|\)|;|\+|\*|\/|%|==|=|<=|<>|<<|<|>=|>>|>|!=|,|&|~|\|\||\||\.)/,
+  id: /"[^"]*(?:""[^"]*)*"|`[^`]*(?:``[^`]*)*`|\[[^[\]]*\]|[a-z_][a-z0-9_$]*/,
+  string: /'[^']*(?:''[^']*)*'/,
+  blob: /x'(?:[0-9a-f][0-9a-f])+'/,
+  numeric: /(?:\d+(?:\.\d*)?|\.\d+)(?:e(?:\+|-)?\d+)?|0x[0-9a-f]+/,
+  variable: /\?\d*|[@$:][a-z0-9_$]+/,
+  operator: /-|\(|\)|;|\+|\*|\/|%|==|=|<=|<>|<<|<|>=|>>|>|!=|,|&|~|\|\||\||\./,
+  _ws: /\s+/,
+};
 
 function parseCreateIndex(sql) {
-  const normalized = sql.replace(/\s+/g, ' ');
+  const result = createIndex({ input: tokenize(sql, TOKENS) });
 
-  const createIndexStatement = parse(
-    normalized,
-    /^CREATE(?<unique> UNIQUE)? INDEX(?<exists> IF NOT EXISTS)? (?:(?<schema>[^.]+)\.)?(?<index>[^.]+) ON (?<table>.+?) ?\((?<columns>.+)\)(?: WHERE (?<where>.+))?$/i
-  );
+  if (!result.success) {
+    throw new Error(
+      `Parsing CREATE INDEX failed at: [${result.input
+        .slice(result.index)
+        .map((t) => t.text)
+        .join(' ')}]`
+    );
+  }
 
-  const unique = createIndexStatement.unique !== undefined;
-  const exists = createIndexStatement.exists !== undefined;
-  const schema = createIndexStatement.schema
-    ? parse(createIndexStatement.schema, IDENTIFIER).identifier
-    : null;
-  const index = parse(createIndexStatement.index, IDENTIFIER).identifier;
-  const table = parse(createIndexStatement.table, IDENTIFIER).identifier;
-  const where = createIndexStatement.where || null;
-
-  const columns = createIndexStatement.columns
-    .split(COMMA_NO_PAREN_REGEX)
-    .map((column) => {
-      const normalized = column.trim();
-
-      const indexedColumn = parse(
-        normalized,
-        /^(?<name>.+?)(?: COLLATE (?<collation>\w+))?(?: (?<order>ASC|DESC))?$/i
-      );
-
-      const expression = !IDENTIFIER.test(indexedColumn.name);
-      const name = !expression
-        ? parse(indexedColumn.name, IDENTIFIER).identifier
-        : indexedColumn.name;
-      const collation = indexedColumn.collation || null;
-      const order = indexedColumn.order
-        ? indexedColumn.order.toUpperCase()
-        : null;
-
-      return { name, expression, collation, order };
-    });
-
-  return { unique, exists, schema, index, table, columns, where };
+  return result.ast;
 }
 
-function parse(sql, regex) {
-  const result = sql.match(regex);
+function createIndex(ctx) {
+  return s(
+    [
+      t({ text: 'CREATE' }, (v) => null),
+      unique,
+      t({ text: 'INDEX' }, (v) => null),
+      exists,
+      schema,
+      index,
+      t({ text: 'ON' }, (v) => null),
+      table,
+      t({ text: '(' }, (v) => null),
+      indexedColumnList,
+      t({ text: ')' }, (v) => null),
+      where,
+      f,
+    ],
+    (v) => Object.assign({}, ...v.filter((x) => x !== null))
+  )(ctx);
+}
 
-  if (result === null) {
-    throw new Error('Parsing SQL command failed');
-  }
-  return result.groups;
+function unique(ctx) {
+  return o(t({ text: 'UNIQUE' }), (v) => ({ unique: v !== null }))(ctx);
+}
+
+function exists(ctx) {
+  return o(
+    s([t({ text: 'IF' }), t({ text: 'NOT' }), t({ text: 'EXISTS' })]),
+    (v) => ({ exists: v !== null })
+  )(ctx);
+}
+
+function schema(ctx) {
+  return o(
+    s([identifier, t({ text: '.' })], (v) => v[0]),
+    (v) => ({ schema: v })
+  )(ctx);
+}
+
+function index(ctx) {
+  return s([identifier], (v) => ({ index: v[0] }))(ctx);
+}
+
+function table(ctx) {
+  return s([identifier], (v) => ({ table: v[0] }))(ctx);
+}
+
+function where(ctx) {
+  return o(
+    s([t({ text: 'WHERE' }), expression], (v) => v[1]),
+    (v) => ({ where: v })
+  )(ctx);
+}
+
+function indexedColumnList(ctx) {
+  return a([
+    s([indexedColumn, t({ text: ',' }), indexedColumnList], (v) => ({
+      columns: [v[0]].concat(v[2].columns),
+    })),
+    s([indexedColumnExpression, t({ text: ',' }), indexedColumnList], (v) => ({
+      columns: [v[0]].concat(v[2].columns),
+    })),
+    l({ do: indexedColumn, next: t({ text: ')' }) }, (v) => ({
+      columns: [v],
+    })),
+    l({ do: indexedColumnExpression, next: t({ text: ')' }) }, (v) => ({
+      columns: [v],
+    })),
+  ])(ctx);
+}
+
+function indexedColumn(ctx) {
+  return s(
+    [
+      s([identifier], (v) => ({ name: v[0], expression: false })),
+      collation,
+      order,
+    ],
+    (v) => Object.assign({}, ...v.filter((x) => x !== null))
+  )(ctx);
+}
+
+function indexedColumnExpression(ctx) {
+  return s(
+    [
+      s([indexedExpression], (v) => ({ name: v[0], expression: true })),
+      collation,
+      order,
+    ],
+    (v) => Object.assign({}, ...v.filter((x) => x !== null))
+  )(ctx);
+}
+
+function collation(ctx) {
+  return o(
+    s([t({ text: 'COLLATE' }), identifier], (v) => v[1]),
+    (v) => ({ collation: v })
+  )(ctx);
+}
+
+function order(ctx) {
+  return a([t({ text: 'ASC' }), t({ text: 'DESC' }), e], (v) => ({
+    order: v ? v.toUpperCase() : null,
+  }))(ctx);
+}
+
+function indexedExpression(ctx) {
+  return m(
+    a([
+      n({
+        do: t({ type: 'keyword' }),
+        not: a([
+          t({ text: 'COLLATE' }),
+          t({ text: 'ASC' }),
+          t({ text: 'DESC' }),
+        ]),
+      }),
+      t({ type: 'id' }),
+      t({ type: 'string' }),
+      t({ type: 'blob' }),
+      t({ type: 'numeric' }),
+      t({ type: 'variable' }),
+      n({
+        do: t({ type: 'operator' }),
+        not: a([t({ text: '(' }), t({ text: ')' }), t({ text: ',' })]),
+      }),
+      s([t({ text: '(' }), o(expression), t({ text: ')' })], (v) => v[1] || []),
+    ])
+  )(ctx);
+}
+
+function expression(ctx) {
+  return m(
+    a([
+      t({ type: 'keyword' }),
+      t({ type: 'id' }),
+      t({ type: 'string' }),
+      t({ type: 'blob' }),
+      t({ type: 'numeric' }),
+      t({ type: 'variable' }),
+      n({
+        do: t({ type: 'operator' }),
+        not: a([t({ text: '(' }), t({ text: ')' })]),
+      }),
+      s([t({ text: '(' }), o(expression), t({ text: ')' })], (v) => v[1] || []),
+    ])
+  )(ctx);
+}
+
+function identifier(ctx) {
+  return t({ type: 'id' }, (v) =>
+    /^["`[][^]*["`\]]$/.test(v.text)
+      ? v.text.substring(1, v.text.length - 1)
+      : v.text
+  )(ctx);
 }
 
 module.exports = {

--- a/lib/dialects/sqlite3/schema/internal/tokenizer.js
+++ b/lib/dialects/sqlite3/schema/internal/tokenizer.js
@@ -1,0 +1,38 @@
+function tokenize(text, tokens) {
+  const compiledRegex = new RegExp(
+    Object.entries(tokens)
+      .map(([type, regex]) => `(?<${type}>${regex.source})`)
+      .join('|'),
+    'yi'
+  );
+
+  let index = 0;
+  const ast = [];
+
+  while (index < text.length) {
+    compiledRegex.lastIndex = index;
+    const result = text.match(compiledRegex);
+
+    if (result !== null) {
+      const [type, text] = Object.entries(result.groups).find(
+        ([name, group]) => group !== undefined
+      );
+
+      index += text.length;
+
+      if (!type.startsWith('_')) {
+        ast.push({ type, text });
+      }
+    } else {
+      throw new Error(
+        `No matching tokenizer rule found at: [${text.substring(index)}]`
+      );
+    }
+  }
+
+  return ast;
+}
+
+module.exports = {
+  tokenize,
+};

--- a/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
@@ -1,7 +1,9 @@
 const filter = require('lodash/filter');
 const values = require('lodash/values');
+const identity = require('lodash/identity');
 
 const TableCompiler = require('../../../schema/tablecompiler');
+const { formatDefault } = require('../../../formatter/formatterUtils');
 
 class TableCompiler_SQLite3 extends TableCompiler {
   constructor() {
@@ -26,15 +28,44 @@ class TableCompiler_SQLite3 extends TableCompiler {
     this.pushQuery(sql);
   }
 
-  addColumns(columns, prefix) {
-    if (prefix) {
-      throw new Error('Sqlite does not support alter column.');
-    }
-    for (let i = 0, l = columns.sql.length; i < l; i++) {
-      this.pushQuery({
-        sql: `alter table ${this.tableName()} add column ${columns.sql[i]}`,
-        bindings: columns.bindings[i],
+  addColumns(columns, prefix, colCompilers) {
+    if (prefix === this.alterColumnsPrefix) {
+      const compiler = this;
+
+      const columnsInfo = colCompilers.map((col) => {
+        const name = this.client.customWrapIdentifier(
+          col.getColumnName(),
+          identity,
+          col.columnBuilder.queryContext()
+        );
+
+        const type = col.getColumnType();
+
+        const defaultTo = col.modified['defaultTo']
+          ? formatDefault(col.modified['defaultTo'][0], type, this.client)
+          : null;
+
+        const notNull =
+          col.modified['nullable'] && col.modified['nullable'][0] === false;
+
+        return { name, type, defaultTo, notNull };
       });
+
+      this.pushQuery({
+        sql: `PRAGMA table_info(${this.tableName()})`,
+        statementsProducer(pragma, connection) {
+          return compiler.client
+            .ddl(compiler, pragma, connection)
+            .alterColumn(columnsInfo);
+        },
+      });
+    } else {
+      for (let i = 0, l = columns.sql.length; i < l; i++) {
+        this.pushQuery({
+          sql: `alter table ${this.tableName()} add column ${columns.sql[i]}`,
+          bindings: columns.bindings[i],
+        });
+      }
     }
   }
 

--- a/lib/formatter/formatterUtils.js
+++ b/lib/formatter/formatterUtils.js
@@ -1,3 +1,5 @@
+const { isObject } = require('../util/is');
+
 // Compiles a callback using the query builder.
 function compileCallback(callback, method, client, bindingsHolder) {
   // Build the callback
@@ -16,7 +18,25 @@ function wrapAsIdentifier(value, builder, client) {
   return client.wrapIdentifier((value || '').trim(), queryContext);
 }
 
+function formatDefault(value, type, client) {
+  if (value === void 0) {
+    return '';
+  } else if (value === null) {
+    return 'null';
+  } else if (value && value.isRawInstance) {
+    return value.toQuery();
+  } else if (type === 'bool') {
+    if (value === 'false') value = 0;
+    return `'${value ? 1 : 0}'`;
+  } else if ((type === 'json' || type === 'jsonb') && isObject(value)) {
+    return `'${JSON.stringify(value)}'`;
+  } else {
+    return client._escapeBinding(value.toString());
+  }
+}
+
 module.exports = {
   compileCallback,
   wrapAsIdentifier,
+  formatDefault,
 };

--- a/lib/schema/columncompiler.js
+++ b/lib/schema/columncompiler.js
@@ -2,14 +2,13 @@
 // Used for designating column definitions
 // during the table "create" / "alter" statements.
 // -------
-const Raw = require('../raw');
 const helpers = require('./internal/helpers');
 const groupBy = require('lodash/groupBy');
 const first = require('lodash/first');
 const has = require('lodash/has');
 const tail = require('lodash/tail');
-const { isObject } = require('../util/is');
 const { toNumber } = require('../util/helpers');
+const { formatDefault } = require('../formatter/formatterUtils');
 
 class ColumnCompiler {
   constructor(client, tableCompiler, columnBuilder) {
@@ -133,24 +132,7 @@ class ColumnCompiler {
   }
 
   defaultTo(value) {
-    if (value === void 0) {
-      return '';
-    } else if (value === null) {
-      value = 'null';
-    } else if (value instanceof Raw) {
-      value = value.toQuery();
-    } else if (this.type === 'bool') {
-      if (value === 'false') value = 0;
-      value = `'${value ? 1 : 0}'`;
-    } else if (
-      (this.type === 'json' || this.type === 'jsonb') &&
-      isObject(value)
-    ) {
-      value = `'${JSON.stringify(value)}'`;
-    } else {
-      value = this.client._escapeBinding(value.toString());
-    }
-    return `default ${value}`;
+    return `default ${formatDefault(value, this.type, this.client)}`;
   }
 }
 

--- a/test/integration2/schema/index.spec.js
+++ b/test/integration2/schema/index.spec.js
@@ -218,6 +218,20 @@ describe('Schema', () => {
             });
           });
 
+          describe('alterColumns', () => {
+            it('recreates indices after altering a column', async () => {
+              const indicesBefore = await knex.raw(QUERY_TABLE_ONE_INDICES);
+
+              await knex.schema.alterTable('index_table_one', (table) => {
+                table.string('column_one').alter();
+              });
+
+              const indicesAfter = await knex.raw(QUERY_TABLE_ONE_INDICES);
+
+              expect(indicesAfter).to.deep.have.same.members(indicesBefore);
+            });
+          });
+
           describe('dropForeign', () => {
             it('recreates indices after dropping a foreign key', async () => {
               const indicesBefore = await knex.raw(QUERY_TABLE_ONE_INDICES);

--- a/test/unit/schema-builder/sqlite3.js
+++ b/test/unit/schema-builder/sqlite3.js
@@ -9,9 +9,11 @@ const SQLite3_Client = require('../../../lib/dialects/sqlite3');
 const client = new SQLite3_Client({ client: 'sqlite3' });
 const SQLite3_DDL = require('../../../lib/dialects/sqlite3/schema/ddl');
 const {
+  parseCreateTable,
   parseCreateIndex,
 } = require('../../../lib/dialects/sqlite3/schema/internal/parser');
 const {
+  compileCreateTable,
   compileCreateIndex,
 } = require('../../../lib/dialects/sqlite3/schema/internal/compiler');
 
@@ -855,6 +857,2952 @@ describe('SQLite SchemaBuilder', function () {
 
 describe('SQLite parser and compiler', function () {
   const wrap = (v) => `"${v}"`;
+
+  describe('create table', function () {
+    it('basic', function () {
+      const sql = 'CREATE TABLE "users" ("foo")';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('temporary', function () {
+      const sql = 'CREATE TEMP TABLE "users" ("foo")';
+      const ast = {
+        temporary: true,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('if not exists', function () {
+      const sql = 'CREATE TABLE IF NOT EXISTS "users" ("foo")';
+      const ast = {
+        temporary: false,
+        exists: true,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('schema', function () {
+      const sql = 'CREATE TABLE "schema"."users" ("foo")';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: 'schema',
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('rowid', function () {
+      const sql = 'CREATE TABLE "users" ("foo") WITHOUT ROWID';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: true,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition type', function () {
+      const sql = 'CREATE TABLE "users" ("foo" INTEGER)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: 'INTEGER',
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition type one parameter', function () {
+      const sql = 'CREATE TABLE "users" ("foo" VARYING CHARACTER(255))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: 'VARYING CHARACTER(255)',
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition type two parameters', function () {
+      const sql = 'CREATE TABLE "users" ("foo" DECIMAL(+10, -5))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: 'DECIMAL(+10, -5)',
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition multiple type', function () {
+      const sql = 'CREATE TABLE "users" ("foo" FLOAT, "bar" DECIMAL(4, 2))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: 'FLOAT',
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'bar',
+            type: 'DECIMAL(4, 2)',
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition primary key', function () {
+      const sql = 'CREATE TABLE "users" ("foo" PRIMARY KEY)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: {
+                name: null,
+                order: null,
+                conflict: null,
+                autoincrement: false,
+              },
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition primary key order', function () {
+      const sql = 'CREATE TABLE "users" ("foo" PRIMARY KEY ASC)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: {
+                name: null,
+                order: 'ASC',
+                conflict: null,
+                autoincrement: false,
+              },
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition primary key conflict', function () {
+      const sql = 'CREATE TABLE "users" ("foo" PRIMARY KEY ON CONFLICT ABORT)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: {
+                name: null,
+                order: null,
+                conflict: 'ABORT',
+                autoincrement: false,
+              },
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition primary key autoincrement', function () {
+      const sql = 'CREATE TABLE "users" ("foo" PRIMARY KEY AUTOINCREMENT)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: {
+                name: null,
+                order: null,
+                conflict: null,
+                autoincrement: true,
+              },
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition primary key all', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo" PRIMARY KEY DESC ON CONFLICT FAIL AUTOINCREMENT)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: {
+                name: null,
+                order: 'DESC',
+                conflict: 'FAIL',
+                autoincrement: true,
+              },
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition not null', function () {
+      const sql = 'CREATE TABLE "users" ("foo" NOT NULL)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: {
+                name: null,
+                conflict: null,
+              },
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition not null conflict', function () {
+      const sql = 'CREATE TABLE "users" ("foo" NOT NULL ON CONFLICT IGNORE)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: {
+                name: null,
+                conflict: 'IGNORE',
+              },
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition unique', function () {
+      const sql = 'CREATE TABLE "users" ("foo" UNIQUE)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: {
+                name: null,
+                conflict: null,
+              },
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition unique conflict', function () {
+      const sql = 'CREATE TABLE "users" ("foo" UNIQUE ON CONFLICT REPLACE)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: {
+                name: null,
+                conflict: 'REPLACE',
+              },
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition check', function () {
+      const sql = 'CREATE TABLE "users" ("foo" CHECK ("foo" != 42))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: {
+                name: null,
+                expression: ['"foo"', '!=', '42'],
+              },
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition default', function () {
+      const sql = `CREATE TABLE "users" ("foo" DEFAULT 'bar')`;
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: {
+                name: null,
+                value: `'bar'`,
+                expression: false,
+              },
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition default signed number', function () {
+      const sql = 'CREATE TABLE "users" ("foo" DEFAULT -42)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: {
+                name: null,
+                value: '-42',
+                expression: false,
+              },
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition default expression', function () {
+      const sql = 'CREATE TABLE "users" ("foo" DEFAULT (random()))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: {
+                name: null,
+                value: ['random', []],
+                expression: true,
+              },
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition collate', function () {
+      const sql = 'CREATE TABLE "users" ("foo" COLLATE RTRIM)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: {
+                name: null,
+                collation: 'RTRIM',
+              },
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition references', function () {
+      const sql = 'CREATE TABLE "users" ("foo" REFERENCES "other")';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: {
+                name: null,
+                table: 'other',
+                columns: [],
+                delete: null,
+                update: null,
+                match: null,
+                deferrable: null,
+              },
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition references referenced column', function () {
+      const sql = 'CREATE TABLE "users" ("foo" REFERENCES "other" ("bar"))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: {
+                name: null,
+                table: 'other',
+                columns: ['bar'],
+                delete: null,
+                update: null,
+                match: null,
+                deferrable: null,
+              },
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition references multiple columns', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo" REFERENCES "other" ("bar", "lar"))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: {
+                name: null,
+                table: 'other',
+                columns: ['bar', 'lar'],
+                delete: null,
+                update: null,
+                match: null,
+                deferrable: null,
+              },
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition references on delete', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo" REFERENCES "other" ON DELETE SET NULL)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: {
+                name: null,
+                table: 'other',
+                columns: [],
+                delete: 'SET NULL',
+                update: null,
+                match: null,
+                deferrable: null,
+              },
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition references on update', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo" REFERENCES "other" ON UPDATE CASCADE)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: {
+                name: null,
+                table: 'other',
+                columns: [],
+                delete: null,
+                update: 'CASCADE',
+                match: null,
+                deferrable: null,
+              },
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition references match', function () {
+      const sql = 'CREATE TABLE "users" ("foo" REFERENCES "other" MATCH FULL)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: {
+                name: null,
+                table: 'other',
+                columns: [],
+                delete: null,
+                update: null,
+                match: 'FULL',
+                deferrable: null,
+              },
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition references deferrable', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo" REFERENCES "other" NOT DEFERRABLE INITIALLY DEFERRED)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: {
+                name: null,
+                table: 'other',
+                columns: [],
+                delete: null,
+                update: null,
+                match: null,
+                deferrable: {
+                  not: true,
+                  initially: 'DEFERRED',
+                },
+              },
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition references all', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo" REFERENCES "other" ("bar") ON DELETE RESTRICT ON UPDATE NO ACTION MATCH PARTIAL DEFERRABLE)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: {
+                name: null,
+                table: 'other',
+                columns: ['bar'],
+                delete: 'RESTRICT',
+                update: 'NO ACTION',
+                match: 'PARTIAL',
+                deferrable: {
+                  not: false,
+                  initially: null,
+                },
+              },
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition as', function () {
+      const sql = 'CREATE TABLE "users" ("foo" AS (count(*)))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: {
+                name: null,
+                generated: false,
+                expression: ['count', ['*']],
+                mode: null,
+              },
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition as generated always', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo" GENERATED ALWAYS AS (length(foo)))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: {
+                name: null,
+                generated: true,
+                expression: ['length', ['foo']],
+                mode: null,
+              },
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition as mode', function () {
+      const sql = 'CREATE TABLE "users" ("foo" AS (length(foo)) VIRTUAL)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: {
+                name: null,
+                generated: false,
+                expression: ['length', ['foo']],
+                mode: 'VIRTUAL',
+              },
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition all', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo" TEXT PRIMARY KEY DESC ON CONFLICT ROLLBACK AUTOINCREMENT NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT REPLACE CHECK ("foo" != 42) DEFAULT NULL COLLATE BINARY REFERENCES "other" ("baz", "bar", "lar") ON UPDATE SET NULL MATCH SIMPLE NOT DEFERRABLE GENERATED ALWAYS AS (count(*)) STORED)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: 'TEXT',
+            constraints: {
+              primary: {
+                name: null,
+                order: 'DESC',
+                conflict: 'ROLLBACK',
+                autoincrement: true,
+              },
+              not: {
+                name: null,
+                conflict: 'FAIL',
+              },
+              unique: {
+                name: null,
+                conflict: 'REPLACE',
+              },
+              check: {
+                name: null,
+                expression: ['"foo"', '!=', '42'],
+              },
+              default: {
+                name: null,
+                value: 'NULL',
+                expression: false,
+              },
+              collate: {
+                name: null,
+                collation: 'BINARY',
+              },
+              references: {
+                name: null,
+                table: 'other',
+                columns: ['baz', 'bar', 'lar'],
+                delete: null,
+                update: 'SET NULL',
+                match: 'SIMPLE',
+                deferrable: {
+                  not: true,
+                  initially: null,
+                },
+              },
+              as: {
+                name: null,
+                generated: true,
+                expression: ['count', ['*']],
+                mode: 'STORED',
+              },
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition named', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo" UNSIGNED BIG INT CONSTRAINT "primary_constraint" PRIMARY KEY DESC ON CONFLICT ROLLBACK AUTOINCREMENT CONSTRAINT "not_constraint" NOT NULL ON CONFLICT FAIL CONSTRAINT "unique_constraint" UNIQUE ON CONFLICT REPLACE CONSTRAINT "check_constraint" CHECK ("foo" != 42) CONSTRAINT "default_constraint" DEFAULT NULL CONSTRAINT "collate_constraint" COLLATE BINARY CONSTRAINT "references_constraint" REFERENCES "other" ("baz", "bar", "lar") ON UPDATE SET NULL MATCH SIMPLE NOT DEFERRABLE CONSTRAINT "as_constraint" GENERATED ALWAYS AS (count(*)) STORED)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: 'UNSIGNED BIG INT',
+            constraints: {
+              primary: {
+                name: 'primary_constraint',
+                order: 'DESC',
+                conflict: 'ROLLBACK',
+                autoincrement: true,
+              },
+              not: {
+                name: 'not_constraint',
+                conflict: 'FAIL',
+              },
+              unique: {
+                name: 'unique_constraint',
+                conflict: 'REPLACE',
+              },
+              check: {
+                name: 'check_constraint',
+                expression: ['"foo"', '!=', '42'],
+              },
+              default: {
+                name: 'default_constraint',
+                value: 'NULL',
+                expression: false,
+              },
+              collate: {
+                name: 'collate_constraint',
+                collation: 'BINARY',
+              },
+              references: {
+                name: 'references_constraint',
+                table: 'other',
+                columns: ['baz', 'bar', 'lar'],
+                delete: null,
+                update: 'SET NULL',
+                match: 'SIMPLE',
+                deferrable: {
+                  not: true,
+                  initially: null,
+                },
+              },
+              as: {
+                name: 'as_constraint',
+                generated: true,
+                expression: ['count', ['*']],
+                mode: 'STORED',
+              },
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition multiple', function () {
+      const sql =
+        'CREATE TABLE "users" ("primary_column" BLOB CONSTRAINT "primary_constraint" PRIMARY KEY DESC ON CONFLICT ROLLBACK AUTOINCREMENT, "not_column" DOUBLE PRECISION NOT NULL ON CONFLICT FAIL, "unique_column" CONSTRAINT "unique_constraint" UNIQUE ON CONFLICT REPLACE, "check_column" CHECK ("foo" != 42), "default_column" INT8 DEFAULT NULL, "collate_column" CONSTRAINT "collate_constraint" COLLATE BINARY, "references_column" NUMERIC REFERENCES "other" ("baz", "bar", "lar") ON UPDATE SET NULL MATCH SIMPLE NOT DEFERRABLE, "as_column" CONSTRAINT "as_constraint" GENERATED ALWAYS AS (count(*)) STORED)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'primary_column',
+            type: 'BLOB',
+            constraints: {
+              primary: {
+                name: 'primary_constraint',
+                order: 'DESC',
+                conflict: 'ROLLBACK',
+                autoincrement: true,
+              },
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'not_column',
+            type: 'DOUBLE PRECISION',
+            constraints: {
+              primary: null,
+              not: {
+                name: null,
+                conflict: 'FAIL',
+              },
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'unique_column',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: {
+                name: 'unique_constraint',
+                conflict: 'REPLACE',
+              },
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'check_column',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: {
+                name: null,
+                expression: ['"foo"', '!=', '42'],
+              },
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'default_column',
+            type: 'INT8',
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: {
+                name: null,
+                value: 'NULL',
+                expression: false,
+              },
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'collate_column',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: {
+                name: 'collate_constraint',
+                collation: 'BINARY',
+              },
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'references_column',
+            type: 'NUMERIC',
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: {
+                name: null,
+                table: 'other',
+                columns: ['baz', 'bar', 'lar'],
+                delete: null,
+                update: 'SET NULL',
+                match: 'SIMPLE',
+                deferrable: {
+                  not: true,
+                  initially: null,
+                },
+              },
+              as: null,
+            },
+          },
+          {
+            name: 'as_column',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: {
+                name: 'as_constraint',
+                generated: true,
+                expression: ['count', ['*']],
+                mode: 'STORED',
+              },
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint primary key', function () {
+      const sql = 'CREATE TABLE "users" ("foo", PRIMARY KEY ("foo"))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'PRIMARY KEY',
+            name: null,
+            columns: [
+              {
+                name: 'foo',
+                expression: false,
+                collation: null,
+                order: null,
+              },
+            ],
+            conflict: null,
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint primary key conflict', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", PRIMARY KEY ("foo") ON CONFLICT ROLLBACK)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'PRIMARY KEY',
+            name: null,
+            columns: [
+              {
+                name: 'foo',
+                expression: false,
+                collation: null,
+                order: null,
+              },
+            ],
+            conflict: 'ROLLBACK',
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint primary key column collation and order', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", PRIMARY KEY ("foo", "baz" COLLATE BINARY, "bar" ASC, "lar" COLLATE NOCASE DESC))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'PRIMARY KEY',
+            name: null,
+            columns: [
+              {
+                name: 'foo',
+                expression: false,
+                collation: null,
+                order: null,
+              },
+              {
+                name: 'baz',
+                expression: false,
+                collation: 'BINARY',
+                order: null,
+              },
+              {
+                name: 'bar',
+                expression: false,
+                collation: null,
+                order: 'ASC',
+              },
+              {
+                name: 'lar',
+                expression: false,
+                collation: 'NOCASE',
+                order: 'DESC',
+              },
+            ],
+            conflict: null,
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint primary key column expression', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", PRIMARY KEY (abs(foo), random() COLLATE RTRIM, baz + bar ASC))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'PRIMARY KEY',
+            name: null,
+            columns: [
+              {
+                name: ['abs', ['foo']],
+                expression: true,
+                collation: null,
+                order: null,
+              },
+              {
+                name: ['random', []],
+                expression: true,
+                collation: 'RTRIM',
+                order: null,
+              },
+              {
+                name: ['baz', '+', 'bar'],
+                expression: true,
+                collation: null,
+                order: 'ASC',
+              },
+            ],
+            conflict: null,
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint unique', function () {
+      const sql = 'CREATE TABLE "users" ("foo", UNIQUE ("foo"))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'UNIQUE',
+            name: null,
+            columns: [
+              {
+                name: 'foo',
+                expression: false,
+                collation: null,
+                order: null,
+              },
+            ],
+            conflict: null,
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint check', function () {
+      const sql = 'CREATE TABLE "users" ("foo", CHECK ("foo" IS NULL))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'CHECK',
+            name: null,
+            expression: ['"foo"', 'IS', 'NULL'],
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint foreign key', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", FOREIGN KEY ("foo") REFERENCES "other")';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'FOREIGN KEY',
+            name: null,
+            columns: ['foo'],
+            references: {
+              table: 'other',
+              columns: [],
+              delete: null,
+              update: null,
+              match: null,
+              deferrable: null,
+            },
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint foreign key referenced column', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", FOREIGN KEY ("foo") REFERENCES "other" ("bar"))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'FOREIGN KEY',
+            name: null,
+            columns: ['foo'],
+            references: {
+              table: 'other',
+              columns: ['bar'],
+              delete: null,
+              update: null,
+              match: null,
+              deferrable: null,
+            },
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint foreign key multiple columns', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", FOREIGN KEY ("foo", "baz") REFERENCES "other" ("bar", "lar"))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'FOREIGN KEY',
+            name: null,
+            columns: ['foo', 'baz'],
+            references: {
+              table: 'other',
+              columns: ['bar', 'lar'],
+              delete: null,
+              update: null,
+              match: null,
+              deferrable: null,
+            },
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint foreign key on delete', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", FOREIGN KEY ("foo") REFERENCES "other" ON DELETE SET NULL)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'FOREIGN KEY',
+            name: null,
+            columns: ['foo'],
+            references: {
+              table: 'other',
+              columns: [],
+              delete: 'SET NULL',
+              update: null,
+              match: null,
+              deferrable: null,
+            },
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint foreign key on update', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", FOREIGN KEY ("foo") REFERENCES "other" ON UPDATE CASCADE)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'FOREIGN KEY',
+            name: null,
+            columns: ['foo'],
+            references: {
+              table: 'other',
+              columns: [],
+              delete: null,
+              update: 'CASCADE',
+              match: null,
+              deferrable: null,
+            },
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint foreign key match', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", FOREIGN KEY ("foo") REFERENCES "other" MATCH FULL)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'FOREIGN KEY',
+            name: null,
+            columns: ['foo'],
+            references: {
+              table: 'other',
+              columns: [],
+              delete: null,
+              update: null,
+              match: 'FULL',
+              deferrable: null,
+            },
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint foreign key deferrable', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", FOREIGN KEY ("foo") REFERENCES "other" NOT DEFERRABLE INITIALLY DEFERRED)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'FOREIGN KEY',
+            name: null,
+            columns: ['foo'],
+            references: {
+              table: 'other',
+              columns: [],
+              delete: null,
+              update: null,
+              match: null,
+              deferrable: {
+                not: true,
+                initially: 'DEFERRED',
+              },
+            },
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint foreign key all', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", FOREIGN KEY ("foo") REFERENCES "other" ("bar") ON DELETE RESTRICT ON UPDATE NO ACTION MATCH PARTIAL DEFERRABLE)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'FOREIGN KEY',
+            name: null,
+            columns: ['foo'],
+            references: {
+              table: 'other',
+              columns: ['bar'],
+              delete: 'RESTRICT',
+              update: 'NO ACTION',
+              match: 'PARTIAL',
+              deferrable: {
+                not: false,
+                initially: null,
+              },
+            },
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint named', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", CONSTRAINT "primary_constraint" PRIMARY KEY ("foo"))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'PRIMARY KEY',
+            name: 'primary_constraint',
+            columns: [
+              {
+                name: 'foo',
+                expression: false,
+                collation: null,
+                order: null,
+              },
+            ],
+            conflict: null,
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('table constraint multiple', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo", PRIMARY KEY ("foo", "baz" DESC) ON CONFLICT IGNORE, CHECK ("foo" IS NULL), CONSTRAINT "check_42" CHECK (count(foo) < 42 AND bar = 42), CONSTRAINT "unique_bar" UNIQUE ("bar"), FOREIGN KEY ("bar") REFERENCES "other" ("foo") ON DELETE SET DEFAULT ON UPDATE SET DEFAULT DEFERRABLE INITIALLY IMMEDIATE, CONSTRAINT "foreign_other_multiple" FOREIGN KEY ("bar", "lar") REFERENCES "other" MATCH SIMPLE NOT DEFERRABLE)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'PRIMARY KEY',
+            name: null,
+            columns: [
+              {
+                name: 'foo',
+                expression: false,
+                collation: null,
+                order: null,
+              },
+              {
+                name: 'baz',
+                expression: false,
+                collation: null,
+                order: 'DESC',
+              },
+            ],
+            conflict: 'IGNORE',
+          },
+          {
+            type: 'CHECK',
+            name: null,
+            expression: ['"foo"', 'IS', 'NULL'],
+          },
+          {
+            type: 'CHECK',
+            name: 'check_42',
+            expression: ['count', ['foo'], '<', '42', 'AND', 'bar', '=', '42'],
+          },
+          {
+            type: 'UNIQUE',
+            name: 'unique_bar',
+            columns: [
+              {
+                name: 'bar',
+                expression: false,
+                collation: null,
+                order: null,
+              },
+            ],
+            conflict: null,
+          },
+          {
+            type: 'FOREIGN KEY',
+            name: null,
+            columns: ['bar'],
+            references: {
+              table: 'other',
+              columns: ['foo'],
+              delete: 'SET DEFAULT',
+              update: 'SET DEFAULT',
+              match: null,
+              deferrable: {
+                not: false,
+                initially: 'IMMEDIATE',
+              },
+            },
+          },
+          {
+            type: 'FOREIGN KEY',
+            name: 'foreign_other_multiple',
+            columns: ['bar', 'lar'],
+            references: {
+              table: 'other',
+              columns: [],
+              delete: null,
+              update: null,
+              match: 'SIMPLE',
+              deferrable: {
+                not: true,
+                initially: null,
+              },
+            },
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('column definition multiple table constraint multiple', function () {
+      const sql =
+        'CREATE TABLE "users" ("primary_column" BLOB CONSTRAINT "primary_constraint" PRIMARY KEY DESC ON CONFLICT ROLLBACK AUTOINCREMENT, "not_column" DOUBLE PRECISION NOT NULL ON CONFLICT FAIL, "unique_column" CONSTRAINT "unique_constraint" UNIQUE ON CONFLICT REPLACE, "check_column" CHECK ("foo" != 42), "default_column" TEXT DEFAULT NULL, "collate_column" CONSTRAINT "collate_constraint" COLLATE BINARY, "references_column" NUMERIC REFERENCES "other" ("baz", "bar", "lar") ON UPDATE SET NULL MATCH SIMPLE NOT DEFERRABLE, "as_column" CONSTRAINT "as_constraint" GENERATED ALWAYS AS (count(*)) STORED, PRIMARY KEY ("foo", "baz" DESC) ON CONFLICT IGNORE, CHECK ("foo" IS NULL), CONSTRAINT "check_42" CHECK (count(foo) < 42 AND bar = 42), CONSTRAINT "unique_bar" UNIQUE ("bar"), FOREIGN KEY ("bar") REFERENCES "other" ("foo") ON DELETE SET DEFAULT ON UPDATE SET DEFAULT DEFERRABLE INITIALLY IMMEDIATE, CONSTRAINT "foreign_other_multiple" FOREIGN KEY ("bar", "lar") REFERENCES "other" MATCH SIMPLE NOT DEFERRABLE)';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'primary_column',
+            type: 'BLOB',
+            constraints: {
+              primary: {
+                name: 'primary_constraint',
+                order: 'DESC',
+                conflict: 'ROLLBACK',
+                autoincrement: true,
+              },
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'not_column',
+            type: 'DOUBLE PRECISION',
+            constraints: {
+              primary: null,
+              not: {
+                name: null,
+                conflict: 'FAIL',
+              },
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'unique_column',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: {
+                name: 'unique_constraint',
+                conflict: 'REPLACE',
+              },
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'check_column',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: {
+                name: null,
+                expression: ['"foo"', '!=', '42'],
+              },
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'default_column',
+            type: 'TEXT',
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: {
+                name: null,
+                value: 'NULL',
+                expression: false,
+              },
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'collate_column',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: {
+                name: 'collate_constraint',
+                collation: 'BINARY',
+              },
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'references_column',
+            type: 'NUMERIC',
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: {
+                name: null,
+                table: 'other',
+                columns: ['baz', 'bar', 'lar'],
+                delete: null,
+                update: 'SET NULL',
+                match: 'SIMPLE',
+                deferrable: {
+                  not: true,
+                  initially: null,
+                },
+              },
+              as: null,
+            },
+          },
+          {
+            name: 'as_column',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: {
+                name: 'as_constraint',
+                generated: true,
+                expression: ['count', ['*']],
+                mode: 'STORED',
+              },
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'PRIMARY KEY',
+            name: null,
+            columns: [
+              {
+                name: 'foo',
+                expression: false,
+                collation: null,
+                order: null,
+              },
+              {
+                name: 'baz',
+                expression: false,
+                collation: null,
+                order: 'DESC',
+              },
+            ],
+            conflict: 'IGNORE',
+          },
+          {
+            type: 'CHECK',
+            name: null,
+            expression: ['"foo"', 'IS', 'NULL'],
+          },
+          {
+            type: 'CHECK',
+            name: 'check_42',
+            expression: ['count', ['foo'], '<', '42', 'AND', 'bar', '=', '42'],
+          },
+          {
+            type: 'UNIQUE',
+            name: 'unique_bar',
+            columns: [
+              {
+                name: 'bar',
+                expression: false,
+                collation: null,
+                order: null,
+              },
+            ],
+            conflict: null,
+          },
+          {
+            type: 'FOREIGN KEY',
+            name: null,
+            columns: ['bar'],
+            references: {
+              table: 'other',
+              columns: ['foo'],
+              delete: 'SET DEFAULT',
+              update: 'SET DEFAULT',
+              match: null,
+              deferrable: {
+                not: false,
+                initially: 'IMMEDIATE',
+              },
+            },
+          },
+          {
+            type: 'FOREIGN KEY',
+            name: 'foreign_other_multiple',
+            columns: ['bar', 'lar'],
+            references: {
+              table: 'other',
+              columns: [],
+              delete: null,
+              update: null,
+              match: 'SIMPLE',
+              deferrable: {
+                not: true,
+                initially: null,
+              },
+            },
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('special character identifier', function () {
+      const sql =
+        'CREATE TABLE "$chem@"."users  table" (" ( ", "[`""foo""`]", " INTEGER ", " PRIMARY KEY ", " ) WITHOUT ROWID")';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: '$chem@',
+        table: 'users  table',
+        columns: [
+          {
+            name: ' ( ',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: '[`""foo""`]',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: ' INTEGER ',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: ' PRIMARY KEY ',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: ' ) WITHOUT ROWID',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast, wrap);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('no wrap', function () {
+      const sql =
+        'CREATE TABLE users (note, foo, CONSTRAINT foreign_constraint FOREIGN KEY (note, foo) REFERENCES other (baz, bar))';
+      const ast = {
+        temporary: false,
+        exists: false,
+        schema: null,
+        table: 'users',
+        columns: [
+          {
+            name: 'note',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+          {
+            name: 'foo',
+            type: null,
+            constraints: {
+              primary: null,
+              not: null,
+              unique: null,
+              check: null,
+              default: null,
+              collate: null,
+              references: null,
+              as: null,
+            },
+          },
+        ],
+        constraints: [
+          {
+            type: 'FOREIGN KEY',
+            name: 'foreign_constraint',
+            columns: ['note', 'foo'],
+            references: {
+              table: 'other',
+              columns: ['baz', 'bar'],
+              delete: null,
+              update: null,
+              match: null,
+              deferrable: null,
+            },
+          },
+        ],
+        rowid: false,
+      };
+
+      const parsed = parseCreateTable(sql);
+      const compiled = compileCreateTable(ast);
+
+      expect(parsed).to.deep.equal(ast);
+      expect(compiled).to.equal(sql);
+    });
+
+    it('ordering', function () {
+      const sql =
+        'CREATE TABLE "users" ("foo" TEXT REFERENCES "other" ("baz", "bar", "lar") MATCH PARTIAL ON UPDATE NO ACTION ON DELETE RESTRICT DEFERRABLE CHECK ("foo" != 42) GENERATED ALWAYS AS (count(*)) STORED UNIQUE ON CONFLICT REPLACE NOT NULL ON CONFLICT FAIL PRIMARY KEY DESC ON CONFLICT ROLLBACK AUTOINCREMENT DEFAULT NULL COLLATE BINARY)';
+      const newSql =
+        'CREATE TABLE "users" ("foo" TEXT PRIMARY KEY DESC ON CONFLICT ROLLBACK AUTOINCREMENT NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT REPLACE CHECK ("foo" != 42) DEFAULT NULL COLLATE BINARY REFERENCES "other" ("baz", "bar", "lar") ON DELETE RESTRICT ON UPDATE NO ACTION MATCH PARTIAL DEFERRABLE GENERATED ALWAYS AS (count(*)) STORED)';
+
+      const parsedSql = compileCreateTable(parseCreateTable(sql), wrap);
+
+      expect(parsedSql).to.equal(newSql);
+    });
+
+    it('lowercase', function () {
+      const sql =
+        'create table "users" ("primary_column" blob constraint "primary_constraint" primary key desc on conflict rollback autoincrement, "not_column" double precision not null on conflict fail, "unique_column" constraint "unique_constraint" unique on conflict replace, "check_column" check ("foo" != 42), "default_column" text default null, "collate_column" constraint "collate_constraint" collate binary, "references_column" numeric references "other" ("baz", "bar", "lar") on update set null match simple not deferrable, "as_column" constraint "as_constraint" generated always as (count(*)) stored, primary key ("foo", "baz" desc) on conflict ignore, check ("foo" is null), constraint "check_42" check (count(foo) < 42 AND bar = 42), constraint "unique_bar" unique ("bar"), foreign key ("bar") references "other" ("foo") on delete set default on update set default deferrable initially immediate, constraint "foreign_other_multiple" foreign key ("bar", "lar") references "other" match simple not deferrable)';
+      const newSql =
+        'CREATE TABLE "users" ("primary_column" blob CONSTRAINT "primary_constraint" PRIMARY KEY DESC ON CONFLICT ROLLBACK AUTOINCREMENT, "not_column" double precision NOT NULL ON CONFLICT FAIL, "unique_column" CONSTRAINT "unique_constraint" UNIQUE ON CONFLICT REPLACE, "check_column" CHECK ("foo" != 42), "default_column" text DEFAULT null, "collate_column" CONSTRAINT "collate_constraint" COLLATE binary, "references_column" numeric REFERENCES "other" ("baz", "bar", "lar") ON UPDATE SET NULL MATCH simple NOT DEFERRABLE, "as_column" CONSTRAINT "as_constraint" GENERATED ALWAYS AS (count(*)) STORED, PRIMARY KEY ("foo", "baz" DESC) ON CONFLICT IGNORE, CHECK ("foo" is null), CONSTRAINT "check_42" CHECK (count(foo) < 42 AND bar = 42), CONSTRAINT "unique_bar" UNIQUE ("bar"), FOREIGN KEY ("bar") REFERENCES "other" ("foo") ON DELETE SET DEFAULT ON UPDATE SET DEFAULT DEFERRABLE INITIALLY IMMEDIATE, CONSTRAINT "foreign_other_multiple" FOREIGN KEY ("bar", "lar") REFERENCES "other" MATCH simple NOT DEFERRABLE)';
+
+      const parsedSql = compileCreateTable(parseCreateTable(sql), wrap);
+
+      expect(parsedSql).to.equal(newSql);
+    });
+
+    it('whitespaces', function () {
+      const sql =
+        'CREATE  TABLE   "users  table"("foo",\t"bar"CHECK("foo"\n!=\t42),    CONSTRAINT\r\n"foreign_constraint" \t FOREIGN \n KEY("foo","bar")REFERENCES \r\n "other"("baz","bar"))';
+      const newSql =
+        'CREATE TABLE "users  table" ("foo", "bar" CHECK ("foo" != 42), CONSTRAINT "foreign_constraint" FOREIGN KEY ("foo", "bar") REFERENCES "other" ("baz", "bar"))';
+
+      const parsedSql = compileCreateTable(parseCreateTable(sql), wrap);
+
+      expect(parsedSql).to.equal(newSql);
+    });
+
+    it('wrap', function () {
+      const sql =
+        'CREATE TABLE "schema".users (`foo`, [bar], CONSTRAINT [foreign_constraint] FOREIGN KEY (foo, `bar`) REFERENCES other ([baz], "bar"))';
+      const newSql =
+        'CREATE TABLE "schema"."users" ("foo", "bar", CONSTRAINT "foreign_constraint" FOREIGN KEY ("foo", "bar") REFERENCES "other" ("baz", "bar"))';
+
+      const parsedSql = compileCreateTable(parseCreateTable(sql), wrap);
+
+      expect(parsedSql).to.equal(newSql);
+    });
+  });
 
   describe('create index', function () {
     it('basic', function () {

--- a/test/unit/schema-builder/sqlite3.js
+++ b/test/unit/schema-builder/sqlite3.js
@@ -943,7 +943,7 @@ describe('SQLite parser and compiler', function () {
 
     it('where', function () {
       const sql =
-        'CREATE INDEX "users_index" on "users" ("foo") where foo IS NOT NULL AND bar=42';
+        'CREATE INDEX "users_index" on "users" ("foo") where foo IS NOT NULL AND bar = 42';
       const ast = {
         unique: false,
         exists: false,
@@ -953,7 +953,7 @@ describe('SQLite parser and compiler', function () {
         columns: [
           { name: 'foo', expression: false, collation: null, order: null },
         ],
-        where: 'foo IS NOT NULL AND bar=42',
+        where: ['foo', 'IS', 'NOT', 'NULL', 'AND', 'bar', '=', '42'],
       };
 
       const parsed = parseCreateIndex(sql);
@@ -1010,7 +1010,7 @@ describe('SQLite parser and compiler', function () {
 
     it('column expression', function () {
       const sql =
-        'CREATE INDEX "users_index" on "users" (abs(foo), lower(baz) COLLATE RTRIM, "bar()" ASC)';
+        'CREATE INDEX "users_index" on "users" (abs(foo), random() COLLATE RTRIM, baz + bar ASC)';
       const ast = {
         unique: false,
         exists: false,
@@ -1019,20 +1019,20 @@ describe('SQLite parser and compiler', function () {
         table: 'users',
         columns: [
           {
-            name: 'abs(foo)',
+            name: ['abs', ['foo']],
             expression: true,
             collation: null,
             order: null,
           },
           {
-            name: 'lower(baz)',
+            name: ['random', []],
             expression: true,
             collation: 'RTRIM',
             order: null,
           },
           {
-            name: 'bar()',
-            expression: false,
+            name: ['baz', '+', 'bar'],
+            expression: true,
             collation: null,
             order: 'ASC',
           },
@@ -1049,12 +1049,12 @@ describe('SQLite parser and compiler', function () {
 
     it('special character identifier', function () {
       const sql =
-        'CREATE INDEX "$chema"."users index" on "use-rs" (" ( ", " COLLATE ", " ""foo"" " ASC, "``b a z``" DESC, "[[``""bar""``]]") where foo IS NOT NULL';
+        'CREATE INDEX "$chema"."users  index" on "use-rs" (" ( ", " COLLATE ", " ""foo"" " ASC, "``b a z``" DESC, "[[``""bar""``]]") where foo IS NOT NULL';
       const ast = {
         unique: false,
         exists: false,
         schema: '$chema',
-        index: 'users index',
+        index: 'users  index',
         table: 'use-rs',
         columns: [
           {
@@ -1088,7 +1088,7 @@ describe('SQLite parser and compiler', function () {
             order: null,
           },
         ],
-        where: 'foo IS NOT NULL',
+        where: ['foo', 'IS', 'NOT', 'NULL'],
       };
 
       const parsed = parseCreateIndex(sql);
@@ -1100,7 +1100,7 @@ describe('SQLite parser and compiler', function () {
 
     it('no wrap', function () {
       const sql =
-        'CREATE INDEX users_index on users (foo COLLATE BINARY ASC) where foo IS NOT NULL';
+        'CREATE INDEX users_index on users (note COLLATE BINARY ASC) where foo IS NOT NULL';
       const ast = {
         unique: false,
         exists: false,
@@ -1109,13 +1109,13 @@ describe('SQLite parser and compiler', function () {
         table: 'users',
         columns: [
           {
-            name: 'foo',
+            name: 'note',
             expression: false,
             collation: 'BINARY',
             order: 'ASC',
           },
         ],
-        where: 'foo IS NOT NULL',
+        where: ['foo', 'IS', 'NOT', 'NULL'],
       };
 
       const parsed = parseCreateIndex(sql);
@@ -1138,9 +1138,9 @@ describe('SQLite parser and compiler', function () {
 
     it('whitespaces', function () {
       const sql =
-        'CREATE  INDEX   "users_index"\non\t"users"("foo"    COLLATE\tBINARY\nASC)\r\nwhere     "foo"\nIS\tNOT\r\nNULL';
+        'CREATE  INDEX   "users  index"\non\t"users"("foo"    COLLATE\tBINARY\nASC)\r\nwhere     "foo"\n  IS\tNOT\r\nNULL';
       const newSql =
-        'CREATE INDEX "users_index" on "users" ("foo" COLLATE BINARY ASC) where "foo" IS NOT NULL';
+        'CREATE INDEX "users  index" on "users" ("foo" COLLATE BINARY ASC) where "foo" IS NOT NULL';
 
       const parsedSql = compileCreateIndex(parseCreateIndex(sql), wrap);
 

--- a/test/unit/schema-builder/sqlite3.js
+++ b/test/unit/schema-builder/sqlite3.js
@@ -83,20 +83,6 @@ describe('SQLite SchemaBuilder', function () {
     expect(expected).to.eql(_.map(tableSql, 'sql'));
   });
 
-  it('alter column not supported', function () {
-    try {
-      tableSql = client
-        .schemaBuilder()
-        .alterTable('users', function (table) {
-          table.string('email').notNull().alter();
-        })
-        .toSQL();
-      expect(false).to.eql('Should have thrown an error');
-    } catch (err) {
-      expect(err.message).to.eql('Sqlite does not support alter column.');
-    }
-  });
-
   it('drop table', function () {
     tableSql = client.schemaBuilder().dropTable('users').toSQL();
     equal(1, tableSql.length);


### PR DESCRIPTION
The approach I took to parse `CREATE INDEX` statements using regexes was unfortunately not flexible and robust enough to properly parse `CREATE TABLE` statements. I replaced it with a tokenizer and parser combinators. The grammar is based on the SQLite documentation.

Any idea where the `formatDefault()` function would fit? It is currently directly inside the `ColumnCompiler` class which doesn't feel right.