### PR TITLE
Allow empty onConflict to not specify conflicting columns

### DIFF
--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -76,10 +76,20 @@ class QueryCompiler_PG extends QueryCompiler {
   }
 
   _ignore(columns) {
-    return ` on conflict (${this.formatter.columnize(columns)}) do nothing`;
+    let sql = ' on conflict';
+    if (columns.length > 0) {
+      sql += ` (${this.formatter.columnize(columns)})`;
+    }
+    sql += ' do nothing';
+    return sql;
   }
 
   _merge(updates, columns, insert) {
+    if (columns.length === 0) {
+      throw new Error(
+        'A conflict target must be set when using ON CONFLICT DO UPDATE'
+      );
+    }
     let sql = ` on conflict (${this.formatter.columnize(
       columns
     )}) do update set `;

--- a/lib/dialects/sqlite3/query/sqlite-querycompiler.js
+++ b/lib/dialects/sqlite3/query/sqlite-querycompiler.js
@@ -131,13 +131,20 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
   }
 
   _ignore(columns) {
-    return ` on conflict (${this.formatter.columnize(columns)}) do nothing`;
+    let sql = ' on conflict';
+    if (columns.length > 0) {
+      sql += ` (${this.formatter.columnize(columns)})`;
+    }
+    sql += ' do nothing';
+    return sql;
   }
 
   _merge(updates, columns, insert) {
-    let sql = ` on conflict (${this.formatter.columnize(
-      columns
-    )}) do update set `;
+    let sql = ' on conflict';
+    if (columns.length > 0) {
+      sql += ` (${this.formatter.columnize(columns)})`;
+    }
+    sql += ' do update set ';
     if (updates && Array.isArray(updates)) {
       sql += updates
         .map((column) =>

--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -1138,7 +1138,7 @@ class Builder extends EventEmitter {
     if (typeof columns === 'string') {
       columns = [columns];
     }
-    return new OnConflictBuilder(this, columns || true);
+    return new OnConflictBuilder(this, columns || []);
   }
 
   // Delete


### PR DESCRIPTION
Both [postgres](https://www.postgresql.org/docs/9.5/sql-insert.html) and [sqllite](https://sqlite.org/lang_upsert.html) allow to not pass the conflicting columns. Right now knex doesn't allow this use case: if you pass nothing to onConflict a query like the following gets generated
```
... on conflict (true) ...
```
which of course fails because it expects a column named "true" to exist.

This PR adds support for this missing use case.

Note: TS types already allow not passing parameters to `onConflict`

CC'ing @nicoburns since he was the main author of this feature.