### PR TITLE
fix: update ts.stub files to new TypeScript namespace

### DIFF
--- a/lib/migrations/migrate/stub/ts.stub
+++ b/lib/migrations/migrate/stub/ts.stub
@@ -1,4 +1,4 @@
-import * as Knex from "knex";
+import { Knex } from "knex";
 
 <% if (d.tableName) { %>
 export async function up(knex: Knex): Promise<Knex.SchemaBuilder> {

--- a/lib/migrations/seed/stub/ts.stub
+++ b/lib/migrations/seed/stub/ts.stub
@@ -1,4 +1,4 @@
-import * as Knex from "knex";
+import { Knex } from "knex";
 
 export async function seed(knex: Knex): Promise<void> {
     // Deletes ALL existing entries

--- a/test/jake-util/knexfile-ts/knexfile_migrations/20200131112749_one.ts
+++ b/test/jake-util/knexfile-ts/knexfile_migrations/20200131112749_one.ts
@@ -1,4 +1,4 @@
-import * as Knex from "../../../../knex";
+import { Knex } from "../../../..";
 
 
 export async function up(knex: Knex): Promise<any> {

--- a/test/jake-util/knexfile-ts/knexfile_migrations/20200131112753_two.ts
+++ b/test/jake-util/knexfile-ts/knexfile_migrations/20200131112753_two.ts
@@ -1,4 +1,4 @@
-import * as Knex from "../../../../knex";
+import { Knex } from "../../../..";
 
 
 export async function up(knex: Knex): Promise<any> {

--- a/test/jake-util/knexfile-ts/knexfile_migrations/20200131112757_three.ts
+++ b/test/jake-util/knexfile-ts/knexfile_migrations/20200131112757_three.ts
@@ -1,4 +1,4 @@
-import * as Knex from "../../../../knex";
+import { Knex } from "../../../..";
 
 
 export async function up(knex: Knex): Promise<any> {

--- a/test/jake-util/knexfile-ts/knexfile_migrations/20200131112801_four.ts
+++ b/test/jake-util/knexfile-ts/knexfile_migrations/20200131112801_four.ts
@@ -1,4 +1,4 @@
-import * as Knex from "../../../../knex";
+import { Knex } from "../../../..";
 
 
 export async function up(knex: Knex): Promise<any> {


### PR DESCRIPTION
Changed `ts.stub` files for migrations and seeds to reflect changes in 0.95, also documented in https://github.com/knex/knex/blob/master/UPGRADING.md#upgrading-to-version-0950
> `import { Knex } from 'knex' // this is a namespace, and a type of a knex object`

---

Also changed `test/jake-util/knexfile-ts/knexfile_migrations` files for the same reason, including an import path change from `<root>/knex.js` to `<root>`, as the node will automatically resolve the `<root>` import to what's in the `package.json#main` field, allowing TypeScript to do similar for `package.json#types` field.