### PR TITLE
Fix typing for increments and bigIncrements

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1806,8 +1806,14 @@ export declare namespace Knex {
   }
 
   interface TableBuilder {
-    increments(columnName?: string): ColumnBuilder;
-    bigIncrements(columnName?: string): ColumnBuilder;
+    increments(
+      columnName?: string,
+      options?: { primaryKey?: boolean }
+    ): ColumnBuilder;
+    bigIncrements(
+      columnName?: string,
+      options?: { primaryKey?: boolean }
+    ): ColumnBuilder;
     dropColumn(columnName: string): TableBuilder;
     dropColumns(...columnNames: string[]): TableBuilder;
     renameColumn(from: string, to: string): ColumnBuilder;


### PR DESCRIPTION
Fix types of `TableBuilder['increments']` and `TableBuilder['bigIncrements']` to allow the optional options object after the column name.