### PR TITLE
fix migrate:up for migrations disabling transactions

### DIFF
--- a/lib/migrations/migrate/Migrator.js
+++ b/lib/migrations/migrate/Migrator.js
@@ -113,7 +113,7 @@ class Migrator {
         }
         return value;
       })
-      .then(([all, completed]) => {
+      .then(async ([all, completed]) => {
         const newMigrations = getNewMigrations(
           this.config.migrationSource,
           all,
@@ -142,7 +142,7 @@ class Migrator {
           useTransaction:
             !migrationToRun ||
             this._useTransaction(
-              this.config.migrationSource.getMigration(migrationToRun)
+              await this.config.migrationSource.getMigration(migrationToRun)
             ),
         };
       })


### PR DESCRIPTION
    knex migrate:up <migration>

does not respect configuration

    export const config = { transaction: false }

due to treating the return value of getMigration as a value rather than a promise.

I could use advice on where to add tests for this behavior.