### PR TITLE
Add RegExp to match unescaped single quotes

### DIFF
--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -17,6 +17,19 @@ class TableCompiler_MySQL extends TableCompiler {
       ? 'create table if not exists '
       : 'create table ';
     const { client } = this;
+
+    // Fixes possible single quotes on columns
+    for (let i = 0, l = columns.sql.length; i < l; i++) {
+      // Matches all of the single quotes that:
+      // - Doesn't come after a parentheses
+      // - Doesn't come before a parentheses
+      // - Doesn't come before a comma
+      // - Doesn't come before a space
+      // https://regexr.com/5spjb
+      const re = /(?<![(\s])(')(?![,)])/g;
+      columns.sql[i] = columns.sql[i].replace(re, "\\'");
+    }
+
     let conn = {};
     let sql =
       createStatement + this.tableName() + ' (' + columns.sql.join(', ') + ')';

--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -26,7 +26,7 @@ class TableCompiler_MySQL extends TableCompiler {
       // - Doesn't come before a comma
       // - Doesn't come before a space
       // https://regexr.com/5spjb
-      const re = /(?<![(\s])(')(?![,)])/g;
+      const re = /(?<![(\s\\])(')(?![,)])/g;
       columns.sql[i] = columns.sql[i].replace(re, "\\'");
     }
 


### PR DESCRIPTION
**Context**

There is a case where the MySQL dialect doesn't parse the query correctly. Here's an example:

```js
await knex.schema.createTable("test", (t) => {
  t.enu("foo", ["invalid's value", "valid value"]);
});
``` 

The lack of parsing on this context where a single quote is wrapped between double quotes was causing an SQL syntax error. This PR fixes this.

**How it was done**

Add a loop to match and escape single quotes to prevent SQL syntax errors.

Created a RegExp that matches only the single quotes that:

- Doesn't come after a parentheses
- Doesn't come before a parentheses
- Doesn't come before a comma
- Doesn't come before a space

If desired, please refer to https://regexr.com/5spjb to validate the behavior of the RegExp.

**Aditional Info**

It seems to be specific to the MySQL dialect. Reading the code for other dialects, I couldn't see any lack of validation for this specific scenario. 

Fixes #4481 