### PR TITLE
fix: mistyping in TypeScript example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const config: Knex.Config = {
   connection: {
     filename: './data.db',
   },
-});
+};
 
 const knexInstance = knex(config);
 


### PR DESCRIPTION
Remove the extra ")" in TypeScript example.