### PR TITLE
Fixed error when running in browser. Dissabled Migrator and Seeder when running in browser.

### DIFF
--- a/lib/knex-builder/make-knex.js
+++ b/lib/knex-builder/make-knex.js
@@ -1,7 +1,5 @@
 const { EventEmitter } = require('events');
 
-const { Migrator } = require('../migrations/migrate/Migrator');
-const Seeder = require('../migrations/seed/Seeder');
 const FunctionHelper = require('./FunctionHelper');
 const QueryInterface = require('../query/method-constants');
 const merge = require('lodash/merge');
@@ -45,20 +43,6 @@ const KNEX_PROPERTY_DEFINITIONS = {
     configurable: true,
   },
 
-  migrate: {
-    get() {
-      return new Migrator(this);
-    },
-    configurable: true,
-  },
-
-  seed: {
-    get() {
-      return new Seeder(this);
-    },
-    configurable: true,
-  },
-
   fn: {
     get() {
       return new FunctionHelper(this.client);
@@ -66,6 +50,25 @@ const KNEX_PROPERTY_DEFINITIONS = {
     configurable: true,
   },
 };
+
+if (typeof window === 'undefined') {
+  const { Migrator } = require('../migrations/migrate/Migrator');
+  const Seeder = require('../migrations/seed/Seeder');
+
+  KNEX_PROPERTY_DEFINITIONS.migrate = {
+    get() {
+      return new Migrator(this);
+    },
+    configurable: true,
+  };
+
+  KNEX_PROPERTY_DEFINITIONS.seed = {
+    get() {
+      return new Seeder(this);
+    },
+    configurable: true,
+  };
+}
 
 // `knex` instances serve as proxies around `context` objects.  So, calling
 // any of these methods on the `knex` instance will forward the call to


### PR DESCRIPTION
Knex will now work correctly with the browser, fixes #4441.
make-knex.js checks if window is undefined before adding migrate and seed to KNEX_PROPERTY_DEFINITIONS.
closes #4441