### PR TITLE
CI: add Node 16 to version matrix

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [15.x, 14.x, 12.x, 10.x]
+        node-version: [16.x, 15.x, 14.x, 12.x, 10.x]
         database-type: [postgres, mysql, mssql, sqlite3]
 
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 15.x, 14.x, 12.x, 10.x]
+        node-version: [16.x, 14.x, 12.x, 10.x]
         database-type: [postgres, mysql, mssql, sqlite3]
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [15.x, 14.x, 12.x, 10.x]
+        node-version: [16.x, 15.x, 14.x, 12.x, 10.x]
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 15.x, 14.x, 12.x, 10.x]
+        node-version: [16.x, 14.x, 12.x, 10.x]
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Node 16 was released short time ago, and became the "current" version. Knex readme states that all Node versions 10+ are supported, but CI is not currently run for Node 16.

Adds Node 16 to version matrixes. Everything seems to pass just fine, as seen [here](https://github.com/stscoundrel/knex/pull/1)