### PR TITLE
#4492: Support use of knex.ref().withSchema() in knex().columnInfo()

### DIFF
--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -3,6 +3,7 @@
 const identity = require('lodash/identity');
 const reduce = require('lodash/reduce');
 
+const Ref = require('../../../ref');
 const QueryCompiler = require('../../../query/querycompiler');
 const { wrapString } = require('../../../formatter/wrappingFormatter');
 
@@ -57,7 +58,7 @@ class QueryCompiler_PG extends QueryCompiler {
     };
   }
 
-  // Compiles an `update` query, allowing for a return value.
+  // Compiles an `delete` query, allowing for a return value.
   del() {
     const sql = super.del(...arguments);
     const { returning } = this.single;
@@ -172,11 +173,18 @@ class QueryCompiler_PG extends QueryCompiler {
   columnInfo() {
     const column = this.single.columnInfo;
     let schema = this.single.schema;
+    let table = this.single.table;
+
+    // Ref can define the tableName and schema
+    if (table instanceof Ref) {
+      schema = table._schema;
+      table = table.ref;
+    }
 
     // The user may have specified a custom wrapIdentifier function in the config. We
     // need to run the identifiers through that function, but not format them as
     // identifiers otherwise.
-    const table = this.client.customWrapIdentifier(this.single.table, identity);
+    table = this.client.customWrapIdentifier(table, identity);
 
     if (schema) {
       schema = this.client.customWrapIdentifier(schema, identity);
@@ -184,7 +192,7 @@ class QueryCompiler_PG extends QueryCompiler {
 
     let sql =
       'select * from information_schema.columns where table_name = ? and table_catalog = ?';
-    const bindings = [table, this.client.database()];
+    const bindings = [`${table}`, this.client.database()];
 
     if (schema) {
       sql += ' and table_schema = ?';

--- a/test/unit/dialects/postgres.js
+++ b/test/unit/dialects/postgres.js
@@ -149,4 +149,17 @@ describe('Postgres Unit Tests', function () {
       done();
     });
   });
+  it('Resolves Ref in columnInfo query', () => {
+    const knexPg = knex({
+      client: 'pg',
+    });
+
+    const sql = knexPg(knexPg.ref('test').withSchema('foo'))
+      .columnInfo()
+      .toSQL();
+    expect(sql.sql).to.equal(
+      'select * from information_schema.columns where table_name = ? and table_catalog = ? and table_schema = ?'
+    );
+    expect(sql.bindings).to.deep.equal(['test', undefined, 'foo']);
+  });
 });


### PR DESCRIPTION
Attempt to fix issue #4492 . Not an idea fix as it doesn't handle the various other things that can be passed to `knex()`. Probably needs something more like in `lib/query/queryCompiler.js:tableName()`