### PR TITLE
Add support for file open flags for sqlite3 

### DIFF
--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -63,23 +63,23 @@ class Client_SQLite3 extends Client {
   acquireRawConnection() {
     return new Promise((resolve, reject) => {
       // the default mode for sqlite3
-      let mode = this.driver.OPEN_READWRITE | this.driver.OPEN_CREATE;
+      let flags = this.driver.OPEN_READWRITE | this.driver.OPEN_CREATE;
 
-      if (this.connectionSettings.mode) {
-        if (!Array.isArray(this.connectionSettings.mode)) {
-          throw new Error(`Mode must be an array of strings`);
+      if (this.connectionSettings.flags) {
+        if (!Array.isArray(this.connectionSettings.flags)) {
+          throw new Error(`flags must be an array of strings`);
         }
-        this.connectionSettings.mode.forEach((_mode) => {
-          if (!_mode.startsWith('OPEN_') || !this.driver[_mode]) {
-            throw new Error(`Mode ${_mode} not supported by node-sqlite3`);
+        this.connectionSettings.flags.forEach((_flags) => {
+          if (!_flags.startsWith('OPEN_') || !this.driver[_flags]) {
+            throw new Error(`flags ${_flags} not supported by node-sqlite3`);
           }
-          mode = mode | this.driver[_mode];
+          flags = flags | this.driver[_flags];
         });
       }
 
       const db = new this.driver.Database(
         this.connectionSettings.filename,
-        mode,
+        flags,
         (err) => {
           if (err) {
             return reject(err);

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -62,8 +62,24 @@ class Client_SQLite3 extends Client {
   // Get a raw connection from the database, returning a promise with the connection object.
   acquireRawConnection() {
     return new Promise((resolve, reject) => {
+      // the default mode for sqlite3
+      let mode = this.driver.OPEN_READWRITE | this.driver.OPEN_CREATE;
+
+      if (this.connectionSettings.mode) {
+        if (!Array.isArray(this.connectionSettings.mode)) {
+          throw new Error(`Mode must be an array of strings`);
+        }
+        this.connectionSettings.mode.forEach((_mode) => {
+          if (!this.driver[_mode]) {
+            throw new Error(`Mode ${_mode} not supported by node-sqlite3`);
+          }
+          mode = mode | this.driver[_mode];
+        });
+      }
+
       const db = new this.driver.Database(
         this.connectionSettings.filename,
+        mode,
         (err) => {
           if (err) {
             return reject(err);

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -70,7 +70,7 @@ class Client_SQLite3 extends Client {
           throw new Error(`Mode must be an array of strings`);
         }
         this.connectionSettings.mode.forEach((_mode) => {
-          if (!this.driver[_mode]) {
+          if (!_mode.startsWith('OPEN_') || !this.driver[_mode]) {
             throw new Error(`Mode ${_mode} not supported by node-sqlite3`);
           }
           mode = mode | this.driver[_mode];

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -69,11 +69,11 @@ class Client_SQLite3 extends Client {
         if (!Array.isArray(this.connectionSettings.flags)) {
           throw new Error(`flags must be an array of strings`);
         }
-        this.connectionSettings.flags.forEach((_flags) => {
-          if (!_flags.startsWith('OPEN_') || !this.driver[_flags]) {
-            throw new Error(`flags ${_flags} not supported by node-sqlite3`);
+        this.connectionSettings.flags.forEach((_flag) => {
+          if (!_flag.startsWith('OPEN_') || !this.driver[_flag]) {
+            throw new Error(`flag ${_flag} not supported by node-sqlite3`);
           }
-          flags = flags | this.driver[_flags];
+          flags = flags | this.driver[_flag];
         });
       }
 

--- a/test/tape/knex.js
+++ b/test/tape/knex.js
@@ -67,14 +67,14 @@ test('it should use knex supported dialect', function (t) {
   knexObj.destroy();
 });
 
-test('it should support mode selection for sqlite3', function (t) {
+test('it should support open flags selection for sqlite3', function (t) {
   t.plan(1);
   const knexObj = knex({
     client: 'sqlite3',
     connection: {
       filename: 'file:memdb-test?mode=memory',
       // allow the filename to be interpreted as a URI
-      mode: ['OPEN_URI'],
+      flags: ['OPEN_URI'],
     },
   });
   // run a query so a connection is created
@@ -89,15 +89,15 @@ test('it should support mode selection for sqlite3', function (t) {
     });
 });
 
-test('it should error when invalid mode is selected for sqlite3', function (t) {
+test('it should error when invalid open flags are selected for sqlite3', function (t) {
   t.plan(2);
 
-  // Test invalid mode
+  // Test invalid flags
   let knexObj = knex({
     client: 'sqlite3',
     connection: {
       filename: ':memory:',
-      mode: ['NON_EXISTING'],
+      flags: ['NON_EXISTING'],
     },
   });
   // run a query so a connection is created
@@ -107,7 +107,7 @@ test('it should error when invalid mode is selected for sqlite3', function (t) {
       t.fail('Should not get here');
     })
     .catch((err) => {
-      t.equal(err.message, 'Mode NON_EXISTING not supported by node-sqlite3');
+      t.equal(err.message, 'flags NON_EXISTING not supported by node-sqlite3');
     })
     .finally(() => {
       knexObj.destroy();
@@ -118,7 +118,7 @@ test('it should error when invalid mode is selected for sqlite3', function (t) {
     client: 'sqlite3',
     connection: {
       filename: ':memory:',
-      mode: 'OPEN_URI',
+      flags: 'OPEN_URI',
     },
   });
   // run a query so a connection is created
@@ -128,7 +128,7 @@ test('it should error when invalid mode is selected for sqlite3', function (t) {
       t.fail('Should not get here');
     })
     .catch((err) => {
-      t.equal(err.message, 'Mode must be an array of strings');
+      t.equal(err.message, 'flags must be an array of strings');
     })
     .finally(() => {
       knexObj.destroy();

--- a/test/tape/knex.js
+++ b/test/tape/knex.js
@@ -107,7 +107,7 @@ test('it should error when invalid open flags are selected for sqlite3', functio
       t.fail('Should not get here');
     })
     .catch((err) => {
-      t.equal(err.message, 'flags NON_EXISTING not supported by node-sqlite3');
+      t.equal(err.message, 'flag NON_EXISTING not supported by node-sqlite3');
     })
     .finally(() => {
       knexObj.destroy();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2263,6 +2263,7 @@ interface MsSqlConnectionConfigBase {
   /** Used with SQLite3 adapter */
   interface Sqlite3ConnectionConfig {
     filename: string;
+    mode: string[];
     debug?: boolean;
     expirationChecker?(): boolean;
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2263,7 +2263,7 @@ interface MsSqlConnectionConfigBase {
   /** Used with SQLite3 adapter */
   interface Sqlite3ConnectionConfig {
     filename: string;
-    mode: string[];
+    flags?: string[];
     debug?: boolean;
     expirationChecker?(): boolean;
   }


### PR DESCRIPTION
With this pull request it should be possible to open a shared memory database without recompiling sqlite, which has quite a lot of use cases, especially in testing. It should for example allow [this](https://github.com/knex/knex/issues/1871#issuecomment-452342526) solution work even if sqlite3 is not compiled with the SQLITE_USE_URI=1 flag.

I set the default mode selection to the default of node-sqlite3 so all existing code should still work.

Link to documentation PR: https://github.com/knex/documentation/pull/320