### PR TITLE
Convert produced statements to objects before querying

### DIFF
--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -223,11 +223,17 @@ class Runner {
       if (!query.statementsProducer) {
         return this.query(query);
       }
+
       const statements = await query.statementsProducer(
         undefined,
         this.connection
       );
-      return this.queryArray(statements);
+      const queryObjects = statements.map((statement) => ({
+        sql: statement,
+        bindings: query.bindings,
+      }));
+
+      return this.queryArray(queryObjects);
     }
 
     const results = [];


### PR DESCRIPTION
This is for consistency with how queries are passed to `queryArray()` without the statements producer.