### PR TITLE
add ability to omit columns on an onConflict().ignore()

### DIFF
--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -76,6 +76,9 @@ class QueryCompiler_PG extends QueryCompiler {
   }
 
   _ignore(columns) {
+    if (columns === true) {
+      return ' on conflict do nothing';
+    }
     return ` on conflict (${this.formatter.columnize(columns)}) do nothing`;
   }
 

--- a/lib/dialects/sqlite3/query/sqlite-querycompiler.js
+++ b/lib/dialects/sqlite3/query/sqlite-querycompiler.js
@@ -131,6 +131,9 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
   }
 
   _ignore(columns) {
+    if (columns === true) {
+      return ' on conflict do nothing';
+    }
     return ` on conflict (${this.formatter.columnize(columns)}) do nothing`;
   }
 


### PR DESCRIPTION
pull request to handle #4552. Adds the ability to omit the column list for onConflict in postgres and sqlite3 (mysql currently only supports omitting the columns).

the column list is used as a proxy for whether an onConflict exists, so that's why it's true if there are no columns, we could try making it something more explicit like a symbol if we think there could be a problem.