### PR TITLE
Fix SQLite not doing rollback when altering columns fails

### DIFF
--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -279,13 +279,9 @@ class SQLite3_DDL {
 
         const newTable = compileCreateTable(parsedTable, this.wrap);
 
-        return await this.generateAlterCommands(
-          newTable,
-          createIndices,
-          (row) => {
-            return row;
-          }
-        );
+        return this.alter(newTable, createIndices, (row) => {
+          return row;
+        });
       },
       { connection: this.connection }
     );

--- a/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
@@ -53,9 +53,9 @@ class TableCompiler_SQLite3 extends TableCompiler {
 
       this.pushQuery({
         sql: `PRAGMA table_info(${this.tableName()})`,
-        statementsProducer(pragma, connection) {
+        output(pragma) {
           return compiler.client
-            .ddl(compiler, pragma, connection)
+            .ddl(compiler, pragma, this.connection)
             .alterColumn(columnsInfo);
         },
       });

--- a/test/integration2/schema/alter.spec.js
+++ b/test/integration2/schema/alter.spec.js
@@ -144,7 +144,7 @@ describe('Schema', () => {
               );
             });
 
-            it('generates correct SQL commands when altering columns', async () => {
+            it.skip('generates correct SQL commands when altering columns', async () => {
               const builder = knex.schema.alterTable('alter_table', (table) => {
                 table.string('column_integer').alter();
               });


### PR DESCRIPTION
The statements produced by the statements producer are currently not executed inside a transaction, which means that the changes are not rolled back if an error occurs. This will be fixed by #4189, but I won't find the time to finish that PR before the `0.95.0` release. Once it's done, this change can be reverted.