### PR TITLE
fix TypeScript migration stub after 0.95.0 changes

### DIFF
--- a/lib/migrations/migrate/stub/ts.stub
+++ b/lib/migrations/migrate/stub/ts.stub
@@ -1,8 +1,8 @@
-import * as Knex from "knex";
+import { Knex } from "knex";
 
 <% if (d.tableName) { %>
 export async function up(knex: Knex): Promise<Knex.SchemaBuilder> {
-    return knex.schema.createTable("<%= d.tableName %>", (t: Knex.AlterTableBuilder) => {
+    return knex.schema.createTable("<%= d.tableName %>", (t) => {
         t.increments();
         t.timestamps();
     });

--- a/test-tsd/types.test-d.ts
+++ b/test-tsd/types.test-d.ts
@@ -24,6 +24,8 @@ expectType<any>(knexCjs({}));
 // eslint-disable-next-line
 expectType<any>(knexCjsNamed({}));
 
+knex({}).schema.createTable("table", (t: Knex.AlterTableBuilder) => {})
+
 const knexInstance = knexDefault(clientConfig);
 
 // ToDo remove this copy-pasted type after we can export it as a named properly


### PR DESCRIPTION
Release 0.95.0 changed how types have to be imported when using TypeScript. This PR fixes the migration stub so new migrations are created correctly.