### PR TITLE
Fix timeout method

### DIFF
--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -165,7 +165,6 @@ class Client_MySQL extends Client {
     const conn = await this.acquireRawConnection();
     try {
       return await this._query(conn, {
-        method: 'raw',
         sql: 'KILL QUERY ?',
         bindings: [connectionToKill.threadId],
         options: {},

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -162,16 +162,16 @@ class Client_MySQL extends Client {
   }
 
   async cancelQuery(connectionToKill) {
-    const conn = await this.acquireConnection();
+    const conn = await this.acquireRawConnection();
     try {
-      return await this.query(conn, {
+      return await this._query(conn, {
         method: 'raw',
         sql: 'KILL QUERY ?',
         bindings: [connectionToKill.threadId],
         options: {},
       });
     } finally {
-      await this.releaseConnection(conn);
+      await this.destroyRawConnection(conn);
     }
   }
 }

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -171,6 +171,9 @@ class Client_MySQL extends Client {
       });
     } finally {
       await this.destroyRawConnection(conn);
+      if (conn.__knex__disposed) {
+        this.logger.warn(`Connection Error: ${conn.__knex__disposed}`);
+      }
     }
   }
 }

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -242,7 +242,9 @@ class Client_PG extends Client {
     try {
       return await this._wrappedCancelQueryCall(conn, connectionToKill);
     } finally {
-      await this.destroyRawConnection(conn);
+      await this.destroyRawConnection(conn).catch((err) => {
+        this.logger.warn(`Connection Error: ${err}`);
+      });
     }
   }
   _wrappedCancelQueryCall(conn, connectionToKill) {

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -241,20 +241,20 @@ class Client_PG extends Client {
     // Purposely not putting timeout on `pg_cancel_backend` execution because erroring
     // early there would release the `connectionToKill` back to the pool with
     // a `KILL QUERY` command yet to finish.
-    const conn = await this.acquireConnection();
+    const conn = await this.acquireRawConnection();
 
     try {
       return await this._wrappedCancelQueryCall(conn, connectionToKill);
     } finally {
       // NOT returning this promise because we want to release the connection
       // in a non-blocking fashion
-      this.releaseConnection(conn);
+      this.destroyRawConnection(conn);
     }
   }
   _wrappedCancelQueryCall(conn, connectionToKill) {
-    return this.query(conn, {
+    return this._query(conn, {
       method: 'raw',
-      sql: 'SELECT pg_cancel_backend(?);',
+      sql: 'SELECT pg_cancel_backend($1);',
       bindings: [connectionToKill.processID],
       options: {},
     });

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -237,18 +237,12 @@ class Client_PG extends Client {
   }
 
   async cancelQuery(connectionToKill) {
-    // Error out if we can't acquire connection in time.
-    // Purposely not putting timeout on `pg_cancel_backend` execution because erroring
-    // early there would release the `connectionToKill` back to the pool with
-    // a `KILL QUERY` command yet to finish.
     const conn = await this.acquireRawConnection();
 
     try {
       return await this._wrappedCancelQueryCall(conn, connectionToKill);
     } finally {
-      // NOT returning this promise because we want to release the connection
-      // in a non-blocking fashion
-      this.destroyRawConnection(conn);
+      await this.destroyRawConnection(conn);
     }
   }
   _wrappedCancelQueryCall(conn, connectionToKill) {

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -253,7 +253,6 @@ class Client_PG extends Client {
   }
   _wrappedCancelQueryCall(conn, connectionToKill) {
     return this._query(conn, {
-      method: 'raw',
       sql: 'SELECT pg_cancel_backend($1);',
       bindings: [connectionToKill.processID],
       options: {},


### PR DESCRIPTION
Based on PR https://github.com/knex/knex/pull/2527 - rebased and added the fix for postgres too:

> KILL commands have to be sent on a seprate connection, and transaction Clients override acquireConnection to always return the same connection.
>
> Furthermore, it is plausible that some applications may never be able to Acquire a pooled connection for cancellation becuase a query which is Exceeding the timeout may coincidentally exhaust the connection pool.
>
> For example, if a DDL operation is blocking writes, a connection pool May be quickly exhaused by write operations.

Timeout cancellation during transaction is fixed by using `acquireRawConnection` and `_query` to bypass the transaction connection and cancel the query from a separate connection.

fixes #2211
