### PR TITLE
SQLite: made the constraint detection case-insensitive

### DIFF
--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -355,8 +355,8 @@ class SQLite3_DDL {
           .map((line) => line.trim())
           .filter((defLine) => {
             if (
-              defLine.startsWith('constraint') === false &&
-              defLine.includes('foreign key') === false
+              defLine.toLowerCase().startsWith('constraint') === false &&
+              defLine.toLowerCase().includes('foreign key') === false
             )
               return true;
 

--- a/test/integration2/schema/foreign-keys.spec.js
+++ b/test/integration2/schema/foreign-keys.spec.js
@@ -195,6 +195,32 @@ describe('Schema', () => {
               expect(err.message).to.include('constraint');
             }
           });
+
+          it('can drop added foreign keys in sqlite after a table rebuild', async () => {
+            if (!isSQLite(knex)) {
+              return;
+            }
+
+            await knex.schema.alterTable('foreign_keys_table_one', (table) => {
+              table
+                .foreign('fkey_three')
+                .references('foreign_keys_table_three.id');
+            });
+
+            await knex.schema.alterTable('foreign_keys_table_one', (table) => {
+              // In sqlite this rebuilds a new foreign_keys_table_one table
+              table.foreign('fkey_two').references('foreign_keys_table_two.id');
+            });
+
+            await knex.schema.alterTable('foreign_keys_table_one', (table) => {
+              table.dropForeign('fkey_three');
+            });
+
+            const fks = await knex.raw(
+              `PRAGMA foreign_key_list('foreign_keys_table_one');`
+            );
+            expect(fks.length).to.equal(1);
+          });
         });
       });
     });


### PR DESCRIPTION
Hey @kibertoad 👋  I'm Thibaut from [Ghost](https://github.com/TryGhost/), we're working on releasing Ghost 4.0 very soon but found a bug in knex that is blocking us, here is the fix for it! The best case scenario for us would be if this fix would land in knex `0.21` ❤️ 

The problem comes when using the `foreign` feature on SQLite.

The limitations of SQLite requires the creation of a temporary table, and the constraints are uppercased due to [this code](https://github.com/knex/knex/blob/0.21/lib/dialects/sqlite3/schema/ddl.js#L478-L489). This means it introduces constraints definitions in uppercase format (like `FOREIGN KEY`).
However the constraint detection is using `startsWith` or `includes` which are both case-sensitive.

This PR fixes this issue by lowercasing the definitions before searching for the keywords.