### PR TITLE
feat #3678: support running multiple specific seed files

### DIFF
--- a/lib/migrations/seed/Seeder.js
+++ b/lib/migrations/seed/Seeder.js
@@ -28,10 +28,18 @@ class Seeder {
     this.config = this.setConfig(config);
     let files = await this._listAll();
     if (config && config.specific) {
-      files = files.filter((file) => path.basename(file) === config.specific);
-      if (files.length === 0) {
+      const seeds = [].concat(config.specific);
+      const map = files.reduce(
+        (cum, file) => ((cum[path.basename(file)] = file), cum),
+        {}
+      );
+      // Ensure that seed files are executed in the same order
+      // as specified in the command line, removing any invalid seeds
+      files = seeds.map((seed) => map[seed]).filter((seed) => seed);
+      if (files.length !== seeds.length) {
+        const invalidSeeds = seeds.filter((seed) => !map[seed]);
         throw new Error(
-          `Invalid argument provided: the specific seed "${config.specific}" does not exist.`
+          `Invalid argument provided: the specific seed(s) "${invalidSeeds.join()}" do(es) not exist.`
         );
       }
     }

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -4,7 +4,15 @@ const { expect } = require('chai');
 
 const _ = require('lodash');
 const { isString, isObject } = require('../../../lib/util/is');
-const { isPgBased, isMysql, isOracle, isPostgreSQL, isSQLite, isRedshift, isMssql } = require('../../util/db-helpers');
+const {
+  isPgBased,
+  isMysql,
+  isOracle,
+  isPostgreSQL,
+  isSQLite,
+  isRedshift,
+  isMssql,
+} = require('../../util/db-helpers');
 
 const wrapIdentifier = (value, wrap) => {
   return wrap(value ? value.toUpperCase() : value);
@@ -921,7 +929,12 @@ module.exports = (knex) => {
           .then(() => knex.schema.dropTable('test_table_numerics2')));
 
       it('allows alter column syntax', function () {
-        if (isSQLite(knex) || isRedshift(knex) || isMssql(knex) || isOracle(knex)) {
+        if (
+          isSQLite(knex) ||
+          isRedshift(knex) ||
+          isMssql(knex) ||
+          isOracle(knex)
+        ) {
           return;
         }
 


### PR DESCRIPTION
This PR provides an implementation for #3678 to enable running multiple specific seed files in the same order as specified in the terminal

```
knex seed:run --specific seed-filename-3.js --specific seed-filename-4.js
```
Should run seed `seed-filename-3.js` followed by `seed-filename-4.js`

See:
- The corresponding [Documentation PR](https://github.com/knex/documentation/pull/316)
- [Issue/feature Discussion](https://github.com/knex/knex/issues/3678)