### PR TITLE
Move QueryBuilder and KnexTimeoutError into knex namespace so that they are accessible at a runtime

### DIFF
--- a/lib/knex-builder/Knex.js
+++ b/lib/knex-builder/Knex.js
@@ -6,7 +6,7 @@ const makeKnex = require('./make-knex');
 const { KnexTimeoutError } = require('../util/timeout');
 const { resolveConfig } = require('./internal/config-resolver');
 
-function Knex(config) {
+function knex(config) {
   const { resolvedConfig, Dialect } = resolveConfig(...arguments);
 
   const newKnex = makeKnex(new Dialect(resolvedConfig));
@@ -17,15 +17,15 @@ function Knex(config) {
 }
 
 // Expose Client on the main Knex namespace.
-Knex.Client = Client;
+knex.Client = Client;
 
-Knex.KnexTimeoutError = KnexTimeoutError;
+knex.KnexTimeoutError = KnexTimeoutError;
 
-Knex.QueryBuilder = {
+knex.QueryBuilder = {
   extend: function (methodName, fn) {
     QueryBuilder.extend(methodName, fn);
     QueryInterface.push(methodName);
   },
 };
 
-module.exports = Knex;
+module.exports = knex;

--- a/test-tsd/querybuilder.test-d.ts
+++ b/test-tsd/querybuilder.test-d.ts
@@ -1,4 +1,4 @@
-import { Knex, knex } from '../types';
+import { knex } from '../types';
 import { expectType } from 'tsd';
 import { clientConfig } from './common';
 
@@ -18,7 +18,7 @@ declare module '../types' {
   }
 }
 
-Knex.QueryBuilder.extend('customSelect', function (value: number) {
+knex.QueryBuilder.extend('customSelect', function (value: number) {
   return this.select(this.client.raw(`${value} as value`));
 });
 

--- a/test-tsd/types.test-d.ts
+++ b/test-tsd/types.test-d.ts
@@ -5,7 +5,7 @@ import knexDefault, { Knex, knex } from '../types';
 import * as knexStar from '../types';
 import knexCjsImport = require('../');
 import QueryBuilder = Knex.QueryBuilder;
-import KnexTimeoutError = Knex.KnexTimeoutError;
+import KnexTimeoutError = knex.KnexTimeoutError;
 
 const knexCjs = require('../knex');
 const { knex: knexCjsNamed } = require('../knex');
@@ -16,8 +16,8 @@ expectType<Knex<any, unknown[]>>(knexStar.default({}));
 expectType<Knex<any, unknown[]>>(knexStar.knex({}));
 expectType<Knex<any, unknown[]>>(knexCjsImport.default({}));
 expectType<Knex<any, unknown[]>>(knexCjsImport.knex({}));
-expectType<KnexTimeoutError>(new KnexTimeoutError());
-expectType<KnexTimeoutError>(new KnexTimeoutError());
+expectType<KnexTimeoutError>(new knex.KnexTimeoutError());
+expectType<KnexTimeoutError>(new knex.KnexTimeoutError());
 
 // eslint-disable-next-line
 expectType<any>(knexCjs({}));

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -397,6 +397,20 @@ export declare function knex<TRecord extends {} = any, TResult = unknown[]>(
   config: Knex.Config | string
 ): Knex<TRecord, TResult>;
 
+export declare namespace knex {
+  class QueryBuilder {
+    static extend(
+      methodName: string,
+      fn: <TRecord extends {} = any, TResult = unknown[]>(
+        this: Knex.QueryBuilder<TRecord, TResult>,
+        ...args: any[]
+      ) => Knex.QueryBuilder<TRecord, TResult>
+    ): void;
+  }
+
+  export class KnexTimeoutError extends Error {}
+}
+
 export declare namespace Knex {
   //
   // Utility Types
@@ -2350,10 +2364,6 @@ interface MsSqlConnectionConfigBase {
     constraintName?: string;
   }
 
-  //
-  // Clients
-  //
-
   class Client extends events.EventEmitter {
     constructor(config: Config);
     config: Config;
@@ -2408,18 +2418,6 @@ interface MsSqlConnectionConfigBase {
     assertCanCancelQuery(): void;
     cancelQuery(): void;
   }
-
-  class QueryBuilder {
-    static extend(
-      methodName: string,
-      fn: <TRecord extends {} = any, TResult = unknown[]>(
-        this: QueryBuilder<TRecord, TResult>,
-        ...args: any[]
-      ) => QueryBuilder<TRecord, TResult>
-    ): void;
-  }
-
-  export class KnexTimeoutError extends Error {}
 }
 
 export default knex;


### PR DESCRIPTION
fixes #4357