### PR TITLE
Fix error message when stream automatically destroyed

### DIFF
--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -68,13 +68,14 @@ class Runner {
       transform: (chunk, _, callback) => {
         callback(null, this.client.postProcessResponse(chunk, queryContext));
       },
-      destroy() {
+      destroy(err) {
         // For some reason destroy is not available for mssql on Node 14. Might be a problem with tedious: https://github.com/tediousjs/tedious/issues/1139
         if (queryStream && queryStream.destroy) {
-          queryStream.destroy(new Error('stream destroyed'));
+          queryStream.destroy(err);
         }
       },
     });
+
     stream.on('pipe', (qs) => {
       queryStream = qs;
     });


### PR DESCRIPTION
This PR addreses #4132 and simillar issues

Starting from 14.0.0 Node.js has autoDestroy: true for all readable and writable streams by default and this causes error when stream is getting destoyed after finish, because Knex was always passing error message despite this natural behaviour

All kudos to @leedm777 for solution