### PR TITLE
[TypeScript] Allow config.client to be non-client instance

### DIFF
--- a/lib/knex-builder/internal/config-resolver.js
+++ b/lib/knex-builder/internal/config-resolver.js
@@ -23,8 +23,7 @@ function resolveConfig(config) {
   }
   // If user provided Client constructor as a parameter, use it
   else if (
-    typeof parsedConfig.client === 'function' &&
-    parsedConfig.client.prototype instanceof Client
+    typeof parsedConfig.client === 'function'
   ) {
     Dialect = parsedConfig.client;
   }


### PR DESCRIPTION
TypeScript makes it very hard to get typescript to correctly check the `instanceof Client` part of the statement.

See: https://github.com/Microsoft/TypeScript/wiki/FAQ#why-doesnt-extending-built-ins-like-error-array-and-map-work