### PR TITLE
log error message

### DIFF
--- a/bin/utils/cli-config-utils.js
+++ b/bin/utils/cli-config-utils.js
@@ -59,6 +59,9 @@ function resolveEnvironmentConfig(opts, allConfigs, configFilePath) {
 
 function exit(text) {
   if (text instanceof Error) {
+    if (text.message) {
+      console.error(color.red(text.message));
+    }
     console.error(
       color.red(`${text.detail ? `${text.detail}\n` : ''}${text.stack}`)
     );


### PR DESCRIPTION
When `stack` and `detail` properties are not available, only `undefined` is printed in the console which makes it extremely difficult to diagnose the issue. This change logs `messsage` property if set

Can be replicated when using `envvar` lib  and  [UnsetVariableError](https://github.com/plaid/envvar/blob/master/index.js#L17  ) is [thrown](https://github.com/plaid/envvar/blob/master/index.js#L39)
