### PR TITLE
Rework dropForeign to use new tokenized structure

### DIFF
--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -334,49 +334,40 @@ class SQLite3_DDL {
     );
   }
 
-  async dropForeign(columns, indexName) {
+  async dropForeign(columns, foreignKeyName) {
     return this.client.transaction(
       async (trx) => {
         this.trx = trx;
 
         const { createTable, createIndices } = await this.getTableSql();
 
-        const oneLineSql = createTable.replace(/\s+/g, ' ');
-        const matched = oneLineSql.match(/^CREATE TABLE\s+(\S+)\s*\((.*)\)/);
+        const parsedTable = parseCreateTable(createTable);
 
-        const defs = matched[2];
-
-        if (!defs) {
-          throw new Error('No column definitions in this statement!');
+        if (!foreignKeyName) {
+          parsedTable.columns = parsedTable.columns.map((column) => ({
+            ...column,
+            references: columns.includes(column.name)
+              ? null
+              : column.references,
+          }));
         }
 
-        const updatedDefs = defs
-          .split(COMMA_NO_PAREN_REGEX)
-          .map((line) => line.trim())
-          .filter((defLine) => {
-            if (
-              defLine.toLowerCase().startsWith('constraint') === false &&
-              defLine.toLowerCase().includes('foreign key') === false
-            )
-              return true;
-
-            if (indexName) {
-              if (defLine.includes(indexName)) return false;
-              return true;
-            } else {
-              const matched = defLine.match(/\(`([^)]+)`\)/);
-              const columnNames = matched[1].split(', ');
-
-              const unknownColumnIncludedCheck = (col) =>
-                !columns.includes(col);
-              return columnNames.every(unknownColumnIncludedCheck) === false;
+        parsedTable.constraints = parsedTable.constraints.filter(
+          (constraint) => {
+            if (foreignKeyName) {
+              return constraint.name !== foreignKeyName;
             }
-          })
-          .join(', ');
 
-        const newSql = oneLineSql.replace(defs, updatedDefs);
+            return (
+              constraint.columns.some((column) => columns.includes(column)) ===
+              false
+            );
+          }
+        );
 
-        return this.alter(newSql, createIndices, (row) => {
+        const newTable = compileCreateTable(parsedTable, this.wrap);
+
+        return this.alter(newTable, createIndices, (row) => {
           return row;
         });
       },


### PR DESCRIPTION
Fix dropForeign not working as expected in SQLite.  Uses the new setup introduced by @nickrum .

Fixes #4369, fixes https://github.com/directus/directus/issues/4489