### PR TITLE
[wip] fixes #4335: warn if negative offset was provided

### DIFF
--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -908,6 +908,8 @@ class Builder extends EventEmitter {
       const val = parseInt(value, 10);
       if (isNaN(val)) {
         this.client.logger.warn('A valid integer must be provided to offset');
+      } else if (val < 0) {
+        throw new Error(`A non-negative integer must be provided to offset.`);
       } else {
         this._single.offset = val;
       }

--- a/test/integration/query/selects.js
+++ b/test/integration/query/selects.js
@@ -156,6 +156,21 @@ module.exports = function (knex) {
         });
     });
 
+    it('#4335 - should throw an error when negative offset provided', function (ok) {
+      try {
+        knex.from('accounts').limit(20).offset(-20);
+        throw new Error('no error was thrown for negative offset!');
+      } catch (error) {
+        if (
+          error.message === 'A non-negative integer must be provided to offset.'
+        ) {
+          ok();
+        } else {
+          throw error;
+        }
+      }
+    });
+
     it('#4199 - adheres to hint comments', async function () {
       const expectedErrors = {
         mysql: {


### PR DESCRIPTION
HI. I started working on this. I faced some challenges I need advice on.

- First of all, I'm only familiar with `mysql`. Is negative offset invalid for all kind of databases? Should I consider database type?
- Then I found `offset` function in `querybuilder.js` file, and extended an existing condition:
![image](https://user-images.githubusercontent.com/5755214/110539889-0e6cd880-813b-11eb-9662-4fc4d8f9238b.png)
- The problem with above solution was that negative offset values resulted in a warn log (orange in my case) and were automatically omitted (or converted to `zero`). I thought this automatic omitting makes bad logic/behavior is user's code hidden or hard-to-debug.
-  Later I  thought maybe it's not a bad idea if we threw an error in case of negative offset
![image](https://user-images.githubusercontent.com/5755214/110539388-6fe07780-813a-11eb-815e-a0135452cd3a.png)
- The above solution can be and not be a breaking change. It can be a breaking change, because it did not use to throw an error, but can not be thought of a breaking change because the query would result to an exception throw (by the database) later anyway.
- The final solution I came up with is this:
![image](https://user-images.githubusercontent.com/5755214/110541589-36f5d200-813d-11eb-9c6f-0675698e2602.png)

I thought if it would be a nice idea if we warn user that this behavior (providing `negative` value to `offset`) would be deprecated and throw in a future version?

Thanks if you really read all that :hearts: 