### PR TITLE
nguymin4/update typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1737,6 +1737,7 @@ export declare namespace Knex {
     connection(connection: any): this;
     debug(enabled: boolean): this;
     transacting(trx: Transaction): this;
+    stream(): AsyncIterable<ArrayMember<T>>;
     stream(handler: (readable: stream.PassThrough) => any): Promise<any>;
     stream(
       options: Readonly<{ [key: string]: any }>,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1419,6 +1419,16 @@ export declare namespace Knex {
   interface TypePreservingAggregation<TRecord = any, TResult = unknown[], TValue = any> {
     <
       TKey extends keyof ResolveTableType<TRecord>,
+      TOptions extends { "as": string },
+      TResult2 = AggregationQueryResult<TResult, {
+        [k in TOptions["as"]]: ResolveTableType<TRecord>[TKey]
+      }>
+    >(
+      columnName: Readonly<TKey>,
+      options: Readonly<TOptions>
+    ): QueryBuilder<TRecord, TResult2>;
+    <
+      TKey extends keyof ResolveTableType<TRecord>,
       TResult2 = AggregationQueryResult<TResult, Dict<ResolveTableType<TRecord>[TKey]>>
     >(
       ...columnNames: readonly TKey[]

--- a/types/test.ts
+++ b/types/test.ts
@@ -1181,6 +1181,18 @@ const main = async () => {
   // $ExpectType Dict<any>
   await knexInstance.first().min('age').from<User>('users');
 
+  // $ExpectType ({ a: string | Date; } & { b: string | Date; })[]
+  await knexInstance<Ticket>('tickets')
+    .min('at', {as: 'a'})
+    .max('at', {as: 'b'});
+
+  // $ExpectType ({ dep: any; } & { a: any; } & { b: any; })[]
+  await knexInstance
+    .select({dep: 'departmentId'})
+    .min('age', {as: 'a'})
+    .max('age', {as: 'b'})
+    .from<User>('users');
+
   // $ExpectType ({ dep: any; } & { a?: any; } & { b?: any; })[]
   await knexInstance
     .select({dep: 'departmentId'})

--- a/types/test.ts
+++ b/types/test.ts
@@ -132,6 +132,9 @@ const main = async () => {
       [ null ]
   );
 
+  // $ExpectType AsyncIterable<User>
+  knexInstance<User>('users').select('*').stream();
+
   // $ExpectType User[]
   await knexInstance<User>('user').where('name', ['a', 'b', 'c']);
 


### PR DESCRIPTION
Update typings for
- `TypePreservingAggregation` with options  `as`. Issue https://github.com/knex/knex/issues/4165
```typescript
await knexInstance<User>('users')
    .min('age', {as: 'a'})
    .max('age', {as: 'b'});
```
- `stream()` AsyncInterable<T>
```typescript
const stream =  knexInstance<User>('users').select('*').stream()
for await (const user of stream) {
    // console.log(user)
}
```