### PR TITLE
[WIP] Unify db test helpers

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -17,6 +17,16 @@ const SUPPORTED_CLIENTS = Object.freeze(
   ].concat(Object.keys(CLIENT_ALIASES))
 );
 
+const DRIVER_NAMES = Object.freeze({
+  MsSQL: 'mssql',
+  MySQL: 'mysql',
+  MySQL2: 'mysql2',
+  Oracle: 'oracle',
+  PostgreSQL: 'pg',
+  Redshift: 'pg-redshift',
+  SQLite: 'sqlite3'
+});
+
 const POOL_CONFIG_OPTIONS = Object.freeze([
   'maxWaitingClients',
   'testOnBorrow',
@@ -41,4 +51,5 @@ module.exports = {
   SUPPORTED_CLIENTS,
   POOL_CONFIG_OPTIONS,
   COMMA_NO_PAREN_REGEX,
+  DRIVER_NAMES,
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -21,10 +21,10 @@ const DRIVER_NAMES = Object.freeze({
   MsSQL: 'mssql',
   MySQL: 'mysql',
   MySQL2: 'mysql2',
-  Oracle: 'oracle',
+  Oracle: 'oracledb',
   PostgreSQL: 'pg',
   Redshift: 'pg-redshift',
-  SQLite: 'sqlite3'
+  SQLite: 'sqlite3',
 });
 
 const POOL_CONFIG_OPTIONS = Object.freeze([

--- a/test/integration/datatype/bigint.js
+++ b/test/integration/datatype/bigint.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
+const { isMssql } = require('../../util/db-helpers');
 
 module.exports = function (knex) {
   const bigintTimestamp = 1464294366973;
@@ -9,7 +10,7 @@ module.exports = function (knex) {
   const negativeUnsafeBigint = -99071992547409911;
 
   it('#test number mssql should not allow unsafe bigint', function () {
-    if (!/mssql/i.test(knex.client.driverName)) {
+    if (!isMssql(knex)) {
       return Promise.resolve();
     }
     const constraintName = 'pk_id';
@@ -92,7 +93,7 @@ module.exports = function (knex) {
   });
 
   it('#1781 - decimal value must not be converted to integer', function () {
-    if (!/mssql/i.test(knex.client.driverName)) {
+    if (!isMssql(knex)) {
       return this.skip();
     }
 

--- a/test/integration/datatype/decimal.js
+++ b/test/integration/datatype/decimal.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const { expect } = require('chai');
+const { isMssql } = require('../../util/db-helpers');
 
 module.exports = function (knex) {
   it('#test decimal mssql should allow large numbers', function () {
     // https://github.com/tediousjs/tedious/issues/1058
-    if (!/mssql/i.test(knex.client.driverName)) {
+    if (!isMssql(knex)) {
       return Promise.resolve();
     }
     const tableName = 'decimal_test';
@@ -34,7 +35,7 @@ module.exports = function (knex) {
       });
   });
   it('#test decimal mssql should allow numbers with precision of 10', function () {
-    if (!/mssql/i.test(knex.client.driverName)) {
+    if (!isMssql(knex)) {
       return Promise.resolve();
     }
     const tableName = 'decimal_test';
@@ -64,7 +65,7 @@ module.exports = function (knex) {
   });
   it('#test decimal mssql should allow numbers with precision of 16', function () {
     // Plain JavaScript cannot handle higher numbers without losing precision.
-    if (!/mssql/i.test(knex.client.driverName)) {
+    if (!isMssql(knex)) {
       return Promise.resolve();
     }
     const tableName = 'decimal_test';

--- a/test/integration/datatype/double.js
+++ b/test/integration/datatype/double.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const { expect } = require('chai');
+const { isMssql } = require('../../util/db-helpers');
 
 module.exports = function (knex) {
   it('#test decimal mssql should allow large numbers', function () {
     // https://github.com/tediousjs/tedious/issues/1058
-    if (!/mssql/i.test(knex.client.driverName)) {
+    if (!isMssql(knex)) {
       return Promise.resolve();
     }
     const tableName = 'decimal_test';
@@ -34,7 +35,7 @@ module.exports = function (knex) {
       });
   });
   it('#test decimal mssql should allow numbers with precision of 10', function () {
-    if (!/mssql/i.test(knex.client.driverName)) {
+    if (!isMssql(knex)) {
       return Promise.resolve();
     }
     const tableName = 'decimal_test';
@@ -64,7 +65,7 @@ module.exports = function (knex) {
   });
   it('#test decimal mssql should allow numbers with precision of 16', function () {
     // Plain JavaScript cannot handle higher numbers without losing precision.
-    if (!/mssql/i.test(knex.client.driverName)) {
+    if (!isMssql(knex)) {
       return Promise.resolve();
     }
     const tableName = 'decimal_test';

--- a/test/integration/logger.js
+++ b/test/integration/logger.js
@@ -2,6 +2,7 @@
 
 const { expect } = require('chai');
 const _ = require('lodash');
+const { DRIVER_NAMES } = require('../../lib/constants');
 const { isObject } = require('../../lib/util/is');
 
 const { TEST_TIMESTAMP } = require('../util/constants');
@@ -10,15 +11,7 @@ module.exports = function (knex) {
   const client = knex.client;
 
   // allowed driver name of a client
-  const allowedClients = [
-    'pg',
-    'mssql',
-    'mysql',
-    'mysql2',
-    'oracledb',
-    'pg-redshift',
-    'sqlite3',
-  ];
+  const allowedClients = Object.values(DRIVER_NAMES);
 
   function compareBindings(gotBindings, wantedBindings) {
     if (Array.isArray(wantedBindings)) {

--- a/test/integration/query/aggregate.js
+++ b/test/integration/query/aggregate.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { isMysql, isPostgreSQL } = require("../../util/db-helpers");
+
 module.exports = function (knex) {
   describe('Aggregate', function () {
     it('has a sum', function () {
@@ -521,8 +523,7 @@ module.exports = function (knex) {
         });
     });
 
-    const testWithMultipleColumns =
-      knex.client.driverName === 'mysql' || knex.client.driverName === 'pg';
+    const testWithMultipleColumns = isMysql(knex) || isPostgreSQL(knex);
 
     it('supports countDistinct with multiple columns', function () {
       if (!testWithMultipleColumns) {

--- a/test/integration/query/joins.js
+++ b/test/integration/query/joins.js
@@ -3,6 +3,7 @@
 const { expect } = require('chai');
 
 const { TEST_TIMESTAMP } = require('../../util/constants');
+const { isOracle, isMssql } = require('../../util/db-helpers');
 
 module.exports = function (knex) {
   describe('Joins', function () {
@@ -1791,7 +1792,7 @@ module.exports = function (knex) {
     });
 
     it('supports joins with overlapping column names', function () {
-      if (knex.client.driverName === 'oracledb') {
+      if (isOracle(knex)) {
         return this.skip();
       }
 
@@ -1890,7 +1891,7 @@ module.exports = function (knex) {
         });
     });
 
-    if (knex.client.driverName !== 'mssql') {
+    if (!isMssql(knex)) {
       it('Can use .using()', () => {
         const joinName = 'accounts_join_test';
 

--- a/test/integration/query/trigger-deletes.js
+++ b/test/integration/query/trigger-deletes.js
@@ -2,6 +2,7 @@
 
 const { expect } = require('chai');
 const { TEST_TIMESTAMP } = require('../../util/constants');
+const { isMssql } = require('../../util/db-helpers');
 
 module.exports = function (knex) {
   describe('Deletes with Triggers', function () {
@@ -9,7 +10,7 @@ module.exports = function (knex) {
     const triggerOptions = { includeTriggerModifications: true };
 
     before(function () {
-      if (knex.client.driverName !== 'mssql') {
+      if (!isMssql(knex)) {
         this.skip('This test is MSSQL only');
       }
     });
@@ -29,7 +30,7 @@ module.exports = function (knex) {
 
       // Create proper environment for tests
       before(async function () {
-        if (knex.client.driverName !== 'mssql') {
+        if (!isMssql(knex)) {
           this.skip('This test is MSSQL only');
         }
 
@@ -72,7 +73,7 @@ module.exports = function (knex) {
 
       // Clean-up test specific tables
       after(async function () {
-        if (knex.client.driverName !== 'mssql') {
+        if (!isMssql(knex)) {
           return;
         }
 
@@ -202,7 +203,7 @@ module.exports = function (knex) {
 
     describe('Re-test all Delete Functions with trigger option and returns', function () {
       before(async function () {
-        if (knex.client.driverName !== 'mssql') {
+        if (!isMssql(knex)) {
           this.skip('This test is MSSQL only');
         }
 

--- a/test/integration/query/trigger-updates.js
+++ b/test/integration/query/trigger-updates.js
@@ -2,6 +2,7 @@
 
 const { expect } = require('chai');
 const { TEST_TIMESTAMP } = require('../../util/constants');
+const { isMssql } = require('../../util/db-helpers');
 
 module.exports = function (knex) {
   describe('Updates with Triggers', function () {
@@ -9,7 +10,7 @@ module.exports = function (knex) {
     const triggerOptions = { includeTriggerModifications: true };
 
     before(function () {
-      if (knex.client.driverName !== 'mssql') {
+      if (!isMssql(knex)) {
         this.skip('This test is MSSQL only');
       }
     });
@@ -29,7 +30,7 @@ module.exports = function (knex) {
 
       // Create proper environment for tests
       before(async function () {
-        if (knex.client.driverName !== 'mssql') {
+        if (!isMssql(knex)) {
           this.skip('This test is MSSQL only');
         }
 
@@ -73,7 +74,7 @@ module.exports = function (knex) {
 
       // Clean-up test specific tables
       after(async function () {
-        if (knex.client.driverName !== 'mssql') {
+        if (!isMssql(knex)) {
           return;
         }
 
@@ -191,7 +192,7 @@ module.exports = function (knex) {
 
     describe('Re-test all Update Functions with trigger option and returns', function () {
       before(async function () {
-        if (knex.client.driverName !== 'mssql') {
+        if (!isMssql(knex)) {
           this.skip('This test is MSSQL only');
         }
 

--- a/test/integration/query/unions.js
+++ b/test/integration/query/unions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
+const { isMssql, isOracle, isPgBased, isSQLite } = require('../../util/db-helpers');
 
 module.exports = function (knex) {
   describe('unions', function () {
@@ -91,11 +92,7 @@ module.exports = function (knex) {
     });
   });
 
-  if (
-    ['pg', 'mssql', 'pg-redshift', 'oracledb', 'sqlite3'].includes(
-      knex.client.driverName
-    )
-  ) {
+  if (isPgBased(knex) || isMssql(knex) || isOracle(knex) || isSQLite(knex)) {
     describe('intersects', function () {
       before(function () {
         return knex.schema.createTable('intersect_test', function (t) {

--- a/test/integration/schema/foreign-keys.js
+++ b/test/integration/schema/foreign-keys.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const { isSQLite, isPostgreSQL } = require('../../util/db-helpers');
 
 module.exports = (knex) => {
   describe('Schema', () => {
@@ -63,12 +64,12 @@ module.exports = (knex) => {
           });
           throw new Error("Shouldn't reach this");
         } catch (err) {
-          if (knex.client.driverName === 'sqlite3') {
+          if (isSQLite(knex)) {
             expect(err.message).to.equal(
               `insert into \`foreign_keys_table_one\` (\`fkey_four_part1\`, \`fkey_four_part2\`, \`fkey_three\`, \`fkey_two\`) values ('a', 'b', 99, 9999) - SQLITE_CONSTRAINT: FOREIGN KEY constraint failed`
             );
           }
-          if (knex.client.driverName === 'pg') {
+          if (isPostgreSQL(knex)) {
             expect(err.message).to.equal(
               `insert into "foreign_keys_table_one" ("fkey_four_part1", "fkey_four_part2", "fkey_three", "fkey_two") values ($1, $2, $3, $4) - insert or update on table "foreign_keys_table_one" violates foreign key constraint "foreign_keys_table_one_fkey_two_foreign"`
             );

--- a/test/integration/suite.js
+++ b/test/integration/suite.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
+const { isOracle } = require('../util/db-helpers');
 
 module.exports = function (knex) {
   const sinon = require('sinon');
@@ -13,7 +14,7 @@ module.exports = function (knex) {
       return knex.destroy();
     });
 
-    if (this.driverName === 'oracledb') {
+    if (isOracle(knex)) {
       describe('Oracledb driver tests', function () {
         this.timeout(process.env.KNEX_TEST_TIMEOUT || 5000);
         require('./dialects/oracledb');

--- a/test/integration2/schema/primary-keys.spec.js
+++ b/test/integration2/schema/primary-keys.spec.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const { isMssql, isSQLite, isPostgreSQL } = require('../../util/db-helpers');
 const { getAllDbs, getKnexForDb } = require('../util/knex-instance-provider');
 
 describe('Schema', () => {
@@ -9,7 +10,7 @@ describe('Schema', () => {
 
         before(function () {
           knex = getKnexForDb(db);
-          if (knex.client.driverName === 'mssql') {
+          if (isMssql(knex)) {
             return this.skip();
           }
         });
@@ -42,12 +43,12 @@ describe('Schema', () => {
               await knex('primary_table').insert({ id_four: 1 });
               throw new Error(`Shouldn't reach this`);
             } catch (err) {
-              if (knex.client.driverName === 'sqlite3') {
+              if (isSQLite(knex)) {
                 expect(err.message).to.equal(
                   'insert into `primary_table` (`id_four`) values (1) - SQLITE_CONSTRAINT: UNIQUE constraint failed: primary_table.id_four'
                 );
               }
-              if (knex.client.driverName === 'pg') {
+              if (isPostgreSQL(knex)) {
                 expect(err.message).to.equal(
                   'insert into "primary_table" ("id_four") values ($1) - duplicate key value violates unique constraint "primary_table_pkey"'
                 );
@@ -65,12 +66,12 @@ describe('Schema', () => {
               await knex('primary_table').insert({ id_four: 1 });
               throw new Error(`Shouldn't reach this`);
             } catch (err) {
-              if (knex.client.driverName === 'sqlite3') {
+              if (isSQLite(knex)) {
                 expect(err.message).to.equal(
                   'insert into `primary_table` (`id_four`) values (1) - SQLITE_CONSTRAINT: UNIQUE constraint failed: primary_table.id_four'
                 );
               }
-              if (knex.client.driverName === 'pg') {
+              if (isPostgreSQL(knex)) {
                 expect(err.message).to.equal(
                   'insert into "primary_table" ("id_four") values ($1) - duplicate key value violates unique constraint "my_custom_constraint_name"'
                 );
@@ -96,12 +97,12 @@ describe('Schema', () => {
             try {
               await knex('primary_table').insert({ id_two: 1, id_three: 1 });
             } catch (err) {
-              if (knex.client.driverName === 'sqlite3') {
+              if (isSQLite(knex)) {
                 expect(err.message).to.equal(
                   'insert into `primary_table` (`id_three`, `id_two`) values (1, 1) - SQLITE_CONSTRAINT: UNIQUE constraint failed: primary_table.id_two, primary_table.id_three'
                 );
               }
-              if (knex.client.driverName === 'pg') {
+              if (isPostgreSQL(knex)) {
                 expect(err.message).to.equal(
                   'insert into "primary_table" ("id_three", "id_two") values ($1, $2) - duplicate key value violates unique constraint "primary_table_pkey"'
                 );
@@ -124,12 +125,12 @@ describe('Schema', () => {
             try {
               await knex('primary_table').insert({ id_two: 1, id_three: 1 });
             } catch (err) {
-              if (knex.client.driverName === 'sqlite3') {
+              if (isSQLite(knex)) {
                 expect(err.message).to.equal(
                   'insert into `primary_table` (`id_three`, `id_two`) values (1, 1) - SQLITE_CONSTRAINT: UNIQUE constraint failed: primary_table.id_two, primary_table.id_three'
                 );
               }
-              if (knex.client.driverName === 'pg') {
+              if (isPostgreSQL(knex)) {
                 expect(err.message).to.equal(
                   'insert into "primary_table" ("id_three", "id_two") values ($1, $2) - duplicate key value violates unique constraint "my_custom_constraint_name"'
                 );

--- a/test/tape/crossdb-compatibility.js
+++ b/test/tape/crossdb-compatibility.js
@@ -1,6 +1,7 @@
 'use strict';
 const tape = require('tape');
 const { expect } = require('chai');
+const { isOracle } = require('../util/db-helpers');
 
 /**
  * Collection of tests for making sure that certain features are cross database compatible
@@ -8,7 +9,7 @@ const { expect } = require('chai');
 module.exports = function (knex) {
   const driverName = knex.client.driverName;
 
-  if (driverName === 'oracledb') {
+  if (isOracle(knex)) {
     // TODO: FIX ORACLE TO WORK THE SAME WAY WITH OTHER DIALECTS IF POSSIBLE
     return;
   }

--- a/test/tape/stream.js
+++ b/test/tape/stream.js
@@ -2,9 +2,10 @@
 
 const tape = require('tape');
 const stream = require('stream');
+const { isPostgreSQL } = require('../util/db-helpers');
 
 module.exports = function (knex) {
-  if (knex.client.driverName === 'pg') {
+  if (isPostgreSQL(knex)) {
     tape('it streams properly in postgres', function (t) {
       const w = new stream.Writable({
         objectMode: true,

--- a/test/tape/transactions.js
+++ b/test/tape/transactions.js
@@ -2,6 +2,7 @@
 const harness = require('./harness');
 const tape = require('tape');
 const JSONStream = require('JSONStream');
+const { isOracle, isMssql, isPostgreSQL } = require('../util/db-helpers');
 
 module.exports = function (knex) {
   tape(knex.client.driverName + ' - transactions: before', function (t) {
@@ -51,11 +52,7 @@ module.exports = function (knex) {
     } finally {
       // BEGIN, INSERT, ROLLBACK
       // oracle & mssql: BEGIN & ROLLBACK not reported as queries
-      const expectedQueryCount =
-        knex.client.driverName === 'oracledb' ||
-        knex.client.driverName === 'mssql'
-          ? 1
-          : 3;
+      const expectedQueryCount = isOracle(knex) || isMssql(knex) ? 1 : 3;
 
       t.equal(
         trxQueryCount,
@@ -87,11 +84,7 @@ module.exports = function (knex) {
     } finally {
       // BEGIN, ROLLBACK
       // oracle & mssql: BEGIN & ROLLBACK not reported as queries
-      const expectedQueryCount =
-        knex.client.driverName === 'oracledb' ||
-        knex.client.driverName === 'mssql'
-          ? 0
-          : 2;
+      const expectedQueryCount = isOracle(knex) || isMssql(knex) ? 0 : 2;
 
       t.equal(
         trxQueryCount,
@@ -147,11 +140,7 @@ module.exports = function (knex) {
       // trx1: BEGIN, INSERT, ROLLBACK
       // trx2: SAVEPOINT, INSERT, SELECT, ROLLBACK TO SAVEPOINT
       // oracle & mssql: BEGIN & ROLLBACK not reported as queries
-      let expectedTrx1QueryCount =
-        knex.client.driverName === 'oracledb' ||
-        knex.client.driverName === 'mssql'
-          ? 1
-          : 3;
+      let expectedTrx1QueryCount = isOracle(knex) || isMssql(knex) ? 1 : 3;
       const expectedTrx2QueryCount = 4;
       expectedTrx1QueryCount += expectedTrx2QueryCount;
       t.equal(
@@ -206,11 +195,7 @@ module.exports = function (knex) {
       // trx1: BEGIN, INSERT, ROLLBACK
       // trx2: SAVEPOINT, ROLLBACK TO SAVEPOINT
       // oracle & mssql: BEGIN & ROLLBACK not reported as queries
-      let expectedTrx1QueryCount =
-        knex.client.driverName === 'oracledb' ||
-        knex.client.driverName === 'mssql'
-          ? 1
-          : 3;
+      let expectedTrx1QueryCount = isOracle(knex) || isMssql(knex) ? 1 : 3;
       const expectedTrx2QueryCount = 2;
       expectedTrx1QueryCount += expectedTrx2QueryCount;
       t.equal(
@@ -537,11 +522,7 @@ module.exports = function (knex) {
       );
     } finally {
       // oracle & mssql: BEGIN & ROLLBACK not reported as queries
-      const expectedQueryCount =
-        knex.client.driverName === 'oracledb' ||
-        knex.client.driverName === 'mssql'
-          ? 1
-          : 3;
+      const expectedQueryCount = isOracle(knex) || isMssql(knex) ? 1 : 3;
       t.equal(
         queryCount,
         expectedQueryCount,
@@ -565,7 +546,7 @@ module.exports = function (knex) {
     }
   });
 
-  if (knex.client.driverName === 'pg') {
+  if (isPostgreSQL(knex)) {
     // TODO: fix to work without old tables from mocha tests
     tape(
       'allows postgres ? operator in knex.raw() if no bindings given #519 and #888',
@@ -619,11 +600,7 @@ module.exports = function (knex) {
       // trx1: BEGIN, INSERT, ROLLBACK
       // trx2: SAVEPOINT, ROLLBACK TO SAVEPOINT
       // oracle & mssql: BEGIN & ROLLBACK not reported as queries
-      let expectedTrx1QueryCount =
-        knex.client.driverName === 'oracledb' ||
-        knex.client.driverName === 'mssql'
-          ? 1
-          : 3;
+      let expectedTrx1QueryCount = isOracle(knex) || isMssql(knex) ? 1 : 3;
       const expectedTrx2QueryCount = 2;
       expectedTrx1QueryCount += expectedTrx2QueryCount;
       t.equal(

--- a/test/util/constants.js
+++ b/test/util/constants.js
@@ -1,4 +1,8 @@
 // Test Constants
 const TEST_TIMESTAMP = new Date();
+const { DRIVER_NAMES } = require('../../lib/constants');
 
-module.exports = { TEST_TIMESTAMP };
+module.exports = {
+  TEST_TIMESTAMP,
+  DRIVER_NAMES,
+};

--- a/test/util/db-helpers.js
+++ b/test/util/db-helpers.js
@@ -1,35 +1,46 @@
+const { get } = require('lodash');
+const { DRIVER_NAMES: drivers } = require('../../lib/constants');
+
+function getDriverName(knex) {
+  return get(knex, 'client.driverName', '');
+}
+
 function isPostgreSQL(knex) {
-  return knex.client.driverName === 'pg';
+  return getDriverName(knex) === drivers.PostgreSQL;
+}
+
+function isPgBased(knex) {
+  return isOneOfDbs(knex, [drivers.PostgreSQL, drivers.Redshift]);
 }
 
 function isMssql(knex) {
-  return knex.client.driverName === 'mssql';
+  return getDriverName(knex) === drivers.MsSQL;
 }
 
 function isOracle(knex) {
-  return /oracle/i.test(knex.client.driverName);
+  return getDriverName(knex) === drivers.Oracle;
 }
 
 function isMysql(knex) {
-  return /mysql/i.test(knex.client.driverName);
+  return isOneOfDbs(knex, [drivers.MySQL, drivers.MySQL2]);
 }
 
 function isRedshift(knex) {
-  return knex.client.driverName === 'redshift';
+  return getDriverName(knex) === drivers.Redshift;
 }
 
 function isSQLite(knex) {
-  return knex.client.driverName === 'sqlite3';
+  return getDriverName(knex) === drivers.SQLite;
 }
 
 /**
  *
  * @param knex
- * @param {('pg'|'oracledb'|'mysql'|'mysql2'|'mssql'|'sqlite3')[]} supportedDbs - supported DB values
+ * @param {('pg'|'pg-redshift'|'oracledb'|'mysql'|'mysql2'|'mssql'|'sqlite3')[]} supportedDbs - supported DB values in DRIVER_NAMES from lib/constants.
  * @returns {*}
  */
 function isOneOfDbs(knex, supportedDbs) {
-  return supportedDbs.includes(knex.client.driverName);
+  return supportedDbs.includes(getDriverName(knex));
 }
 
 module.exports = {
@@ -38,6 +49,7 @@ module.exports = {
   isMssql,
   isOracle,
   isPostgreSQL,
+  isPgBased,
   isRedshift,
   isSQLite,
 };


### PR DESCRIPTION
Refactoring tests to use the functions in db-helpers rather than checking for the type of driver in `n` different ways (feedback on #4327).

This PR seemed large enough to break out into its own and do it in a standalone fashion before moving on with #4327. 

Also adding constants for driver names

When testing against the `driverName` there seems to be a number of
locations where the value being checked against may not be the actual
`driverName`. This may result in tests passing or failing incorrectly.

Adding a constant that has all current `driverName`s defined so that
matching can be done confidently and with tooling support. It's
effectively an enum.

Updating the tests to use the db-helpers, and having the db-helpers
utilize the drivers for correct naming should ensure all tests fire as 
expected and allow for easier refactoring.