### PR TITLE
#873 | implement delete with join

### DIFF
--- a/lib/dialects/mssql/query/mssql-querycompiler.js
+++ b/lib/dialects/mssql/query/mssql-querycompiler.js
@@ -244,12 +244,20 @@ class QueryCompiler_MSSQL extends QueryCompiler {
     const withSQL = this.with();
     const { tableName } = this;
     const wheres = this.where();
+    const joins = this.join();
     const { returning } = this.single;
+    const returningStr = returning
+      ? ` ${this._returning('del', returning, true)}`
+      : '';
+    const deleteSelector = joins ? `${tableName}${returningStr} ` : '';
     return {
       sql:
         withSQL +
-        `${this._buildTempTable(returning)}delete from ${tableName}` +
-        (returning ? ` ${this._returning('del', returning, true)}` : '') +
+        `${this._buildTempTable(
+          returning
+        )}delete ${deleteSelector}from ${tableName}` +
+        (!joins ? returningStr : '') +
+        (joins ? ` ${joins}` : '') +
         (wheres ? ` ${wheres}` : '') +
         (!returning
           ? this._returning('rowcount', '@@rowcount')
@@ -263,12 +271,19 @@ class QueryCompiler_MSSQL extends QueryCompiler {
     const withSQL = this.with();
     const { tableName } = this;
     const wheres = this.where();
+    const joins = this.join();
     const { returning } = this.single;
+    const returningStr = returning
+      ? ` ${this._returning('del', returning)}`
+      : '';
+    // returning needs to be before "from" when using join
+    const deleteSelector = joins ? `${tableName}${returningStr} ` : '';
     return {
       sql:
         withSQL +
-        `delete from ${tableName}` +
-        (returning ? ` ${this._returning('del', returning)}` : '') +
+        `delete ${deleteSelector}from ${tableName}` +
+        (!joins ? returningStr : '') +
+        (joins ? ` ${joins}` : '') +
         (wheres ? ` ${wheres}` : '') +
         (!returning ? this._returning('rowcount', '@@rowcount') : ''),
       returning: returning || '@@rowcount',

--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -730,9 +730,15 @@ class QueryCompiler {
     const { tableName } = this;
     const withSQL = this.with();
     const wheres = this.where();
+    const joins = this.join();
+    // When using joins, delete the "from" table values as a default
+    const deleteSelector = joins ? tableName + ' ' : '';
     return (
       withSQL +
-      `delete from ${this.single.only ? 'only ' : ''}${tableName}` +
+      `delete ${deleteSelector}from ${
+        this.single.only ? 'only ' : ''
+      }${tableName}` +
+      (joins ? ` ${joins}` : '') +
       (wheres ? ` ${wheres}` : '')
     );
   }

--- a/test/integration/query/deletes.js
+++ b/test/integration/query/deletes.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const { expect } = require('chai');
 const { TEST_TIMESTAMP } = require('../../util/constants');
+const { isSQLite, isPostgreSQL, isOracle } = require('../../util/db-helpers');
 
 module.exports = function (knex) {
   describe('Deletes', function () {
@@ -81,6 +83,62 @@ module.exports = function (knex) {
             ]
           );
         });
+    });
+
+    describe('Delete with join', function () {
+      it('should handle basic delete with join', async function () {
+        const query = knex('test_table_two')
+          .join('accounts', 'accounts.id', 'test_table_two.account_id')
+          .where({ 'accounts.email': 'test3@example.com' })
+          .del();
+        if (isSQLite(knex) || isPostgreSQL(knex) || isOracle(knex)) {
+          await expect(query).to.be.rejected;
+          return;
+        }
+        return query.testSql(function (tester) {
+          tester(
+            'mysql',
+            'delete `test_table_two` from `test_table_two` inner join `accounts` on `accounts`.`id` = `test_table_two`.`account_id` where `accounts`.`email` = ?',
+            ['test3@example.com'],
+            1
+          );
+          tester(
+            'mssql',
+            'delete [test_table_two] from [test_table_two] inner join [accounts] on [accounts].[id] = [test_table_two].[account_id] where [accounts].[email] = ?;select @@rowcount',
+            ['test3@example.com'],
+            1
+          );
+        });
+      });
+      it('should handle returning', async function () {
+        await knex('test_table_two').insert({
+          account_id: 4,
+          details: '',
+          status: 1,
+        });
+        const query = knex('test_table_two')
+          .join('accounts', 'accounts.id', 'test_table_two.account_id')
+          .where({ 'accounts.email': 'test4@example.com' })
+          .del('*');
+        if (isSQLite(knex) || isPostgreSQL(knex) || isOracle(knex)) {
+          await expect(query).to.be.rejected;
+          return;
+        }
+        return query.testSql(function (tester) {
+          tester(
+            'mysql',
+            'delete `test_table_two` from `test_table_two` inner join `accounts` on `accounts`.`id` = `test_table_two`.`account_id` where `accounts`.`email` = ?',
+            ['test4@example.com'],
+            1
+          );
+          tester(
+            'mssql',
+            'delete [test_table_two] output deleted.* from [test_table_two] inner join [accounts] on [accounts].[id] = [test_table_two].[account_id] where [accounts].[email] = ?',
+            ['test4@example.com'],
+            [{ id: 11, account_id: 4, details: '', status: 1, json_data: null }]
+          );
+        });
+      });
     });
   });
 };

--- a/test/integration/query/trigger-deletes.js
+++ b/test/integration/query/trigger-deletes.js
@@ -265,5 +265,19 @@ module.exports = function (knex) {
           });
       });
     });
+    it('should handle delete with join and trigger options', function () {
+      return knex('test_table_two')
+        .join('accounts', 'accounts.id', 'test_table_two.account_id')
+        .where({ 'accounts.email': 'test3@example.com' })
+        .del('*', triggerOptions)
+        .testSql(function (tester) {
+          tester(
+            'mssql',
+            'select top(0) [t].* into #out from [test_table_two] as t left join [test_table_two] on 0=1;delete [test_table_two] output deleted.* into #out from [test_table_two] inner join [accounts] on [accounts].[id] = [test_table_two].[account_id] where [accounts].[email] = ?; select * from #out; drop table #out;',
+            ['test3@example.com'],
+            [{ id: 3, account_id: 3, details: '', status: 1, json_data: null }]
+          );
+        });
+    });
   });
 };

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -177,8 +177,7 @@ describe('Custom identifier wrapping', () => {
           'select [users_wrapper_was_here].[foo_wrapper_was_here] as [bar_wrapper_was_here] from [schema_wrapper_was_here].[users_wrapper_was_here]',
         oracledb:
           'select "users_wrapper_was_here"."foo_wrapper_was_here" "bar_wrapper_was_here" from "schema_wrapper_was_here"."users_wrapper_was_here"',
-        pg:
-          'select "users_wrapper_was_here"."foo_wrapper_was_here" as "bar_wrapper_was_here" from "schema_wrapper_was_here"."users_wrapper_was_here"',
+        pg: 'select "users_wrapper_was_here"."foo_wrapper_was_here" as "bar_wrapper_was_here" from "schema_wrapper_was_here"."users_wrapper_was_here"',
         'pg-redshift':
           'select "users_wrapper_was_here"."foo_wrapper_was_here" as "bar_wrapper_was_here" from "schema_wrapper_was_here"."users_wrapper_was_here"',
         sqlite3:
@@ -203,32 +202,26 @@ describe('Custom identifier wrapping', () => {
         ),
       {
         mysql: {
-          sql:
-            'insert into `users_wrapper_was_here` (`email_wrapper_was_here`, `name_wrapper_was_here`) values (?, ?), (?, ?)',
+          sql: 'insert into `users_wrapper_was_here` (`email_wrapper_was_here`, `name_wrapper_was_here`) values (?, ?), (?, ?)',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         sqlite3: {
-          sql:
-            'insert into `users_wrapper_was_here` (`email_wrapper_was_here`, `name_wrapper_was_here`) select ? as `email_wrapper_was_here`, ? as `name_wrapper_was_here` union all select ? as `email_wrapper_was_here`, ? as `name_wrapper_was_here`',
+          sql: 'insert into `users_wrapper_was_here` (`email_wrapper_was_here`, `name_wrapper_was_here`) select ? as `email_wrapper_was_here`, ? as `name_wrapper_was_here` union all select ? as `email_wrapper_was_here`, ? as `name_wrapper_was_here`',
         },
         pg: {
-          sql:
-            'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (?, ?), (?, ?) returning "id_wrapper_was_here"',
+          sql: 'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (?, ?), (?, ?) returning "id_wrapper_was_here"',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         'pg-redshift': {
-          sql:
-            'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (?, ?), (?, ?)',
+          sql: 'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (?, ?), (?, ?)',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         mssql: {
-          sql:
-            'insert into [users_wrapper_was_here] ([email_wrapper_was_here], [name_wrapper_was_here]) output inserted.[id_wrapper_was_here] values (?, ?), (?, ?)',
+          sql: 'insert into [users_wrapper_was_here] ([email_wrapper_was_here], [name_wrapper_was_here]) output inserted.[id_wrapper_was_here] values (?, ?), (?, ?)',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         oracledb: {
-          sql:
-            'begin execute immediate \'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (:1, :2) returning "id_wrapper_was_here" into :3\' using ?, ?, out ?; execute immediate \'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (:1, :2) returning "id_wrapper_was_here" into :3\' using ?, ?, out ?;end;',
+          sql: 'begin execute immediate \'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (:1, :2) returning "id_wrapper_was_here" into :3\' using ?, ?, out ?; execute immediate \'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (:1, :2) returning "id_wrapper_was_here" into :3\' using ?, ?, out ?;end;',
           bindings: (bindings) => {
             expect(bindings.length).to.equal(6);
             expect(bindings[0]).to.equal('foo');
@@ -261,33 +254,27 @@ describe('Custom identifier wrapping', () => {
         ),
       {
         mysql: {
-          sql:
-            'insert into `users_wrapper_was_here` (`email_wrapper_was_here`, `name_wrapper_was_here`) values (?, ?), (?, ?)',
+          sql: 'insert into `users_wrapper_was_here` (`email_wrapper_was_here`, `name_wrapper_was_here`) values (?, ?), (?, ?)',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         sqlite3: {
-          sql:
-            'insert into `users_wrapper_was_here` (`email_wrapper_was_here`, `name_wrapper_was_here`) select ? as `email_wrapper_was_here`, ? as `name_wrapper_was_here` union all select ? as `email_wrapper_was_here`, ? as `name_wrapper_was_here`',
+          sql: 'insert into `users_wrapper_was_here` (`email_wrapper_was_here`, `name_wrapper_was_here`) select ? as `email_wrapper_was_here`, ? as `name_wrapper_was_here` union all select ? as `email_wrapper_was_here`, ? as `name_wrapper_was_here`',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         pg: {
-          sql:
-            'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (?, ?), (?, ?) returning "id_wrapper_was_here", "name_wrapper_was_here"',
+          sql: 'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (?, ?), (?, ?) returning "id_wrapper_was_here", "name_wrapper_was_here"',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         'pg-redshift': {
-          sql:
-            'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (?, ?), (?, ?)',
+          sql: 'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (?, ?), (?, ?)',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         mssql: {
-          sql:
-            'insert into [users_wrapper_was_here] ([email_wrapper_was_here], [name_wrapper_was_here]) output inserted.[id_wrapper_was_here], inserted.[name_wrapper_was_here] values (?, ?), (?, ?)',
+          sql: 'insert into [users_wrapper_was_here] ([email_wrapper_was_here], [name_wrapper_was_here]) output inserted.[id_wrapper_was_here], inserted.[name_wrapper_was_here] values (?, ?), (?, ?)',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         oracledb: {
-          sql:
-            'begin execute immediate \'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (:1, :2) returning "id_wrapper_was_here","name_wrapper_was_here" into :3, :4\' using ?, ?, out ?, out ?; execute immediate \'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (:1, :2) returning "id_wrapper_was_here","name_wrapper_was_here" into :3, :4\' using ?, ?, out ?, out ?;end;',
+          sql: 'begin execute immediate \'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (:1, :2) returning "id_wrapper_was_here","name_wrapper_was_here" into :3, :4\' using ?, ?, out ?, out ?; execute immediate \'insert into "users_wrapper_was_here" ("email_wrapper_was_here", "name_wrapper_was_here") values (:1, :2) returning "id_wrapper_was_here","name_wrapper_was_here" into :3, :4\' using ?, ?, out ?, out ?;end;',
           bindings: (bindings) => {
             expect(bindings.length).to.equal(8);
             expect(bindings[0]).to.equal('foo');
@@ -328,8 +315,7 @@ describe('Custom identifier wrapping', () => {
             'select [users_fancy_wrapper_was_here].[foo_fancy_wrapper_was_here] as [bar_fancy_wrapper_was_here] from [schema_fancy_wrapper_was_here].[users_fancy_wrapper_was_here]',
           oracledb:
             'select "users_fancy_wrapper_was_here"."foo_fancy_wrapper_was_here" "bar_fancy_wrapper_was_here" from "schema_fancy_wrapper_was_here"."users_fancy_wrapper_was_here"',
-          pg:
-            'select "users_fancy_wrapper_was_here"."foo_fancy_wrapper_was_here" as "bar_fancy_wrapper_was_here" from "schema_fancy_wrapper_was_here"."users_fancy_wrapper_was_here"',
+          pg: 'select "users_fancy_wrapper_was_here"."foo_fancy_wrapper_was_here" as "bar_fancy_wrapper_was_here" from "schema_fancy_wrapper_was_here"."users_fancy_wrapper_was_here"',
           sqlite3:
             'select `users_fancy_wrapper_was_here`.`foo_fancy_wrapper_was_here` as `bar_fancy_wrapper_was_here` from `schema_fancy_wrapper_was_here`.`users_fancy_wrapper_was_here`',
         },
@@ -350,8 +336,7 @@ describe('Custom identifier wrapping', () => {
             'select [col1_fancy_wrapper_was_here] as [a_fancy_wrapper_was_here] from [users_fancy_wrapper_was_here]',
           oracledb:
             'select "col1_fancy_wrapper_was_here" "a_fancy_wrapper_was_here" from "users_fancy_wrapper_was_here"',
-          pg:
-            'select "col1_fancy_wrapper_was_here" as "a_fancy_wrapper_was_here" from "users_fancy_wrapper_was_here"',
+          pg: 'select "col1_fancy_wrapper_was_here" as "a_fancy_wrapper_was_here" from "users_fancy_wrapper_was_here"',
           sqlite3:
             'select `col1_fancy_wrapper_was_here` as `a_fancy_wrapper_was_here` from `users_fancy_wrapper_was_here`',
         },
@@ -532,8 +517,7 @@ describe('QueryBuilder', () => {
       {
         mysql:
           'select `table1`.* as `bar`, (select `col1` as `a`, `col2` as `b` from `test` limit ?) as `subq` from `table` as `table1`, `table` as `table2`, (select * from `test` limit ?) as `subq`',
-        pg:
-          'select "table1".* as "bar", (select "col1" as "a", "col2" as "b" from "test" limit ?) as "subq" from "table" as "table1", "table" as "table2", (select * from "test" limit ?) as "subq"',
+        pg: 'select "table1".* as "bar", (select "col1" as "a", "col2" as "b" from "test" limit ?) as "subq" from "table" as "table1", "table" as "table2", (select * from "test" limit ?) as "subq"',
         sqlite3:
           'select `table1`.* as `bar`, (select `col1` as `a`, `col2` as `b` from `test` limit ?) as `subq` from `table` as `table1`, `table` as `table2`, (select * from `test` limit ?) as `subq`',
         oracledb:
@@ -823,8 +807,7 @@ describe('QueryBuilder', () => {
           bindings: ['foo@bar.com', 1],
         },
         mssql: {
-          sql:
-            'update [users] set [email] = ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [email] = ? where [id] = ?;select @@rowcount',
           bindings: ['foo@bar.com', 1],
         },
         'pg-redshift': {
@@ -1004,23 +987,19 @@ describe('QueryBuilder', () => {
         .whereNot({ first_name: 'Test', last_name: 'User' }),
       {
         mysql: {
-          sql:
-            'select * from `users` where not `first_name` = ? and not `last_name` = ?',
+          sql: 'select * from `users` where not `first_name` = ? and not `last_name` = ?',
           bindings: ['Test', 'User'],
         },
         mssql: {
-          sql:
-            'select * from [users] where not [first_name] = ? and not [last_name] = ?',
+          sql: 'select * from [users] where not [first_name] = ? and not [last_name] = ?',
           bindings: ['Test', 'User'],
         },
         pg: {
-          sql:
-            'select * from "users" where not "first_name" = ? and not "last_name" = ?',
+          sql: 'select * from "users" where not "first_name" = ? and not "last_name" = ?',
           bindings: ['Test', 'User'],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" where not "first_name" = ? and not "last_name" = ?',
+          sql: 'select * from "users" where not "first_name" = ? and not "last_name" = ?',
           bindings: ['Test', 'User'],
         },
       }
@@ -1034,8 +1013,7 @@ describe('QueryBuilder', () => {
       {
         mysql:
           "select * from `users` where not `first_name` = 'Test' and not `last_name` = 'User'",
-        pg:
-          'select * from "users" where not "first_name" = \'Test\' and not "last_name" = \'User\'',
+        pg: 'select * from "users" where not "first_name" = \'Test\' and not "last_name" = \'User\'',
         'pg-redshift':
           'select * from "users" where not "first_name" = \'Test\' and not "last_name" = \'User\'',
         mssql:
@@ -1111,23 +1089,19 @@ describe('QueryBuilder', () => {
         .andWhereBetween('id', [1, 2]),
       {
         mysql: {
-          sql:
-            'select * from `users` where `name` = ? and `id` between ? and ?',
+          sql: 'select * from `users` where `name` = ? and `id` between ? and ?',
           bindings: ['user1', 1, 2],
         },
         mssql: {
-          sql:
-            'select * from [users] where [name] = ? and [id] between ? and ?',
+          sql: 'select * from [users] where [name] = ? and [id] between ? and ?',
           bindings: ['user1', 1, 2],
         },
         pg: {
-          sql:
-            'select * from "users" where "name" = ? and "id" between ? and ?',
+          sql: 'select * from "users" where "name" = ? and "id" between ? and ?',
           bindings: ['user1', 1, 2],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" where "name" = ? and "id" between ? and ?',
+          sql: 'select * from "users" where "name" = ? and "id" between ? and ?',
           bindings: ['user1', 1, 2],
         },
       }
@@ -1143,23 +1117,19 @@ describe('QueryBuilder', () => {
         .andWhereNotBetween('id', [1, 2]),
       {
         mysql: {
-          sql:
-            'select * from `users` where `name` = ? and `id` not between ? and ?',
+          sql: 'select * from `users` where `name` = ? and `id` not between ? and ?',
           bindings: ['user1', 1, 2],
         },
         mssql: {
-          sql:
-            'select * from [users] where [name] = ? and [id] not between ? and ?',
+          sql: 'select * from [users] where [name] = ? and [id] not between ? and ?',
           bindings: ['user1', 1, 2],
         },
         pg: {
-          sql:
-            'select * from "users" where "name" = ? and "id" not between ? and ?',
+          sql: 'select * from "users" where "name" = ? and "id" not between ? and ?',
           bindings: ['user1', 1, 2],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" where "name" = ? and "id" not between ? and ?',
+          sql: 'select * from "users" where "name" = ? and "id" not between ? and ?',
           bindings: ['user1', 1, 2],
         },
       }
@@ -1428,33 +1398,27 @@ describe('QueryBuilder', () => {
         ),
       {
         mysql: {
-          sql:
-            'select * from `users` where (`a`, `b`) in ((?, ?), (?, ?), (?, ?))',
+          sql: 'select * from `users` where (`a`, `b`) in ((?, ?), (?, ?), (?, ?))',
           bindings: [1, 2, 3, 4, 5, 6],
         },
         pg: {
-          sql:
-            'select * from "users" where ("a", "b") in ((?, ?), (?, ?), (?, ?))',
+          sql: 'select * from "users" where ("a", "b") in ((?, ?), (?, ?), (?, ?))',
           bindings: [1, 2, 3, 4, 5, 6],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" where ("a", "b") in ((?, ?), (?, ?), (?, ?))',
+          sql: 'select * from "users" where ("a", "b") in ((?, ?), (?, ?), (?, ?))',
           bindings: [1, 2, 3, 4, 5, 6],
         },
         mssql: {
-          sql:
-            'select * from [users] where ([a], [b]) in ((?, ?), (?, ?), (?, ?))',
+          sql: 'select * from [users] where ([a], [b]) in ((?, ?), (?, ?), (?, ?))',
           bindings: [1, 2, 3, 4, 5, 6],
         },
         oracledb: {
-          sql:
-            'select * from "users" where ("a", "b") in ((?, ?), (?, ?), (?, ?))',
+          sql: 'select * from "users" where ("a", "b") in ((?, ?), (?, ?), (?, ?))',
           bindings: [1, 2, 3, 4, 5, 6],
         },
         sqlite3: {
-          sql:
-            'select * from `users` where (`a`, `b`) in ( values (?, ?), (?, ?), (?, ?))',
+          sql: 'select * from `users` where (`a`, `b`) in ( values (?, ?), (?, ?), (?, ?))',
           bindings: [1, 2, 3, 4, 5, 6],
         },
       }
@@ -1715,23 +1679,19 @@ describe('QueryBuilder', () => {
 
     testsql(chain, {
       mysql: {
-        sql:
-          'select * where `id` = (select `account_id` from `names` where `names`.`id` > ? or (`names`.`first_name` like ? and `names`.`id` > ?))',
+        sql: 'select * where `id` = (select `account_id` from `names` where `names`.`id` > ? or (`names`.`first_name` like ? and `names`.`id` > ?))',
         bindings: [1, 'Tim%', 10],
       },
       mssql: {
-        sql:
-          'select * where [id] = (select [account_id] from [names] where [names].[id] > ? or ([names].[first_name] like ? and [names].[id] > ?))',
+        sql: 'select * where [id] = (select [account_id] from [names] where [names].[id] > ? or ([names].[first_name] like ? and [names].[id] > ?))',
         bindings: [1, 'Tim%', 10],
       },
       pg: {
-        sql:
-          'select * where "id" = (select "account_id" from "names" where "names"."id" > ? or ("names"."first_name" like ? and "names"."id" > ?))',
+        sql: 'select * where "id" = (select "account_id" from "names" where "names"."id" > ? or ("names"."first_name" like ? and "names"."id" > ?))',
         bindings: [1, 'Tim%', 10],
       },
       'pg-redshift': {
-        sql:
-          'select * where "id" = (select "account_id" from "names" where "names"."id" > ? or ("names"."first_name" like ? and "names"."id" > ?))',
+        sql: 'select * where "id" = (select "account_id" from "names" where "names"."id" > ? or ("names"."first_name" like ? and "names"."id" > ?))',
         bindings: [1, 'Tim%', 10],
       },
     });
@@ -1739,8 +1699,7 @@ describe('QueryBuilder', () => {
     testquery(chain, {
       mysql:
         "select * where `id` = (select `account_id` from `names` where `names`.`id` > 1 or (`names`.`first_name` like 'Tim%' and `names`.`id` > 10))",
-      pg:
-        'select * where "id" = (select "account_id" from "names" where "names"."id" > 1 or ("names"."first_name" like \'Tim%\' and "names"."id" > 10))',
+      pg: 'select * where "id" = (select "account_id" from "names" where "names"."id" > 1 or ("names"."first_name" like \'Tim%\' and "names"."id" > 10))',
       'pg-redshift':
         'select * where "id" = (select "account_id" from "names" where "names"."id" > 1 or ("names"."first_name" like \'Tim%\' and "names"."id" > 10))',
       mssql:
@@ -1765,23 +1724,19 @@ describe('QueryBuilder', () => {
 
     testsql(chain, {
       mysql: {
-        sql:
-          'select * where `id` = (select `account_id` from `names` where `names`.`id` > ? or (`names`.`first_name` like ? and `names`.`id` > ?))',
+        sql: 'select * where `id` = (select `account_id` from `names` where `names`.`id` > ? or (`names`.`first_name` like ? and `names`.`id` > ?))',
         bindings: [1, 'Tim%', 10],
       },
       mssql: {
-        sql:
-          'select * where [id] = (select [account_id] from [names] where [names].[id] > ? or ([names].[first_name] like ? and [names].[id] > ?))',
+        sql: 'select * where [id] = (select [account_id] from [names] where [names].[id] > ? or ([names].[first_name] like ? and [names].[id] > ?))',
         bindings: [1, 'Tim%', 10],
       },
       pg: {
-        sql:
-          'select * where "id" = (select "account_id" from "names" where "names"."id" > ? or ("names"."first_name" like ? and "names"."id" > ?))',
+        sql: 'select * where "id" = (select "account_id" from "names" where "names"."id" > ? or ("names"."first_name" like ? and "names"."id" > ?))',
         bindings: [1, 'Tim%', 10],
       },
       'pg-redshift': {
-        sql:
-          'select * where "id" = (select "account_id" from "names" where "names"."id" > ? or ("names"."first_name" like ? and "names"."id" > ?))',
+        sql: 'select * where "id" = (select "account_id" from "names" where "names"."id" > ? or ("names"."first_name" like ? and "names"."id" > ?))',
         bindings: [1, 'Tim%', 10],
       },
     });
@@ -1813,23 +1768,19 @@ describe('QueryBuilder', () => {
       });
     testsql(chain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union select * from `users` where `id` = ?',
+        sql: 'select * from `users` where `id` = ? union select * from `users` where `id` = ?',
         bindings: [1, 2],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union select * from [users] where [id] = ?',
+        sql: 'select * from [users] where [id] = ? union select * from [users] where [id] = ?',
         bindings: [1, 2],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union select * from "users" where "id" = ?',
         bindings: [1, 2],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union select * from "users" where "id" = ?',
         bindings: [1, 2],
       },
     });
@@ -1848,23 +1799,19 @@ describe('QueryBuilder', () => {
       );
     testsql(multipleArgumentsChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union select * from `users` where `id` = ? union select * from `users` where `id` = ?',
+        sql: 'select * from `users` where `id` = ? union select * from `users` where `id` = ? union select * from `users` where `id` = ?',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union select * from [users] where [id] = ? union select * from [users] where [id] = ?',
+        sql: 'select * from [users] where [id] = ? union select * from [users] where [id] = ? union select * from [users] where [id] = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -1883,23 +1830,19 @@ describe('QueryBuilder', () => {
       ]);
     testsql(arrayChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union select * from `users` where `id` = ? union select * from `users` where `id` = ?',
+        sql: 'select * from `users` where `id` = ? union select * from `users` where `id` = ? union select * from `users` where `id` = ?',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union select * from [users] where [id] = ? union select * from [users] where [id] = ?',
+        sql: 'select * from [users] where [id] = ? union select * from [users] where [id] = ? union select * from [users] where [id] = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -1918,23 +1861,19 @@ describe('QueryBuilder', () => {
       });
     testsql(wrappedChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` in (select max(`id`) from `users` union (select min(`id`) from `users`))',
+        sql: 'select * from `users` where `id` in (select max(`id`) from `users` union (select min(`id`) from `users`))',
         bindings: [],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] in (select max([id]) from [users] union (select min([id]) from [users]))',
+        sql: 'select * from [users] where [id] in (select max([id]) from [users] union (select min([id]) from [users]))',
         bindings: [],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" in (select max("id") from "users" union (select min("id") from "users"))',
+        sql: 'select * from "users" where "id" in (select max("id") from "users" union (select min("id") from "users"))',
         bindings: [],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" in (select max("id") from "users" union (select min("id") from "users"))',
+        sql: 'select * from "users" where "id" in (select max("id") from "users" union (select min("id") from "users"))',
         bindings: [],
       },
     });
@@ -1955,23 +1894,19 @@ describe('QueryBuilder', () => {
       );
     testsql(multipleArgumentsWrappedChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union (select * from `users` where `id` = ?) union (select * from `users` where `id` = ?)',
+        sql: 'select * from `users` where `id` = ? union (select * from `users` where `id` = ?) union (select * from `users` where `id` = ?)',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union (select * from [users] where [id] = ?) union (select * from [users] where [id] = ?)',
+        sql: 'select * from [users] where [id] = ? union (select * from [users] where [id] = ?) union (select * from [users] where [id] = ?)',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union (select * from "users" where "id" = ?) union (select * from "users" where "id" = ?)',
+        sql: 'select * from "users" where "id" = ? union (select * from "users" where "id" = ?) union (select * from "users" where "id" = ?)',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union (select * from "users" where "id" = ?) union (select * from "users" where "id" = ?)',
+        sql: 'select * from "users" where "id" = ? union (select * from "users" where "id" = ?) union (select * from "users" where "id" = ?)',
         bindings: [1, 2, 3],
       },
     });
@@ -1993,23 +1928,19 @@ describe('QueryBuilder', () => {
       );
     testsql(arrayWrappedChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union (select * from `users` where `id` = ?) union (select * from `users` where `id` = ?)',
+        sql: 'select * from `users` where `id` = ? union (select * from `users` where `id` = ?) union (select * from `users` where `id` = ?)',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union (select * from [users] where [id] = ?) union (select * from [users] where [id] = ?)',
+        sql: 'select * from [users] where [id] = ? union (select * from [users] where [id] = ?) union (select * from [users] where [id] = ?)',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union (select * from "users" where "id" = ?) union (select * from "users" where "id" = ?)',
+        sql: 'select * from "users" where "id" = ? union (select * from "users" where "id" = ?) union (select * from "users" where "id" = ?)',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union (select * from "users" where "id" = ?) union (select * from "users" where "id" = ?)',
+        sql: 'select * from "users" where "id" = ? union (select * from "users" where "id" = ?) union (select * from "users" where "id" = ?)',
         bindings: [1, 2, 3],
       },
     });
@@ -2028,23 +1959,19 @@ describe('QueryBuilder', () => {
       });
     testsql(wrappedChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` in (select max(`id`) from `users` union all (select min(`id`) from `users`))',
+        sql: 'select * from `users` where `id` in (select max(`id`) from `users` union all (select min(`id`) from `users`))',
         bindings: [],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] in (select max([id]) from [users] union all (select min([id]) from [users]))',
+        sql: 'select * from [users] where [id] in (select max([id]) from [users] union all (select min([id]) from [users]))',
         bindings: [],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" in (select max("id") from "users" union all (select min("id") from "users"))',
+        sql: 'select * from "users" where "id" in (select max("id") from "users" union all (select min("id") from "users"))',
         bindings: [],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" in (select max("id") from "users" union all (select min("id") from "users"))',
+        sql: 'select * from "users" where "id" in (select max("id") from "users" union all (select min("id") from "users"))',
         bindings: [],
       },
     });
@@ -2065,23 +1992,19 @@ describe('QueryBuilder', () => {
       );
     testsql(multipleArgumentsWrappedChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union all (select * from `users` where `id` = ?) union all (select * from `users` where `id` = ?)',
+        sql: 'select * from `users` where `id` = ? union all (select * from `users` where `id` = ?) union all (select * from `users` where `id` = ?)',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union all (select * from [users] where [id] = ?) union all (select * from [users] where [id] = ?)',
+        sql: 'select * from [users] where [id] = ? union all (select * from [users] where [id] = ?) union all (select * from [users] where [id] = ?)',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)',
+        sql: 'select * from "users" where "id" = ? union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)',
+        sql: 'select * from "users" where "id" = ? union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)',
         bindings: [1, 2, 3],
       },
     });
@@ -2103,23 +2026,19 @@ describe('QueryBuilder', () => {
       );
     testsql(arrayWrappedChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union all (select * from `users` where `id` = ?) union all (select * from `users` where `id` = ?)',
+        sql: 'select * from `users` where `id` = ? union all (select * from `users` where `id` = ?) union all (select * from `users` where `id` = ?)',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union all (select * from [users] where [id] = ?) union all (select * from [users] where [id] = ?)',
+        sql: 'select * from [users] where [id] = ? union all (select * from [users] where [id] = ?) union all (select * from [users] where [id] = ?)',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)',
+        sql: 'select * from "users" where "id" = ? union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)',
+        sql: 'select * from "users" where "id" = ? union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)',
         bindings: [1, 2, 3],
       },
     });
@@ -2144,23 +2063,19 @@ describe('QueryBuilder', () => {
       });
     testsql(chain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union all select * from `users` where `id` = ?',
+        sql: 'select * from `users` where `id` = ? union all select * from `users` where `id` = ?',
         bindings: [1, 2],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union all select * from [users] where [id] = ?',
+        sql: 'select * from [users] where [id] = ? union all select * from [users] where [id] = ?',
         bindings: [1, 2],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
         bindings: [1, 2],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
         bindings: [1, 2],
       },
     });
@@ -2179,23 +2094,19 @@ describe('QueryBuilder', () => {
       );
     testsql(multipleArgumentsChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from `users` where `id` = ?',
+        sql: 'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from `users` where `id` = ?',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from [users] where [id] = ?',
+        sql: 'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from [users] where [id] = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2214,23 +2125,19 @@ describe('QueryBuilder', () => {
       ]);
     testsql(arrayChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from `users` where `id` = ?',
+        sql: 'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from `users` where `id` = ?',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from [users] where [id] = ?',
+        sql: 'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from [users] where [id] = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2247,23 +2154,19 @@ describe('QueryBuilder', () => {
       });
     testsql(chain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union select * from `users` where `id` = ? union select * from `users` where `id` = ?',
+        sql: 'select * from `users` where `id` = ? union select * from `users` where `id` = ? union select * from `users` where `id` = ?',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union select * from [users] where [id] = ? union select * from [users] where [id] = ?',
+        sql: 'select * from [users] where [id] = ? union select * from [users] where [id] = ? union select * from [users] where [id] = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2278,23 +2181,19 @@ describe('QueryBuilder', () => {
       ]);
     testsql(arrayChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union select * from `users` where `id` = ? union select * from users where id = ?',
+        sql: 'select * from `users` where `id` = ? union select * from `users` where `id` = ? union select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union select * from [users] where [id] = ? union select * from users where id = ?',
+        sql: 'select * from [users] where [id] = ? union select * from [users] where [id] = ? union select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from users where id = ?',
+        sql: 'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from users where id = ?',
+        sql: 'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from users where id = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2309,23 +2208,19 @@ describe('QueryBuilder', () => {
       );
     testsql(multipleArgumentsChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union select * from `users` where `id` = ? union select * from users where id = ?',
+        sql: 'select * from `users` where `id` = ? union select * from `users` where `id` = ? union select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union select * from [users] where [id] = ? union select * from users where id = ?',
+        sql: 'select * from [users] where [id] = ? union select * from [users] where [id] = ? union select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from users where id = ?',
+        sql: 'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from users where id = ?',
+        sql: 'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from users where id = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2341,23 +2236,19 @@ describe('QueryBuilder', () => {
 
     testsql(chain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from `users` where `id` = ?',
+        sql: 'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from `users` where `id` = ?',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from [users] where [id] = ?',
+        sql: 'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from [users] where [id] = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2372,23 +2263,19 @@ describe('QueryBuilder', () => {
       ]);
     testsql(arrayChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from users where id = ?',
+        sql: 'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from users where id = ?',
+        sql: 'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from users where id = ?',
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from users where id = ?',
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from users where id = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2403,23 +2290,19 @@ describe('QueryBuilder', () => {
       );
     testsql(multipleArgumentsChain, {
       mysql: {
-        sql:
-          'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from users where id = ?',
+        sql: 'select * from `users` where `id` = ? union all select * from `users` where `id` = ? union all select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from users where id = ?',
+        sql: 'select * from [users] where [id] = ? union all select * from [users] where [id] = ? union all select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from users where id = ?',
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from users where id = ?',
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from users where id = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2436,28 +2319,23 @@ describe('QueryBuilder', () => {
 
     testsql(chain, {
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? intersect select * from [users] where [id] = ?',
+        sql: 'select * from [users] where [id] = ? intersect select * from [users] where [id] = ?',
         bindings: [1, 2],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
         bindings: [1, 2],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
         bindings: [1, 2],
       },
       oracledb: {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
         bindings: [1, 2],
       },
       sqlite3: {
-        sql:
-          'select * from `users` where `id` = ? intersect select * from `users` where `id` = ?',
+        sql: 'select * from `users` where `id` = ? intersect select * from `users` where `id` = ?',
         bindings: [1, 2],
       },
     });
@@ -2476,28 +2354,23 @@ describe('QueryBuilder', () => {
       );
     testsql(multipleArgumentsChain, {
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? intersect select * from [users] where [id] = ? intersect select * from [users] where [id] = ?',
+        sql: 'select * from [users] where [id] = ? intersect select * from [users] where [id] = ? intersect select * from [users] where [id] = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       oracledb: {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       sqlite3: {
-        sql:
-          'select * from `users` where `id` = ? intersect select * from `users` where `id` = ? intersect select * from `users` where `id` = ?',
+        sql: 'select * from `users` where `id` = ? intersect select * from `users` where `id` = ? intersect select * from `users` where `id` = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2516,28 +2389,23 @@ describe('QueryBuilder', () => {
       ]);
     testsql(arrayChain, {
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? intersect select * from [users] where [id] = ? intersect select * from [users] where [id] = ?',
+        sql: 'select * from [users] where [id] = ? intersect select * from [users] where [id] = ? intersect select * from [users] where [id] = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       oracledb: {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       sqlite3: {
-        sql:
-          'select * from `users` where `id` = ? intersect select * from `users` where `id` = ? intersect select * from `users` where `id` = ?',
+        sql: 'select * from `users` where `id` = ? intersect select * from `users` where `id` = ? intersect select * from `users` where `id` = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2556,18 +2424,15 @@ describe('QueryBuilder', () => {
       });
     testsql(wrappedChain, {
       mssql: {
-        sql:
-          'select * from [users] where [id] in (select max([id]) from [users] intersect (select min([id]) from [users]))',
+        sql: 'select * from [users] where [id] in (select max([id]) from [users] intersect (select min([id]) from [users]))',
         bindings: [],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" in (select max("id") from "users" intersect (select min("id") from "users"))',
+        sql: 'select * from "users" where "id" in (select max("id") from "users" intersect (select min("id") from "users"))',
         bindings: [],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" in (select max("id") from "users" intersect (select min("id") from "users"))',
+        sql: 'select * from "users" where "id" in (select max("id") from "users" intersect (select min("id") from "users"))',
         bindings: [],
       },
     });
@@ -2588,18 +2453,15 @@ describe('QueryBuilder', () => {
       );
     testsql(multipleArgumentsWrappedChain, {
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? intersect (select * from [users] where [id] = ?) intersect (select * from [users] where [id] = ?)',
+        sql: 'select * from [users] where [id] = ? intersect (select * from [users] where [id] = ?) intersect (select * from [users] where [id] = ?)',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? intersect (select * from "users" where "id" = ?) intersect (select * from "users" where "id" = ?)',
+        sql: 'select * from "users" where "id" = ? intersect (select * from "users" where "id" = ?) intersect (select * from "users" where "id" = ?)',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? intersect (select * from "users" where "id" = ?) intersect (select * from "users" where "id" = ?)',
+        sql: 'select * from "users" where "id" = ? intersect (select * from "users" where "id" = ?) intersect (select * from "users" where "id" = ?)',
         bindings: [1, 2, 3],
       },
     });
@@ -2621,18 +2483,15 @@ describe('QueryBuilder', () => {
       );
     testsql(arrayWrappedChain, {
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? intersect (select * from [users] where [id] = ?) intersect (select * from [users] where [id] = ?)',
+        sql: 'select * from [users] where [id] = ? intersect (select * from [users] where [id] = ?) intersect (select * from [users] where [id] = ?)',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? intersect (select * from "users" where "id" = ?) intersect (select * from "users" where "id" = ?)',
+        sql: 'select * from "users" where "id" = ? intersect (select * from "users" where "id" = ?) intersect (select * from "users" where "id" = ?)',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? intersect (select * from "users" where "id" = ?) intersect (select * from "users" where "id" = ?)',
+        sql: 'select * from "users" where "id" = ? intersect (select * from "users" where "id" = ?) intersect (select * from "users" where "id" = ?)',
         bindings: [1, 2, 3],
       },
     });
@@ -2649,18 +2508,15 @@ describe('QueryBuilder', () => {
       });
     testsql(chain, {
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? intersect select * from [users] where [id] = ? intersect select * from [users] where [id] = ?',
+        sql: 'select * from [users] where [id] = ? intersect select * from [users] where [id] = ? intersect select * from [users] where [id] = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from "users" where "id" = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2675,18 +2531,15 @@ describe('QueryBuilder', () => {
       ]);
     testsql(arrayChain, {
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? intersect select * from [users] where [id] = ? intersect select * from users where id = ?',
+        sql: 'select * from [users] where [id] = ? intersect select * from [users] where [id] = ? intersect select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from users where id = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from users where id = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from users where id = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2701,18 +2554,15 @@ describe('QueryBuilder', () => {
       );
     testsql(multipleArgumentsChain, {
       mssql: {
-        sql:
-          'select * from [users] where [id] = ? intersect select * from [users] where [id] = ? intersect select * from users where id = ?',
+        sql: 'select * from [users] where [id] = ? intersect select * from [users] where [id] = ? intersect select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       pg: {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from users where id = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from users where id = ?',
         bindings: [1, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from users where id = ?',
+        sql: 'select * from "users" where "id" = ? intersect select * from "users" where "id" = ? intersect select * from users where id = ?',
         bindings: [1, 2, 3],
       },
     });
@@ -2728,28 +2578,23 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `users` where `id` in (select `id` from `users` where `age` > ? limit ?)',
+          sql: 'select * from `users` where `id` in (select `id` from `users` where `age` > ? limit ?)',
           bindings: [25, 3],
         },
         mssql: {
-          sql:
-            'select * from [users] where [id] in (select top (?) [id] from [users] where [age] > ?)',
+          sql: 'select * from [users] where [id] in (select top (?) [id] from [users] where [age] > ?)',
           bindings: [3, 25],
         },
         oracledb: {
-          sql:
-            'select * from "users" where "id" in (select * from (select "id" from "users" where "age" > ?) where rownum <= ?)',
+          sql: 'select * from "users" where "id" in (select * from (select "id" from "users" where "age" > ?) where rownum <= ?)',
           bindings: [25, 3],
         },
         pg: {
-          sql:
-            'select * from "users" where "id" in (select "id" from "users" where "age" > ? limit ?)',
+          sql: 'select * from "users" where "id" in (select "id" from "users" where "age" > ? limit ?)',
           bindings: [25, 3],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" where "id" in (select "id" from "users" where "age" > ? limit ?)',
+          sql: 'select * from "users" where "id" in (select "id" from "users" where "age" > ? limit ?)',
           bindings: [25, 3],
         },
       }
@@ -2769,28 +2614,23 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `users` where (`id_a`, `id_b`) in (select `id_a`, `id_b` from `users` where `age` > ? limit ?)',
+          sql: 'select * from `users` where (`id_a`, `id_b`) in (select `id_a`, `id_b` from `users` where `age` > ? limit ?)',
           bindings: [25, 3],
         },
         oracledb: {
-          sql:
-            'select * from "users" where ("id_a", "id_b") in (select * from (select "id_a", "id_b" from "users" where "age" > ?) where rownum <= ?)',
+          sql: 'select * from "users" where ("id_a", "id_b") in (select * from (select "id_a", "id_b" from "users" where "age" > ?) where rownum <= ?)',
           bindings: [25, 3],
         },
         pg: {
-          sql:
-            'select * from "users" where ("id_a", "id_b") in (select "id_a", "id_b" from "users" where "age" > ? limit ?)',
+          sql: 'select * from "users" where ("id_a", "id_b") in (select "id_a", "id_b" from "users" where "age" > ? limit ?)',
           bindings: [25, 3],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" where ("id_a", "id_b") in (select "id_a", "id_b" from "users" where "age" > ? limit ?)',
+          sql: 'select * from "users" where ("id_a", "id_b") in (select "id_a", "id_b" from "users" where "age" > ? limit ?)',
           bindings: [25, 3],
         },
         mssql: {
-          sql:
-            'select * from [users] where ([id_a], [id_b]) in (select top (?) [id_a], [id_b] from [users] where [age] > ?)',
+          sql: 'select * from [users] where ([id_a], [id_b]) in (select top (?) [id_a], [id_b] from [users] where [age] > ?)',
           bindings: [3, 25],
         },
       }
@@ -2807,23 +2647,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `users` where `id` not in (select `id` from `users` where `age` > ?)',
+          sql: 'select * from `users` where `id` not in (select `id` from `users` where `age` > ?)',
           bindings: [25],
         },
         mssql: {
-          sql:
-            'select * from [users] where [id] not in (select [id] from [users] where [age] > ?)',
+          sql: 'select * from [users] where [id] not in (select [id] from [users] where [age] > ?)',
           bindings: [25],
         },
         pg: {
-          sql:
-            'select * from "users" where "id" not in (select "id" from "users" where "age" > ?)',
+          sql: 'select * from "users" where "id" not in (select "id" from "users" where "age" > ?)',
           bindings: [25],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" where "id" not in (select "id" from "users" where "age" > ?)',
+          sql: 'select * from "users" where "id" not in (select "id" from "users" where "age" > ?)',
           bindings: [25],
         },
       }
@@ -3033,23 +2869,19 @@ describe('QueryBuilder', () => {
         ),
       {
         mysql: {
-          sql:
-            'select * from `persons` order by (select `p`.`id` from `persons` as `p` where `persons`.`id` = `p`.`id`) asc',
+          sql: 'select * from `persons` order by (select `p`.`id` from `persons` as `p` where `persons`.`id` = `p`.`id`) asc',
           bindings: [],
         },
         mssql: {
-          sql:
-            'select * from [persons] order by (select [p].[id] from [persons] as [p] where [persons].[id] = [p].[id]) asc',
+          sql: 'select * from [persons] order by (select [p].[id] from [persons] as [p] where [persons].[id] = [p].[id]) asc',
           bindings: [],
         },
         pg: {
-          sql:
-            'select * from "persons" order by (select "p"."id" from "persons" as "p" where "persons"."id" = "p"."id") asc',
+          sql: 'select * from "persons" order by (select "p"."id" from "persons" as "p" where "persons"."id" = "p"."id") asc',
           bindings: [],
         },
         sqlite3: {
-          sql:
-            'select * from `persons` order by (select `p`.`id` from `persons` as `p` where `persons`.`id` = `p`.`id`) asc',
+          sql: 'select * from `persons` order by (select `p`.`id` from `persons` as `p` where `persons`.`id` = `p`.`id`) asc',
           bindings: [],
         },
       }
@@ -3363,8 +3195,7 @@ describe('QueryBuilder', () => {
           'select * from `users` having `baz` is not null or `foo` is not null',
         mssql:
           'select * from [users] having [baz] is not null or [foo] is not null',
-        pg:
-          'select * from "users" having "baz" is not null or "foo" is not null',
+        pg: 'select * from "users" having "baz" is not null or "foo" is not null',
         'pg-redshift':
           'select * from "users" having "baz" is not null or "foo" is not null',
         oracledb:
@@ -3411,8 +3242,7 @@ describe('QueryBuilder', () => {
           'select * from `users` having exists (select `baz` from `users`) or exists (select `foo` from `users`)',
         mssql:
           'select * from [users] having exists (select [baz] from [users]) or exists (select [foo] from [users])',
-        pg:
-          'select * from "users" having exists (select "baz" from "users") or exists (select "foo" from "users")',
+        pg: 'select * from "users" having exists (select "baz" from "users") or exists (select "foo" from "users")',
         'pg-redshift':
           'select * from "users" having exists (select "baz" from "users") or exists (select "foo" from "users")',
         oracledb:
@@ -3434,8 +3264,7 @@ describe('QueryBuilder', () => {
           'select * from `users` having not exists (select `baz` from `users`)',
         mssql:
           'select * from [users] having not exists (select [baz] from [users])',
-        pg:
-          'select * from "users" having not exists (select "baz" from "users")',
+        pg: 'select * from "users" having not exists (select "baz" from "users")',
         'pg-redshift':
           'select * from "users" having not exists (select "baz" from "users")',
         oracledb:
@@ -3460,8 +3289,7 @@ describe('QueryBuilder', () => {
           'select * from `users` having not exists (select `baz` from `users`) or not exists (select `foo` from `users`)',
         mssql:
           'select * from [users] having not exists (select [baz] from [users]) or not exists (select [foo] from [users])',
-        pg:
-          'select * from "users" having not exists (select "baz" from "users") or not exists (select "foo" from "users")',
+        pg: 'select * from "users" having not exists (select "baz" from "users") or not exists (select "foo" from "users")',
         'pg-redshift':
           'select * from "users" having not exists (select "baz" from "users") or not exists (select "foo" from "users")',
         oracledb:
@@ -3492,8 +3320,7 @@ describe('QueryBuilder', () => {
           'select * from `users` having `baz` between ? and ? or `baz` between ? and ?',
         mssql:
           'select * from [users] having [baz] between ? and ? or [baz] between ? and ?',
-        pg:
-          'select * from "users" having "baz" between ? and ? or "baz" between ? and ?',
+        pg: 'select * from "users" having "baz" between ? and ? or "baz" between ? and ?',
         'pg-redshift':
           'select * from "users" having "baz" between ? and ? or "baz" between ? and ?',
         oracledb:
@@ -3524,8 +3351,7 @@ describe('QueryBuilder', () => {
           'select * from `users` having `baz` not between ? and ? or `baz` not between ? and ?',
         mssql:
           'select * from [users] having [baz] not between ? and ? or [baz] not between ? and ?',
-        pg:
-          'select * from "users" having "baz" not between ? and ? or "baz" not between ? and ?',
+        pg: 'select * from "users" having "baz" not between ? and ? or "baz" not between ? and ?',
         'pg-redshift':
           'select * from "users" having "baz" not between ? and ? or "baz" not between ? and ?',
         oracledb:
@@ -3556,8 +3382,7 @@ describe('QueryBuilder', () => {
           'select * from `users` having `baz` in (?, ?, ?) or `foo` in (?, ?)',
         mssql:
           'select * from [users] having [baz] in (?, ?, ?) or [foo] in (?, ?)',
-        pg:
-          'select * from "users" having "baz" in (?, ?, ?) or "foo" in (?, ?)',
+        pg: 'select * from "users" having "baz" in (?, ?, ?) or "foo" in (?, ?)',
         'pg-redshift':
           'select * from "users" having "baz" in (?, ?, ?) or "foo" in (?, ?)',
         oracledb:
@@ -3588,8 +3413,7 @@ describe('QueryBuilder', () => {
           'select * from `users` having `baz` not in (?, ?, ?) or `foo` not in (?, ?)',
         mssql:
           'select * from [users] having [baz] not in (?, ?, ?) or [foo] not in (?, ?)',
-        pg:
-          'select * from "users" having "baz" not in (?, ?, ?) or "foo" not in (?, ?)',
+        pg: 'select * from "users" having "baz" not in (?, ?, ?) or "foo" not in (?, ?)',
         'pg-redshift':
           'select * from "users" having "baz" not in (?, ?, ?) or "foo" not in (?, ?)',
         oracledb:
@@ -3659,8 +3483,7 @@ describe('QueryBuilder', () => {
         bindings: [5, 10],
       },
       oracledb: {
-        sql:
-          'select * from (select row_.*, ROWNUM rownum_ from (select * from "users") row_ where rownum <= ?) where rownum_ > ?',
+        sql: 'select * from (select row_.*, ROWNUM rownum_ from (select * from "users") row_ where rownum <= ?) where rownum_ > ?',
         bindings: [15, 5],
       },
       pg: {
@@ -3685,8 +3508,7 @@ describe('QueryBuilder', () => {
         bindings: [10],
       },
       oracledb: {
-        sql:
-          'select * from (select row_.*, ROWNUM rownum_ from (select * from "users") row_ where rownum <= ?) where rownum_ > 5',
+        sql: 'select * from (select row_.*, ROWNUM rownum_ from (select * from "users") row_ where rownum <= ?) where rownum_ > 5',
         bindings: [15],
       },
       pg: {
@@ -3716,8 +3538,7 @@ describe('QueryBuilder', () => {
           bindings: [1, 'john'],
         },
         oracledb: {
-          sql:
-            'select * from (select name = ? as isJohn from "users") where rownum <= ?',
+          sql: 'select * from (select name = ? as isJohn from "users") where rownum <= ?',
           bindings: ['john', 1],
         },
         pg: {
@@ -3780,8 +3601,7 @@ describe('QueryBuilder', () => {
         bindings: [5],
       },
       oracledb: {
-        sql:
-          'select * from (select row_.*, ROWNUM rownum_ from (select * from "users") row_ where rownum <= ?) where rownum_ > ?',
+        sql: 'select * from (select row_.*, ROWNUM rownum_ from (select * from "users") row_ where rownum <= ?) where rownum_ > ?',
         bindings: [10000000000005, 5],
       },
     });
@@ -3822,23 +3642,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `users` where `email` = ? or (`name` = ? and `age` = ?)',
+          sql: 'select * from `users` where `email` = ? or (`name` = ? and `age` = ?)',
           bindings: ['foo', 'bar', 25],
         },
         mssql: {
-          sql:
-            'select * from [users] where [email] = ? or ([name] = ? and [age] = ?)',
+          sql: 'select * from [users] where [email] = ? or ([name] = ? and [age] = ?)',
           bindings: ['foo', 'bar', 25],
         },
         pg: {
-          sql:
-            'select * from "users" where "email" = ? or ("name" = ? and "age" = ?)',
+          sql: 'select * from "users" where "email" = ? or ("name" = ? and "age" = ?)',
           bindings: ['foo', 'bar', 25],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" where "email" = ? or ("name" = ? and "age" = ?)',
+          sql: 'select * from "users" where "email" = ? or ("name" = ? and "age" = ?)',
           bindings: ['foo', 'bar', 25],
         },
       }
@@ -3913,23 +3729,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `users` where `email` = ? or `id` = (select max(id) from `users` where `email` = ?)',
+          sql: 'select * from `users` where `email` = ? or `id` = (select max(id) from `users` where `email` = ?)',
           bindings: ['foo', 'bar'],
         },
         mssql: {
-          sql:
-            'select * from [users] where [email] = ? or [id] = (select max(id) from [users] where [email] = ?)',
+          sql: 'select * from [users] where [email] = ? or [id] = (select max(id) from [users] where [email] = ?)',
           bindings: ['foo', 'bar'],
         },
         pg: {
-          sql:
-            'select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)',
+          sql: 'select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)',
           bindings: ['foo', 'bar'],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)',
+          sql: 'select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)',
           bindings: ['foo', 'bar'],
         },
       }
@@ -3950,23 +3762,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select `email` from `users` where `email` = ? or `id` = (select * from `users` where `email` = ?)',
+          sql: 'select `email` from `users` where `email` = ? or `id` = (select * from `users` where `email` = ?)',
           bindings: ['foo', 'bar'],
         },
         mssql: {
-          sql:
-            'select [email] from [users] where [email] = ? or [id] = (select * from [users] where [email] = ?)',
+          sql: 'select [email] from [users] where [email] = ? or [id] = (select * from [users] where [email] = ?)',
           bindings: ['foo', 'bar'],
         },
         pg: {
-          sql:
-            'select "email" from "users" where "email" = ? or "id" = (select * from "users" where "email" = ?)',
+          sql: 'select "email" from "users" where "email" = ? or "id" = (select * from "users" where "email" = ?)',
           bindings: ['foo', 'bar'],
         },
         'pg-redshift': {
-          sql:
-            'select "email" from "users" where "email" = ? or "id" = (select * from "users" where "email" = ?)',
+          sql: 'select "email" from "users" where "email" = ? or "id" = (select * from "users" where "email" = ?)',
           bindings: ['foo', 'bar'],
         },
       }
@@ -3985,23 +3793,19 @@ describe('QueryBuilder', () => {
         .clearSelect(),
       {
         mysql: {
-          sql:
-            'select * from `users` where `email` = ? or `id` = (select max(id) from `users` where `email` = ?)',
+          sql: 'select * from `users` where `email` = ? or `id` = (select max(id) from `users` where `email` = ?)',
           bindings: ['foo', 'bar'],
         },
         mssql: {
-          sql:
-            'select * from [users] where [email] = ? or [id] = (select max(id) from [users] where [email] = ?)',
+          sql: 'select * from [users] where [email] = ? or [id] = (select max(id) from [users] where [email] = ?)',
           bindings: ['foo', 'bar'],
         },
         pg: {
-          sql:
-            'select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)',
+          sql: 'select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)',
           bindings: ['foo', 'bar'],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)',
+          sql: 'select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)',
           bindings: ['foo', 'bar'],
         },
       }
@@ -4020,23 +3824,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `orders` where exists (select * from `products` where `products`.`id` = "orders"."id")',
+          sql: 'select * from `orders` where exists (select * from `products` where `products`.`id` = "orders"."id")',
           bindings: [],
         },
         mssql: {
-          sql:
-            'select * from [orders] where exists (select * from [products] where [products].[id] = "orders"."id")',
+          sql: 'select * from [orders] where exists (select * from [products] where [products].[id] = "orders"."id")',
           bindings: [],
         },
         pg: {
-          sql:
-            'select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")',
+          sql: 'select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")',
+          sql: 'select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")',
           bindings: [],
         },
       }
@@ -4053,23 +3853,19 @@ describe('QueryBuilder', () => {
         ),
       {
         mysql: {
-          sql:
-            'select * from `orders` where exists (select * from `products` where products.id = orders.id)',
+          sql: 'select * from `orders` where exists (select * from `products` where products.id = orders.id)',
           bindings: [],
         },
         mssql: {
-          sql:
-            'select * from [orders] where exists (select * from [products] where products.id = orders.id)',
+          sql: 'select * from [orders] where exists (select * from [products] where products.id = orders.id)',
           bindings: [],
         },
         pg: {
-          sql:
-            'select * from "orders" where exists (select * from "products" where products.id = orders.id)',
+          sql: 'select * from "orders" where exists (select * from "products" where products.id = orders.id)',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select * from "orders" where exists (select * from "products" where products.id = orders.id)',
+          sql: 'select * from "orders" where exists (select * from "products" where products.id = orders.id)',
           bindings: [],
         },
       }
@@ -4088,23 +3884,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `orders` where not exists (select * from `products` where `products`.`id` = "orders"."id")',
+          sql: 'select * from `orders` where not exists (select * from `products` where `products`.`id` = "orders"."id")',
           bindings: [],
         },
         mssql: {
-          sql:
-            'select * from [orders] where not exists (select * from [products] where [products].[id] = "orders"."id")',
+          sql: 'select * from [orders] where not exists (select * from [products] where [products].[id] = "orders"."id")',
           bindings: [],
         },
         pg: {
-          sql:
-            'select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."id")',
+          sql: 'select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."id")',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."id")',
+          sql: 'select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."id")',
           bindings: [],
         },
       }
@@ -4124,23 +3916,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `orders` where `id` = ? or exists (select * from `products` where `products`.`id` = "orders"."id")',
+          sql: 'select * from `orders` where `id` = ? or exists (select * from `products` where `products`.`id` = "orders"."id")',
           bindings: [1],
         },
         mssql: {
-          sql:
-            'select * from [orders] where [id] = ? or exists (select * from [products] where [products].[id] = "orders"."id")',
+          sql: 'select * from [orders] where [id] = ? or exists (select * from [products] where [products].[id] = "orders"."id")',
           bindings: [1],
         },
         pg: {
-          sql:
-            'select * from "orders" where "id" = ? or exists (select * from "products" where "products"."id" = "orders"."id")',
+          sql: 'select * from "orders" where "id" = ? or exists (select * from "products" where "products"."id" = "orders"."id")',
           bindings: [1],
         },
         'pg-redshift': {
-          sql:
-            'select * from "orders" where "id" = ? or exists (select * from "products" where "products"."id" = "orders"."id")',
+          sql: 'select * from "orders" where "id" = ? or exists (select * from "products" where "products"."id" = "orders"."id")',
           bindings: [1],
         },
       }
@@ -4160,23 +3948,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `orders` where `id` = ? or not exists (select * from `products` where `products`.`id` = "orders"."id")',
+          sql: 'select * from `orders` where `id` = ? or not exists (select * from `products` where `products`.`id` = "orders"."id")',
           bindings: [1],
         },
         mssql: {
-          sql:
-            'select * from [orders] where [id] = ? or not exists (select * from [products] where [products].[id] = "orders"."id")',
+          sql: 'select * from [orders] where [id] = ? or not exists (select * from [products] where [products].[id] = "orders"."id")',
           bindings: [1],
         },
         pg: {
-          sql:
-            'select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")',
+          sql: 'select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")',
           bindings: [1],
         },
         'pg-redshift': {
-          sql:
-            'select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")',
+          sql: 'select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")',
           bindings: [1],
         },
       }
@@ -4188,33 +3972,27 @@ describe('QueryBuilder', () => {
       qb().select('*').from('users').crossJoin('contracts').crossJoin('photos'),
       {
         mysql: {
-          sql:
-            'select * from `users` cross join `contracts` cross join `photos`',
+          sql: 'select * from `users` cross join `contracts` cross join `photos`',
           bindings: [],
         },
         mssql: {
-          sql:
-            'select * from [users] cross join [contracts] cross join [photos]',
+          sql: 'select * from [users] cross join [contracts] cross join [photos]',
           bindings: [],
         },
         pg: {
-          sql:
-            'select * from "users" cross join "contracts" cross join "photos"',
+          sql: 'select * from "users" cross join "contracts" cross join "photos"',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" cross join "contracts" cross join "photos"',
+          sql: 'select * from "users" cross join "contracts" cross join "photos"',
           bindings: [],
         },
         sqlite3: {
-          sql:
-            'select * from `users` cross join `contracts` cross join `photos`',
+          sql: 'select * from `users` cross join `contracts` cross join `photos`',
           bindings: [],
         },
         oracledb: {
-          sql:
-            'select * from "users" cross join "contracts" cross join "photos"',
+          sql: 'select * from "users" cross join "contracts" cross join "photos"',
           bindings: [],
         },
       }
@@ -4229,23 +4007,19 @@ describe('QueryBuilder', () => {
         .fullOuterJoin('contacts', 'users.id', '=', 'contacts.id'),
       {
         mssql: {
-          sql:
-            'select * from [users] full outer join [contacts] on [users].[id] = [contacts].[id]',
+          sql: 'select * from [users] full outer join [contacts] on [users].[id] = [contacts].[id]',
           bindings: [],
         },
         oracledb: {
-          sql:
-            'select * from "users" full outer join "contacts" on "users"."id" = "contacts"."id"',
+          sql: 'select * from "users" full outer join "contacts" on "users"."id" = "contacts"."id"',
           bindings: [],
         },
         pg: {
-          sql:
-            'select * from "users" full outer join "contacts" on "users"."id" = "contacts"."id"',
+          sql: 'select * from "users" full outer join "contacts" on "users"."id" = "contacts"."id"',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" full outer join "contacts" on "users"."id" = "contacts"."id"',
+          sql: 'select * from "users" full outer join "contacts" on "users"."id" = "contacts"."id"',
           bindings: [],
         },
       }
@@ -4260,13 +4034,11 @@ describe('QueryBuilder', () => {
         .crossJoin('contracts', 'users.contractId', 'contracts.id'),
       {
         mysql: {
-          sql:
-            'select * from `users` cross join `contracts` on `users`.`contractId` = `contracts`.`id`',
+          sql: 'select * from `users` cross join `contracts` on `users`.`contractId` = `contracts`.`id`',
           bindings: [],
         },
         sqlite3: {
-          sql:
-            'select * from `users` cross join `contracts` on `users`.`contractId` = `contracts`.`id`',
+          sql: 'select * from `users` cross join `contracts` on `users`.`contractId` = `contracts`.`id`',
           bindings: [],
         },
       }
@@ -4282,23 +4054,19 @@ describe('QueryBuilder', () => {
         .leftJoin('photos', 'users.id', '=', 'photos.id'),
       {
         mysql: {
-          sql:
-            'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` left join `photos` on `users`.`id` = `photos`.`id`',
+          sql: 'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` left join `photos` on `users`.`id` = `photos`.`id`',
           bindings: [],
         },
         mssql: {
-          sql:
-            'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] left join [photos] on [users].[id] = [photos].[id]',
+          sql: 'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] left join [photos] on [users].[id] = [photos].[id]',
           bindings: [],
         },
         pg: {
-          sql:
-            'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" left join "photos" on "users"."id" = "photos"."id"',
+          sql: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" left join "photos" on "users"."id" = "photos"."id"',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" left join "photos" on "users"."id" = "photos"."id"',
+          sql: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" left join "photos" on "users"."id" = "photos"."id"',
           bindings: [],
         },
       }
@@ -4314,28 +4082,23 @@ describe('QueryBuilder', () => {
         .rightOuterJoin('photos', 'users.id', '=', 'photos.id'),
       {
         mssql: {
-          sql:
-            'select * from [users] right join [contacts] on [users].[id] = [contacts].[id] right outer join [photos] on [users].[id] = [photos].[id]',
+          sql: 'select * from [users] right join [contacts] on [users].[id] = [contacts].[id] right outer join [photos] on [users].[id] = [photos].[id]',
           bindings: [],
         },
         mysql: {
-          sql:
-            'select * from `users` right join `contacts` on `users`.`id` = `contacts`.`id` right outer join `photos` on `users`.`id` = `photos`.`id`',
+          sql: 'select * from `users` right join `contacts` on `users`.`id` = `contacts`.`id` right outer join `photos` on `users`.`id` = `photos`.`id`',
           bindings: [],
         },
         oracledb: {
-          sql:
-            'select * from "users" right join "contacts" on "users"."id" = "contacts"."id" right outer join "photos" on "users"."id" = "photos"."id"',
+          sql: 'select * from "users" right join "contacts" on "users"."id" = "contacts"."id" right outer join "photos" on "users"."id" = "photos"."id"',
           bindings: [],
         },
         pg: {
-          sql:
-            'select * from "users" right join "contacts" on "users"."id" = "contacts"."id" right outer join "photos" on "users"."id" = "photos"."id"',
+          sql: 'select * from "users" right join "contacts" on "users"."id" = "contacts"."id" right outer join "photos" on "users"."id" = "photos"."id"',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" right join "contacts" on "users"."id" = "contacts"."id" right outer join "photos" on "users"."id" = "photos"."id"',
+          sql: 'select * from "users" right join "contacts" on "users"."id" = "contacts"."id" right outer join "photos" on "users"."id" = "photos"."id"',
           bindings: [],
         },
       }
@@ -4356,23 +4119,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` or `users`.`name` = `contacts`.`name`',
+          sql: 'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` or `users`.`name` = `contacts`.`name`',
           bindings: [],
         },
         mssql: {
-          sql:
-            'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] or [users].[name] = [contacts].[name]',
+          sql: 'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] or [users].[name] = [contacts].[name]',
           bindings: [],
         },
         pg: {
-          sql:
-            'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "users"."name" = "contacts"."name"',
+          sql: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "users"."name" = "contacts"."name"',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "users"."name" = "contacts"."name"',
+          sql: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "users"."name" = "contacts"."name"',
           bindings: [],
         },
       }
@@ -4392,23 +4151,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `users` inner join `contacts` on (`users`.`id` = `contacts`.`id` or `users`.`name` = `contacts`.`name`)',
+          sql: 'select * from `users` inner join `contacts` on (`users`.`id` = `contacts`.`id` or `users`.`name` = `contacts`.`name`)',
           bindings: [],
         },
         mssql: {
-          sql:
-            'select * from [users] inner join [contacts] on ([users].[id] = [contacts].[id] or [users].[name] = [contacts].[name])',
+          sql: 'select * from [users] inner join [contacts] on ([users].[id] = [contacts].[id] or [users].[name] = [contacts].[name])',
           bindings: [],
         },
         pg: {
-          sql:
-            'select * from "users" inner join "contacts" on ("users"."id" = "contacts"."id" or "users"."name" = "contacts"."name")',
+          sql: 'select * from "users" inner join "contacts" on ("users"."id" = "contacts"."id" or "users"."name" = "contacts"."name")',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" inner join "contacts" on ("users"."id" = "contacts"."id" or "users"."name" = "contacts"."name")',
+          sql: 'select * from "users" inner join "contacts" on ("users"."id" = "contacts"."id" or "users"."name" = "contacts"."name")',
           bindings: [],
         },
       }
@@ -4425,23 +4180,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and 1 = 0',
+          sql: 'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and 1 = 0',
           bindings: [],
         },
         mssql: {
-          sql:
-            'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and 1 = 0',
+          sql: 'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and 1 = 0',
           bindings: [],
         },
         pg: {
-          sql:
-            'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and 1 = 0',
+          sql: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and 1 = 0',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and 1 = 0',
+          sql: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and 1 = 0',
           bindings: [],
         },
       }
@@ -4457,23 +4208,19 @@ describe('QueryBuilder', () => {
         .leftJoin('photos', 'photos.title', '=', raw('?', ['My Photo'])),
       {
         mysql: {
-          sql:
-            'select * from `users` inner join `contacts` on `users`.`id` = 1 left join `photos` on `photos`.`title` = ?',
+          sql: 'select * from `users` inner join `contacts` on `users`.`id` = 1 left join `photos` on `photos`.`title` = ?',
           bindings: ['My Photo'],
         },
         mssql: {
-          sql:
-            'select * from [users] inner join [contacts] on [users].[id] = 1 left join [photos] on [photos].[title] = ?',
+          sql: 'select * from [users] inner join [contacts] on [users].[id] = 1 left join [photos] on [photos].[title] = ?',
           bindings: ['My Photo'],
         },
         pg: {
-          sql:
-            'select * from "users" inner join "contacts" on "users"."id" = 1 left join "photos" on "photos"."title" = ?',
+          sql: 'select * from "users" inner join "contacts" on "users"."id" = 1 left join "photos" on "photos"."title" = ?',
           bindings: ['My Photo'],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" inner join "contacts" on "users"."id" = 1 left join "photos" on "photos"."title" = ?',
+          sql: 'select * from "users" inner join "contacts" on "users"."id" = 1 left join "photos" on "photos"."title" = ?',
           bindings: ['My Photo'],
         },
       }
@@ -4490,23 +4237,19 @@ describe('QueryBuilder', () => {
         .leftJoin('photos', 'users.id', '=', 'photos.id'),
       {
         mysql: {
-          sql:
-            'select * from `myschema`.`users` inner join `myschema`.`contacts` on `users`.`id` = `contacts`.`id` left join `myschema`.`photos` on `users`.`id` = `photos`.`id`',
+          sql: 'select * from `myschema`.`users` inner join `myschema`.`contacts` on `users`.`id` = `contacts`.`id` left join `myschema`.`photos` on `users`.`id` = `photos`.`id`',
           bindings: [],
         },
         mssql: {
-          sql:
-            'select * from [myschema].[users] inner join [myschema].[contacts] on [users].[id] = [contacts].[id] left join [myschema].[photos] on [users].[id] = [photos].[id]',
+          sql: 'select * from [myschema].[users] inner join [myschema].[contacts] on [users].[id] = [contacts].[id] left join [myschema].[photos] on [users].[id] = [photos].[id]',
           bindings: [],
         },
         pg: {
-          sql:
-            'select * from "myschema"."users" inner join "myschema"."contacts" on "users"."id" = "contacts"."id" left join "myschema"."photos" on "users"."id" = "photos"."id"',
+          sql: 'select * from "myschema"."users" inner join "myschema"."contacts" on "users"."id" = "contacts"."id" left join "myschema"."photos" on "users"."id" = "photos"."id"',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select * from "myschema"."users" inner join "myschema"."contacts" on "users"."id" = "contacts"."id" left join "myschema"."photos" on "users"."id" = "photos"."id"',
+          sql: 'select * from "myschema"."users" inner join "myschema"."contacts" on "users"."id" = "contacts"."id" left join "myschema"."photos" on "users"."id" = "photos"."id"',
           bindings: [],
         },
       }
@@ -4526,8 +4269,7 @@ describe('QueryBuilder', () => {
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and `contacts`.`address` is null',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and [contacts].[address] is null',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."address" is null',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."address" is null',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."address" is null',
         oracledb:
@@ -4551,8 +4293,7 @@ describe('QueryBuilder', () => {
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and `contacts`.`address` is null or `contacts`.`phone` is null',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and [contacts].[address] is null or [contacts].[phone] is null',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."address" is null or "contacts"."phone" is null',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."address" is null or "contacts"."phone" is null',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."address" is null or "contacts"."phone" is null',
         oracledb:
@@ -4574,8 +4315,7 @@ describe('QueryBuilder', () => {
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and `contacts`.`address` is not null',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and [contacts].[address] is not null',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."address" is not null',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."address" is not null',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."address" is not null',
         oracledb:
@@ -4599,8 +4339,7 @@ describe('QueryBuilder', () => {
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and `contacts`.`address` is not null or `contacts`.`phone` is not null',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and [contacts].[address] is not null or [contacts].[phone] is not null',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."address" is not null or "contacts"."phone" is not null',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."address" is not null or "contacts"."phone" is not null',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."address" is not null or "contacts"."phone" is not null',
         oracledb:
@@ -4624,8 +4363,7 @@ describe('QueryBuilder', () => {
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and exists (select * from `foo`)',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and exists (select * from [foo])',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and exists (select * from "foo")',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and exists (select * from "foo")',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and exists (select * from "foo")',
         oracledb:
@@ -4653,8 +4391,7 @@ describe('QueryBuilder', () => {
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and exists (select * from `foo`) or exists (select * from `bar`)',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and exists (select * from [foo]) or exists (select * from [bar])',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and exists (select * from "foo") or exists (select * from "bar")',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and exists (select * from "foo") or exists (select * from "bar")',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and exists (select * from "foo") or exists (select * from "bar")',
         oracledb:
@@ -4678,8 +4415,7 @@ describe('QueryBuilder', () => {
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and not exists (select * from `foo`)',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and not exists (select * from [foo])',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and not exists (select * from "foo")',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and not exists (select * from "foo")',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and not exists (select * from "foo")',
         oracledb:
@@ -4707,8 +4443,7 @@ describe('QueryBuilder', () => {
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and not exists (select * from `foo`) or not exists (select * from `bar`)',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and not exists (select * from [foo]) or not exists (select * from [bar])',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and not exists (select * from "foo") or not exists (select * from "bar")',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and not exists (select * from "foo") or not exists (select * from "bar")',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and not exists (select * from "foo") or not exists (select * from "bar")',
         oracledb:
@@ -4723,18 +4458,17 @@ describe('QueryBuilder', () => {
         .select('*')
         .from('users')
         .join('contacts', (qb) => {
-          qb.on('users.id', '=', 'contacts.id').onBetween('contacts.id', [
-            7,
-            15,
-          ]);
+          qb.on('users.id', '=', 'contacts.id').onBetween(
+            'contacts.id',
+            [7, 15]
+          );
         }),
       {
         mysql:
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and `contacts`.`id` between ? and ?',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and [contacts].[id] between ? and ?',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" between ? and ?',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" between ? and ?',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" between ? and ?',
         oracledb:
@@ -4758,8 +4492,7 @@ describe('QueryBuilder', () => {
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and `contacts`.`id` between ? and ? or `users`.`id` between ? and ?',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and [contacts].[id] between ? and ? or [users].[id] between ? and ?',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" between ? and ? or "users"."id" between ? and ?',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" between ? and ? or "users"."id" between ? and ?',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" between ? and ? or "users"."id" between ? and ?',
         oracledb:
@@ -4774,18 +4507,17 @@ describe('QueryBuilder', () => {
         .select('*')
         .from('users')
         .join('contacts', (qb) => {
-          qb.on('users.id', '=', 'contacts.id').onNotBetween('contacts.id', [
-            7,
-            15,
-          ]);
+          qb.on('users.id', '=', 'contacts.id').onNotBetween(
+            'contacts.id',
+            [7, 15]
+          );
         }),
       {
         mysql:
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and `contacts`.`id` not between ? and ?',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and [contacts].[id] not between ? and ?',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" not between ? and ?',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" not between ? and ?',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" not between ? and ?',
         oracledb:
@@ -4809,8 +4541,7 @@ describe('QueryBuilder', () => {
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and `contacts`.`id` not between ? and ? or `users`.`id` not between ? and ?',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and [contacts].[id] not between ? and ? or [users].[id] not between ? and ?',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" not between ? and ? or "users"."id" not between ? and ?',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" not between ? and ? or "users"."id" not between ? and ?',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" not between ? and ? or "users"."id" not between ? and ?',
         oracledb:
@@ -4825,20 +4556,17 @@ describe('QueryBuilder', () => {
         .select('*')
         .from('users')
         .join('contacts', (qb) => {
-          qb.on('users.id', '=', 'contacts.id').onIn('contacts.id', [
-            7,
-            15,
-            23,
-            41,
-          ]);
+          qb.on('users.id', '=', 'contacts.id').onIn(
+            'contacts.id',
+            [7, 15, 23, 41]
+          );
         }),
       {
         mysql:
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and `contacts`.`id` in (?, ?, ?, ?)',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and [contacts].[id] in (?, ?, ?, ?)',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" in (?, ?, ?, ?)',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" in (?, ?, ?, ?)',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" in (?, ?, ?, ?)',
         oracledb:
@@ -4862,8 +4590,7 @@ describe('QueryBuilder', () => {
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and `contacts`.`id` in (?, ?, ?, ?) or `users`.`id` in (?, ?)',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and [contacts].[id] in (?, ?, ?, ?) or [users].[id] in (?, ?)',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" in (?, ?, ?, ?) or "users"."id" in (?, ?)',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" in (?, ?, ?, ?) or "users"."id" in (?, ?)',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" in (?, ?, ?, ?) or "users"."id" in (?, ?)',
         oracledb:
@@ -4878,20 +4605,17 @@ describe('QueryBuilder', () => {
         .select('*')
         .from('users')
         .join('contacts', (qb) => {
-          qb.on('users.id', '=', 'contacts.id').onNotIn('contacts.id', [
-            7,
-            15,
-            23,
-            41,
-          ]);
+          qb.on('users.id', '=', 'contacts.id').onNotIn(
+            'contacts.id',
+            [7, 15, 23, 41]
+          );
         }),
       {
         mysql:
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and `contacts`.`id` not in (?, ?, ?, ?)',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and [contacts].[id] not in (?, ?, ?, ?)',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" not in (?, ?, ?, ?)',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" not in (?, ?, ?, ?)',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" not in (?, ?, ?, ?)',
         oracledb:
@@ -4915,8 +4639,7 @@ describe('QueryBuilder', () => {
           'select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` and `contacts`.`id` not in (?, ?, ?, ?) or `users`.`id` not in (?, ?)',
         mssql:
           'select * from [users] inner join [contacts] on [users].[id] = [contacts].[id] and [contacts].[id] not in (?, ?, ?, ?) or [users].[id] not in (?, ?)',
-        pg:
-          'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" not in (?, ?, ?, ?) or "users"."id" not in (?, ?)',
+        pg: 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" not in (?, ?, ?, ?) or "users"."id" not in (?, ?)',
         'pg-redshift':
           'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."id" not in (?, ?, ?, ?) or "users"."id" not in (?, ?)',
         oracledb:
@@ -5437,8 +5160,7 @@ describe('QueryBuilder', () => {
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         sqlite3: {
-          sql:
-            'insert into `users` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name`',
+          sql: 'insert into `users` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name`',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         mssql: {
@@ -5446,8 +5168,7 @@ describe('QueryBuilder', () => {
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         oracledb: {
-          sql:
-            'begin execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using ?, ?; execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using ?, ?;end;',
+          sql: 'begin execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using ?, ?; execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using ?, ?;end;',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         pg: {
@@ -5476,8 +5197,7 @@ describe('QueryBuilder', () => {
           "insert into [users] ([email], [name]) values ('foo', 'taylor'), (NULL, 'dayle')",
         oracledb:
           'begin execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using \'foo\', \'taylor\'; execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using NULL, \'dayle\';end;',
-        pg:
-          'insert into "users" ("email", "name") values (\'foo\', \'taylor\'), (NULL, \'dayle\')',
+        pg: 'insert into "users" ("email", "name") values (\'foo\', \'taylor\'), (NULL, \'dayle\')',
         'pg-redshift':
           'insert into "users" ("email", "name") values (\'foo\', \'taylor\'), (NULL, \'dayle\')',
       },
@@ -5497,8 +5217,7 @@ describe('QueryBuilder', () => {
           "insert into [users] ([email], [name]) values ('foo', 'taylor'), (DEFAULT, 'dayle')",
         oracledb:
           'begin execute immediate \'insert into "users" ("email", "name") values (:1, :2)\' using \'foo\', \'taylor\'; execute immediate \'insert into "users" ("email", "name") values (DEFAULT, :1)\' using \'dayle\';end;',
-        pg:
-          'insert into "users" ("email", "name") values (\'foo\', \'taylor\'), (DEFAULT, \'dayle\')',
+        pg: 'insert into "users" ("email", "name") values (\'foo\', \'taylor\'), (DEFAULT, \'dayle\')',
         'pg-redshift':
           'insert into "users" ("email", "name") values (\'foo\', \'taylor\'), (DEFAULT, \'dayle\')',
       }
@@ -5537,12 +5256,10 @@ describe('QueryBuilder', () => {
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         sqlite3: {
-          sql:
-            'insert into `users` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name`',
+          sql: 'insert into `users` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name`',
         },
         pg: {
-          sql:
-            'insert into "users" ("email", "name") values (?, ?), (?, ?) returning "id"',
+          sql: 'insert into "users" ("email", "name") values (?, ?), (?, ?) returning "id"',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         'pg-redshift': {
@@ -5550,13 +5267,11 @@ describe('QueryBuilder', () => {
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         mssql: {
-          sql:
-            'insert into [users] ([email], [name]) output inserted.[id] values (?, ?), (?, ?)',
+          sql: 'insert into [users] ([email], [name]) output inserted.[id] values (?, ?), (?, ?)',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         oracledb: {
-          sql:
-            'begin execute immediate \'insert into "users" ("email", "name") values (:1, :2) returning "id" into :3\' using ?, ?, out ?; execute immediate \'insert into "users" ("email", "name") values (:1, :2) returning "id" into :3\' using ?, ?, out ?;end;',
+          sql: 'begin execute immediate \'insert into "users" ("email", "name") values (:1, :2) returning "id" into :3\' using ?, ?, out ?; execute immediate \'insert into "users" ("email", "name") values (:1, :2) returning "id" into :3\' using ?, ?, out ?;end;',
           bindings: (bindings) => {
             expect(bindings.length).to.equal(6);
             expect(bindings[0]).to.equal('foo');
@@ -5592,13 +5307,11 @@ describe('QueryBuilder', () => {
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         sqlite3: {
-          sql:
-            'insert into `users` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name`',
+          sql: 'insert into `users` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name`',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         pg: {
-          sql:
-            'insert into "users" ("email", "name") values (?, ?), (?, ?) returning "id", "name"',
+          sql: 'insert into "users" ("email", "name") values (?, ?), (?, ?) returning "id", "name"',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         'pg-redshift': {
@@ -5606,13 +5319,11 @@ describe('QueryBuilder', () => {
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         mssql: {
-          sql:
-            'insert into [users] ([email], [name]) output inserted.[id], inserted.[name] values (?, ?), (?, ?)',
+          sql: 'insert into [users] ([email], [name]) output inserted.[id], inserted.[name] values (?, ?), (?, ?)',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         oracledb: {
-          sql:
-            'begin execute immediate \'insert into "users" ("email", "name") values (:1, :2) returning "id","name" into :3, :4\' using ?, ?, out ?, out ?; execute immediate \'insert into "users" ("email", "name") values (:1, :2) returning "id","name" into :3, :4\' using ?, ?, out ?, out ?;end;',
+          sql: 'begin execute immediate \'insert into "users" ("email", "name") values (:1, :2) returning "id","name" into :3, :4\' using ?, ?, out ?, out ?; execute immediate \'insert into "users" ("email", "name") values (:1, :2) returning "id","name" into :3, :4\' using ?, ?, out ?, out ?;end;',
           bindings: (bindings) => {
             expect(bindings.length).to.equal(8);
             expect(bindings[0]).to.equal('foo');
@@ -5674,13 +5385,11 @@ describe('QueryBuilder', () => {
 
     testsql(qb().insert(data).into('table'), {
       mysql: {
-        sql:
-          'insert into `table` (`a`, `b`, `c`) values (?, DEFAULT, DEFAULT), (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+        sql: 'insert into `table` (`a`, `b`, `c`) values (?, DEFAULT, DEFAULT), (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
         bindings: [1, 2, 2, 3],
       },
       sqlite3: {
-        sql:
-          'insert into `table` (`a`, `b`, `c`) select ? as `a`, ? as `b`, ? as `c` union all select ? as `a`, ? as `b`, ? as `c` union all select ? as `a`, ? as `b`, ? as `c`',
+        sql: 'insert into `table` (`a`, `b`, `c`) select ? as `a`, ? as `b`, ? as `c` union all select ? as `a`, ? as `b`, ? as `c` union all select ? as `a`, ? as `b`, ? as `c`',
         bindings: [
           1,
           undefined,
@@ -5694,23 +5403,19 @@ describe('QueryBuilder', () => {
         ],
       },
       mssql: {
-        sql:
-          'insert into [table] ([a], [b], [c]) values (?, DEFAULT, DEFAULT), (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+        sql: 'insert into [table] ([a], [b], [c]) values (?, DEFAULT, DEFAULT), (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
         bindings: [1, 2, 2, 3],
       },
       oracledb: {
-        sql:
-          'begin execute immediate \'insert into "table" ("a", "b", "c") values (:1, DEFAULT, DEFAULT)\' using ?; execute immediate \'insert into "table" ("a", "b", "c") values (DEFAULT, :1, DEFAULT)\' using ?; execute immediate \'insert into "table" ("a", "b", "c") values (:1, DEFAULT, :2)\' using ?, ?;end;',
+        sql: 'begin execute immediate \'insert into "table" ("a", "b", "c") values (:1, DEFAULT, DEFAULT)\' using ?; execute immediate \'insert into "table" ("a", "b", "c") values (DEFAULT, :1, DEFAULT)\' using ?; execute immediate \'insert into "table" ("a", "b", "c") values (:1, DEFAULT, :2)\' using ?, ?;end;',
         bindings: [1, 2, 2, 3],
       },
       pg: {
-        sql:
-          'insert into "table" ("a", "b", "c") values (?, DEFAULT, DEFAULT), (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+        sql: 'insert into "table" ("a", "b", "c") values (?, DEFAULT, DEFAULT), (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
         bindings: [1, 2, 2, 3],
       },
       'pg-redshift': {
-        sql:
-          'insert into "table" ("a", "b", "c") values (?, DEFAULT, DEFAULT), (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+        sql: 'insert into "table" ("a", "b", "c") values (?, DEFAULT, DEFAULT), (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
         bindings: [1, 2, 2, 3],
       },
     });
@@ -5790,8 +5495,7 @@ describe('QueryBuilder', () => {
         bindings: [],
       },
       oracledb: {
-        sql:
-          'insert into "users" ("id") values (default) returning "id" into ?',
+        sql: 'insert into "users" ("id") values (default) returning "id" into ?',
         bindings: (bindings) => {
           expect(bindings.length).to.equal(1);
           expect(bindings[0].toString()).to.equal(
@@ -5814,8 +5518,7 @@ describe('QueryBuilder', () => {
           bindings: ['foo', 'bar', 1],
         },
         mssql: {
-          sql:
-            'update [users] set [email] = ?, [name] = ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [email] = ?, [name] = ? where [id] = ?;select @@rowcount',
           bindings: ['foo', 'bar', 1],
         },
         pg: {
@@ -5877,8 +5580,7 @@ describe('QueryBuilder', () => {
           bindings: [null, 'bar', 1],
         },
         mssql: {
-          sql:
-            'update [users] set [email] = ?, [name] = ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [email] = ?, [name] = ? where [id] = ?;select @@rowcount',
           bindings: [null, 'bar', 1],
         },
         pg: {
@@ -5904,13 +5606,11 @@ describe('QueryBuilder', () => {
         .update({ email: 'foo', name: 'bar' }),
       {
         mysql: {
-          sql:
-            'update `users` set `email` = ?, `name` = ? where `id` = ? order by `foo` desc limit ?',
+          sql: 'update `users` set `email` = ?, `name` = ? where `id` = ? order by `foo` desc limit ?',
           bindings: ['foo', 'bar', 1, 5],
         },
         mssql: {
-          sql:
-            'update top (?) [users] set [email] = ?, [name] = ? where [id] = ? order by [foo] desc;select @@rowcount',
+          sql: 'update top (?) [users] set [email] = ?, [name] = ? where [id] = ? order by [foo] desc;select @@rowcount',
           bindings: [5, 'foo', 'bar', 1],
         },
         pg: {
@@ -5934,23 +5634,19 @@ describe('QueryBuilder', () => {
         .update({ email: 'foo', name: 'bar' }),
       {
         mysql: {
-          sql:
-            'update `users` inner join `orders` on `users`.`id` = `orders`.`user_id` set `email` = ?, `name` = ? where `users`.`id` = ?',
+          sql: 'update `users` inner join `orders` on `users`.`id` = `orders`.`user_id` set `email` = ?, `name` = ? where `users`.`id` = ?',
           bindings: ['foo', 'bar', 1],
         },
         mssql: {
-          sql:
-            'update [users] set [email] = ?, [name] = ? from [users] inner join [orders] on [users].[id] = [orders].[user_id] where [users].[id] = ?;select @@rowcount',
+          sql: 'update [users] set [email] = ?, [name] = ? from [users] inner join [orders] on [users].[id] = [orders].[user_id] where [users].[id] = ?;select @@rowcount',
           bindings: ['foo', 'bar', 1],
         },
         pg: {
-          sql:
-            'update "users" set "email" = ?, "name" = ? where "users"."id" = ?',
+          sql: 'update "users" set "email" = ?, "name" = ? where "users"."id" = ?',
           bindings: ['foo', 'bar', 1],
         },
         'pg-redshift': {
-          sql:
-            'update "users" set "email" = ?, "name" = ? where "users"."id" = ?',
+          sql: 'update "users" set "email" = ?, "name" = ? where "users"."id" = ?',
           bindings: ['foo', 'bar', 1],
         },
       }
@@ -5967,23 +5663,19 @@ describe('QueryBuilder', () => {
         .limit(1),
       {
         mysql: {
-          sql:
-            'update `users` set `email` = ?, `name` = ? where `users`.`id` = ? limit ?',
+          sql: 'update `users` set `email` = ?, `name` = ? where `users`.`id` = ? limit ?',
           bindings: ['foo', 'bar', 1, 1],
         },
         mssql: {
-          sql:
-            'update top (?) [users] set [email] = ?, [name] = ? where [users].[id] = ?;select @@rowcount',
+          sql: 'update top (?) [users] set [email] = ?, [name] = ? where [users].[id] = ?;select @@rowcount',
           bindings: [1, 'foo', 'bar', 1],
         },
         pg: {
-          sql:
-            'update "users" set "email" = ?, "name" = ? where "users"."id" = ?',
+          sql: 'update "users" set "email" = ?, "name" = ? where "users"."id" = ?',
           bindings: ['foo', 'bar', 1],
         },
         'pg-redshift': {
-          sql:
-            'update "users" set "email" = ?, "name" = ? where "users"."id" = ?',
+          sql: 'update "users" set "email" = ?, "name" = ? where "users"."id" = ?',
           bindings: ['foo', 'bar', 1],
         },
       }
@@ -6002,8 +5694,7 @@ describe('QueryBuilder', () => {
           bindings: ['foo', 'bar', 1],
         },
         mssql: {
-          sql:
-            'update [users] set [email] = ?, [name] = ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [email] = ?, [name] = ? where [id] = ?;select @@rowcount',
           bindings: ['foo', 'bar', 1],
         },
         pg: {
@@ -6026,8 +5717,7 @@ describe('QueryBuilder', () => {
         .update({ email: 'foo', name: 'bar' }, '*'),
       {
         oracledb: {
-          sql:
-            'update "users" set "email" = ?, "name" = ? where "id" = ? returning "ROWID" into ?',
+          sql: 'update "users" set "email" = ?, "name" = ? where "id" = ? returning "ROWID" into ?',
           bindings: (bindings) => {
             expect(bindings.length).to.equal(4);
             expect(bindings[0]).to.equal('foo');
@@ -6061,8 +5751,7 @@ describe('QueryBuilder', () => {
           bindings: ['bar', 1],
         },
         mssql: {
-          sql:
-            'update [users] set [email] = foo, [name] = ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [email] = foo, [name] = ? where [id] = ?;select @@rowcount',
           bindings: ['bar', 1],
         },
         pg: {
@@ -6084,8 +5773,7 @@ describe('QueryBuilder', () => {
         bindings: [10, 1],
       },
       mssql: {
-        sql:
-          'update [users] set [balance] = [balance] + ? where [id] = ?;select @@rowcount',
+        sql: 'update [users] set [balance] = [balance] + ? where [id] = ?;select @@rowcount',
         bindings: [10, 1],
       },
       pg: {
@@ -6116,8 +5804,7 @@ describe('QueryBuilder', () => {
           bindings: [20, 1],
         },
         mssql: {
-          sql:
-            'update [users] set [balance] = [balance] + ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [balance] = [balance] + ? where [id] = ?;select @@rowcount',
           bindings: [20, 1],
         },
         'pg-redshift': {
@@ -6145,8 +5832,7 @@ describe('QueryBuilder', () => {
           bindings: [90, 1],
         },
         mssql: {
-          sql:
-            'update [users] set [balance] = [balance] - ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [balance] = [balance] - ? where [id] = ?;select @@rowcount',
           bindings: [90, 1],
         },
         'pg-redshift': {
@@ -6174,8 +5860,7 @@ describe('QueryBuilder', () => {
           bindings: [20, 1],
         },
         mssql: {
-          sql:
-            'update [users] set [balance] = [balance] - ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [balance] = [balance] - ? where [id] = ?;select @@rowcount',
           bindings: [20, 1],
         },
         'pg-redshift': {
@@ -6221,13 +5906,11 @@ describe('QueryBuilder', () => {
           bindings: ['foo'],
         },
         pg: {
-          sql:
-            'insert into "users" ("email") values (?) on conflict ("email") do nothing',
+          sql: 'insert into "users" ("email") values (?) on conflict ("email") do nothing',
           bindings: ['foo'],
         },
         sqlite3: {
-          sql:
-            'insert into `users` (`email`) values (?) on conflict (`email`) do nothing',
+          sql: 'insert into `users` (`email`) values (?) on conflict (`email`) do nothing',
           bindings: ['foo'],
         },
       }
@@ -6247,13 +5930,11 @@ describe('QueryBuilder', () => {
           bindings: ['foo', 'bar'],
         },
         pg: {
-          sql:
-            'insert into "users" ("email") values (?), (?) on conflict ("email") do nothing',
+          sql: 'insert into "users" ("email") values (?), (?) on conflict ("email") do nothing',
           bindings: ['foo', 'bar'],
         },
         sqlite3: {
-          sql:
-            'insert into `users` (`email`) select ? as `email` union all select ? as `email` where true on conflict (`email`) do nothing',
+          sql: 'insert into `users` (`email`) select ? as `email` union all select ? as `email` where true on conflict (`email`) do nothing',
           bindings: ['foo', 'bar'],
         },
       }
@@ -6273,13 +5954,11 @@ describe('QueryBuilder', () => {
           bindings: ['foo', 'acme-inc'],
         },
         pg: {
-          sql:
-            'insert into "users" ("email", "org") values (?, ?) on conflict ("org", "email") do nothing',
+          sql: 'insert into "users" ("email", "org") values (?, ?) on conflict ("org", "email") do nothing',
           bindings: ['foo', 'acme-inc'],
         },
         sqlite3: {
-          sql:
-            'insert into `users` (`email`, `org`) values (?, ?) on conflict (`org`, `email`) do nothing',
+          sql: 'insert into `users` (`email`, `org`) values (?, ?) on conflict (`org`, `email`) do nothing',
           bindings: ['foo', 'acme-inc'],
         },
       }
@@ -6298,18 +5977,15 @@ describe('QueryBuilder', () => {
         .merge({ name: 'overidden' }),
       {
         mysql: {
-          sql:
-            'insert into `users` (`email`, `name`) values (?, ?), (?, ?) on duplicate key update `name` = ?',
+          sql: 'insert into `users` (`email`, `name`) values (?, ?), (?, ?) on duplicate key update `name` = ?',
           bindings: ['foo', 'taylor', 'bar', 'dayle', 'overidden'],
         },
         sqlite3: {
-          sql:
-            'insert into `users` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name` where true on conflict (`email`) do update set `name` = ?',
+          sql: 'insert into `users` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name` where true on conflict (`email`) do update set `name` = ?',
           bindings: ['foo', 'taylor', 'bar', 'dayle', 'overidden'],
         },
         pg: {
-          sql:
-            'insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "name" = ?',
+          sql: 'insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "name" = ?',
           bindings: ['foo', 'taylor', 'bar', 'dayle', 'overidden'],
         },
       }
@@ -6328,18 +6004,15 @@ describe('QueryBuilder', () => {
         .merge(),
       {
         mysql: {
-          sql:
-            'insert into `users` (`email`, `name`) values (?, ?), (?, ?) on duplicate key update `email` = values(`email`), `name` = values(`name`)',
+          sql: 'insert into `users` (`email`, `name`) values (?, ?), (?, ?) on duplicate key update `email` = values(`email`), `name` = values(`name`)',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         sqlite3: {
-          sql:
-            'insert into `users` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name` where true on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name`',
+          sql: 'insert into `users` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name` where true on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name`',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
         pg: {
-          sql:
-            'insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "email" = excluded."email", "name" = excluded."name"',
+          sql: 'insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "email" = excluded."email", "name" = excluded."name"',
           bindings: ['foo', 'taylor', 'bar', 'dayle'],
         },
       }
@@ -6356,13 +6029,11 @@ describe('QueryBuilder', () => {
         .where('email', 'foo2'),
       {
         pg: {
-          sql:
-            'insert into "users" ("email", "name") values (?, ?) on conflict ("email") do update set "email" = excluded."email", "name" = excluded."name" where "email" = ?',
+          sql: 'insert into "users" ("email", "name") values (?, ?) on conflict ("email") do update set "email" = excluded."email", "name" = excluded."name" where "email" = ?',
           bindings: ['foo', 'taylor', 'foo2'],
         },
         sqlite3: {
-          sql:
-            'insert into `users` (`email`, `name`) values (?, ?) on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name` where `email` = ?',
+          sql: 'insert into `users` (`email`, `name`) values (?, ?) on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name` where `email` = ?',
           bindings: ['foo', 'taylor', 'foo2'],
         },
       }
@@ -6396,8 +6067,7 @@ describe('QueryBuilder', () => {
           bindings: [90, 1],
         },
         mssql: {
-          sql:
-            'update [users] set [balance] = [balance] + ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [balance] = [balance] + ? where [id] = ?;select @@rowcount',
           bindings: [90, 1],
         },
         'pg-redshift': {
@@ -6420,23 +6090,19 @@ describe('QueryBuilder', () => {
         .decrement('subbalance', 100),
       {
         pg: {
-          sql:
-            'update "users" set "email" = ?, "balance" = "balance" + ?, "subbalance" = "subbalance" - ? where "id" = ?',
+          sql: 'update "users" set "email" = ?, "balance" = "balance" + ?, "subbalance" = "subbalance" - ? where "id" = ?',
           bindings: ['foo@bar.com', 10, 100, 1],
         },
         mysql: {
-          sql:
-            'update `users` set `email` = ?, `balance` = `balance` + ?, `subbalance` = `subbalance` - ? where `id` = ?',
+          sql: 'update `users` set `email` = ?, `balance` = `balance` + ?, `subbalance` = `subbalance` - ? where `id` = ?',
           bindings: ['foo@bar.com', 10, 100, 1],
         },
         mssql: {
-          sql:
-            'update [users] set [email] = ?, [balance] = [balance] + ?, [subbalance] = [subbalance] - ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [email] = ?, [balance] = [balance] + ?, [subbalance] = [subbalance] - ? where [id] = ?;select @@rowcount',
           bindings: ['foo@bar.com', 10, 100, 1],
         },
         'pg-redshift': {
-          sql:
-            'update "users" set "email" = ?, "balance" = "balance" + ?, "subbalance" = "subbalance" - ? where "id" = ?',
+          sql: 'update "users" set "email" = ?, "balance" = "balance" + ?, "subbalance" = "subbalance" - ? where "id" = ?',
           bindings: ['foo@bar.com', 10, 100, 1],
         },
       }
@@ -6463,8 +6129,7 @@ describe('QueryBuilder', () => {
           bindings: [500, 1],
         },
         mssql: {
-          sql:
-            'update [users] set [balance] = ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [balance] = ? where [id] = ?;select @@rowcount',
           bindings: [500, 1],
         },
         'pg-redshift': {
@@ -6490,23 +6155,19 @@ describe('QueryBuilder', () => {
         }),
       {
         pg: {
-          sql:
-            'update "users" set "balance" = "balance" + ?, "times" = "times" + ?, "value" = "value" - ?, "subvalue" = "subvalue" - ? where "id" = ?',
+          sql: 'update "users" set "balance" = "balance" + ?, "times" = "times" + ?, "value" = "value" - ?, "subvalue" = "subvalue" - ? where "id" = ?',
           bindings: [10, 1, 50, 30, 1],
         },
         mysql: {
-          sql:
-            'update `users` set `balance` = `balance` + ?, `times` = `times` + ?, `value` = `value` - ?, `subvalue` = `subvalue` - ? where `id` = ?',
+          sql: 'update `users` set `balance` = `balance` + ?, `times` = `times` + ?, `value` = `value` - ?, `subvalue` = `subvalue` - ? where `id` = ?',
           bindings: [10, 1, 50, 30, 1],
         },
         mssql: {
-          sql:
-            'update [users] set [balance] = [balance] + ?, [times] = [times] + ?, [value] = [value] - ?, [subvalue] = [subvalue] - ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [balance] = [balance] + ?, [times] = [times] + ?, [value] = [value] - ?, [subvalue] = [subvalue] - ? where [id] = ?;select @@rowcount',
           bindings: [10, 1, 50, 30, 1],
         },
         'pg-redshift': {
-          sql:
-            'update "users" set "balance" = "balance" + ?, "times" = "times" + ?, "value" = "value" - ?, "subvalue" = "subvalue" - ? where "id" = ?',
+          sql: 'update "users" set "balance" = "balance" + ?, "times" = "times" + ?, "value" = "value" - ?, "subvalue" = "subvalue" - ? where "id" = ?',
           bindings: [10, 1, 50, 30, 1],
         },
       }
@@ -6536,8 +6197,7 @@ describe('QueryBuilder', () => {
           bindings: ['foo@bar.com', 1],
         },
         mssql: {
-          sql:
-            'update [users] set [email] = ? where [id] = ?;select @@rowcount',
+          sql: 'update [users] set [email] = ? where [id] = ?;select @@rowcount',
           bindings: ['foo@bar.com', 1],
         },
         'pg-redshift': {
@@ -6555,8 +6215,7 @@ describe('QueryBuilder', () => {
         bindings: [1.23, 1],
       },
       mssql: {
-        sql:
-          'update [users] set [balance] = [balance] + ? where [id] = ?;select @@rowcount',
+        sql: 'update [users] set [balance] = [balance] + ? where [id] = ?;select @@rowcount',
         bindings: [1.23, 1],
       },
       pg: {
@@ -6577,8 +6236,7 @@ describe('QueryBuilder', () => {
         bindings: [10, 1],
       },
       mssql: {
-        sql:
-          'update [users] set [balance] = [balance] - ? where [id] = ?;select @@rowcount',
+        sql: 'update [users] set [balance] = [balance] - ? where [id] = ?;select @@rowcount',
         bindings: [10, 1],
       },
       pg: {
@@ -6599,8 +6257,7 @@ describe('QueryBuilder', () => {
         bindings: [1.23, 1],
       },
       mssql: {
-        sql:
-          'update [users] set [balance] = [balance] - ? where [id] = ?;select @@rowcount',
+        sql: 'update [users] set [balance] = [balance] - ? where [id] = ?;select @@rowcount',
         bindings: [1.23, 1],
       },
       pg: {
@@ -6875,23 +6532,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'insert into `entries` (`secret`, `sequence`) values (?, (select count(*) from `entries` where `secret` = ?))',
+          sql: 'insert into `entries` (`secret`, `sequence`) values (?, (select count(*) from `entries` where `secret` = ?))',
           bindings: [123, 123],
         },
         mssql: {
-          sql:
-            'insert into [entries] ([secret], [sequence]) values (?, (select count(*) from [entries] where [secret] = ?))',
+          sql: 'insert into [entries] ([secret], [sequence]) values (?, (select count(*) from [entries] where [secret] = ?))',
           bindings: [123, 123],
         },
         pg: {
-          sql:
-            'insert into "entries" ("secret", "sequence") values (?, (select count(*) from "entries" where "secret" = ?))',
+          sql: 'insert into "entries" ("secret", "sequence") values (?, (select count(*) from "entries" where "secret" = ?))',
           bindings: [123, 123],
         },
         'pg-redshift': {
-          sql:
-            'insert into "entries" ("secret", "sequence") values (?, (select count(*) from "entries" where "secret" = ?))',
+          sql: 'insert into "entries" ("secret", "sequence") values (?, (select count(*) from "entries" where "secret" = ?))',
           bindings: [123, 123],
         },
       }
@@ -6911,23 +6564,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `student` left outer join `student_languages` on `student`.`id` = `student_languages`.`student_id` and `student_languages`.`code` = ?',
+          sql: 'select * from `student` left outer join `student_languages` on `student`.`id` = `student_languages`.`student_id` and `student_languages`.`code` = ?',
           bindings: ['en_US'],
         },
         mssql: {
-          sql:
-            'select * from [student] left outer join [student_languages] on [student].[id] = [student_languages].[student_id] and [student_languages].[code] = ?',
+          sql: 'select * from [student] left outer join [student_languages] on [student].[id] = [student_languages].[student_id] and [student_languages].[code] = ?',
           bindings: ['en_US'],
         },
         pg: {
-          sql:
-            'select * from "student" left outer join "student_languages" on "student"."id" = "student_languages"."student_id" and "student_languages"."code" = ?',
+          sql: 'select * from "student" left outer join "student_languages" on "student"."id" = "student_languages"."student_id" and "student_languages"."code" = ?',
           bindings: ['en_US'],
         },
         'pg-redshift': {
-          sql:
-            'select * from "student" left outer join "student_languages" on "student"."id" = "student_languages"."student_id" and "student_languages"."code" = ?',
+          sql: 'select * from "student" left outer join "student_languages" on "student"."id" = "student_languages"."student_id" and "student_languages"."code" = ?',
           bindings: ['en_US'],
         },
       }
@@ -7069,46 +6718,38 @@ describe('QueryBuilder', () => {
 
     testsql(one, {
       mysql: {
-        sql:
-          'delete from `word` where `page_id` in (select `id` from `page` where `chapter_id` in (select `id` from `chapter` where `book` = ?))',
+        sql: 'delete from `word` where `page_id` in (select `id` from `page` where `chapter_id` in (select `id` from `chapter` where `book` = ?))',
         bindings: [1],
       },
       mssql: {
-        sql:
-          'delete from [word] where [page_id] in (select [id] from [page] where [chapter_id] in (select [id] from [chapter] where [book] = ?));select @@rowcount',
+        sql: 'delete from [word] where [page_id] in (select [id] from [page] where [chapter_id] in (select [id] from [chapter] where [book] = ?));select @@rowcount',
         bindings: [1],
       },
       pg: {
-        sql:
-          'delete from "word" where "page_id" in (select "id" from "page" where "chapter_id" in (select "id" from "chapter" where "book" = ?))',
+        sql: 'delete from "word" where "page_id" in (select "id" from "page" where "chapter_id" in (select "id" from "chapter" where "book" = ?))',
         bindings: [1],
       },
       'pg-redshift': {
-        sql:
-          'delete from "word" where "page_id" in (select "id" from "page" where "chapter_id" in (select "id" from "chapter" where "book" = ?))',
+        sql: 'delete from "word" where "page_id" in (select "id" from "page" where "chapter_id" in (select "id" from "chapter" where "book" = ?))',
         bindings: [1],
       },
     });
 
     testsql(two, {
       mysql: {
-        sql:
-          'delete from `page` where `chapter_id` in (select `id` from `chapter` where `book` = ?)',
+        sql: 'delete from `page` where `chapter_id` in (select `id` from `chapter` where `book` = ?)',
         bindings: [1],
       },
       mssql: {
-        sql:
-          'delete from [page] where [chapter_id] in (select [id] from [chapter] where [book] = ?);select @@rowcount',
+        sql: 'delete from [page] where [chapter_id] in (select [id] from [chapter] where [book] = ?);select @@rowcount',
         bindings: [1],
       },
       pg: {
-        sql:
-          'delete from "page" where "chapter_id" in (select "id" from "chapter" where "book" = ?)',
+        sql: 'delete from "page" where "chapter_id" in (select "id" from "chapter" where "book" = ?)',
         bindings: [1],
       },
       'pg-redshift': {
-        sql:
-          'delete from "page" where "chapter_id" in (select "id" from "chapter" where "book" = ?)',
+        sql: 'delete from "page" where "chapter_id" in (select "id" from "chapter" where "book" = ?)',
         bindings: [1],
       },
     });
@@ -7148,23 +6789,19 @@ describe('QueryBuilder', () => {
         ),
       {
         mysql: {
-          sql:
-            'insert into recipients (recipient_id, email) select ?, ? where not exists (select 1 from `recipients` where `recipient_id` = ?)',
+          sql: 'insert into recipients (recipient_id, email) select ?, ? where not exists (select 1 from `recipients` where `recipient_id` = ?)',
           bindings: [1, 'foo@bar.com', 1],
         },
         mssql: {
-          sql:
-            'insert into recipients (recipient_id, email) select ?, ? where not exists (select 1 from [recipients] where [recipient_id] = ?)',
+          sql: 'insert into recipients (recipient_id, email) select ?, ? where not exists (select 1 from [recipients] where [recipient_id] = ?)',
           bindings: [1, 'foo@bar.com', 1],
         },
         pg: {
-          sql:
-            'insert into recipients (recipient_id, email) select ?, ? where not exists (select 1 from "recipients" where "recipient_id" = ?)',
+          sql: 'insert into recipients (recipient_id, email) select ?, ? where not exists (select 1 from "recipients" where "recipient_id" = ?)',
           bindings: [1, 'foo@bar.com', 1],
         },
         'pg-redshift': {
-          sql:
-            'insert into recipients (recipient_id, email) select ?, ? where not exists (select 1 from "recipients" where "recipient_id" = ?)',
+          sql: 'insert into recipients (recipient_id, email) select ?, ? where not exists (select 1 from "recipients" where "recipient_id" = ?)',
           bindings: [1, 'foo@bar.com', 1],
         },
       }
@@ -7187,23 +6824,19 @@ describe('QueryBuilder', () => {
 
     testsql(query, {
       mysql: {
-        sql:
-          'update `tblPerson` inner join `tblPersonData` on `tblPersonData`.`PersonId` = `tblPerson`.`PersonId` set `tblPerson`.`City` = ? where `tblPersonData`.`DataId` = ? and `tblPerson`.`PersonId` = ?',
+        sql: 'update `tblPerson` inner join `tblPersonData` on `tblPersonData`.`PersonId` = `tblPerson`.`PersonId` set `tblPerson`.`City` = ? where `tblPersonData`.`DataId` = ? and `tblPerson`.`PersonId` = ?',
         bindings: ['Boonesville', 1, 5],
       },
       mssql: {
-        sql:
-          'update [tblPerson] set [tblPerson].[City] = ? from [tblPerson] inner join [tblPersonData] on [tblPersonData].[PersonId] = [tblPerson].[PersonId] where [tblPersonData].[DataId] = ? and [tblPerson].[PersonId] = ?;select @@rowcount',
+        sql: 'update [tblPerson] set [tblPerson].[City] = ? from [tblPerson] inner join [tblPersonData] on [tblPersonData].[PersonId] = [tblPerson].[PersonId] where [tblPersonData].[DataId] = ? and [tblPerson].[PersonId] = ?;select @@rowcount',
         bindings: ['Boonesville', 1, 5],
       },
       pg: {
-        sql:
-          'update "tblPerson" set "tblPerson"."City" = ? where "tblPersonData"."DataId" = ? and "tblPerson"."PersonId" = ?',
+        sql: 'update "tblPerson" set "tblPerson"."City" = ? where "tblPersonData"."DataId" = ? and "tblPerson"."PersonId" = ?',
         bindings: ['Boonesville', 1, 5],
       },
       'pg-redshift': {
-        sql:
-          'update "tblPerson" set "tblPerson"."City" = ? where "tblPersonData"."DataId" = ? and "tblPerson"."PersonId" = ?',
+        sql: 'update "tblPerson" set "tblPerson"."City" = ? where "tblPersonData"."DataId" = ? and "tblPerson"."PersonId" = ?',
         bindings: ['Boonesville', 1, 5],
       },
     });
@@ -7229,13 +6862,11 @@ describe('QueryBuilder', () => {
       //   bindings: [1]
       // },
       pg: {
-        sql:
-          'insert into "recipients" (recipient_id, email) (select \'user\', \'user@foo.com\' where not exists (select 1 from "recipients" where "recipient_id" = ?))',
+        sql: 'insert into "recipients" (recipient_id, email) (select \'user\', \'user@foo.com\' where not exists (select 1 from "recipients" where "recipient_id" = ?))',
         bindings: [1],
       },
       'pg-redshift': {
-        sql:
-          'insert into "recipients" (recipient_id, email) (select \'user\', \'user@foo.com\' where not exists (select 1 from "recipients" where "recipient_id" = ?))',
+        sql: 'insert into "recipients" (recipient_id, email) (select \'user\', \'user@foo.com\' where not exists (select 1 from "recipients" where "recipient_id" = ?))',
         bindings: [1],
       },
     });
@@ -7313,18 +6944,15 @@ describe('QueryBuilder', () => {
         .join('table', 'table.array_column[1]', '=', raw('?', 1)),
       {
         mysql: {
-          sql:
-            'select * from `value` inner join `table` on `table`.`array_column[1]` = ?',
+          sql: 'select * from `value` inner join `table` on `table`.`array_column[1]` = ?',
           bindings: [1],
         },
         pg: {
-          sql:
-            'select * from "value" inner join "table" on "table"."array_column"[1] = ?',
+          sql: 'select * from "value" inner join "table" on "table"."array_column"[1] = ?',
           bindings: [1],
         },
         'pg-redshift': {
-          sql:
-            'select * from "value" inner join "table" on "table"."array_column"[1] = ?',
+          sql: 'select * from "value" inner join "table" on "table"."array_column"[1] = ?',
           bindings: [1],
         },
       }
@@ -7357,18 +6985,15 @@ describe('QueryBuilder', () => {
         //   bindings: ['e.dept_no']
         // },
         oracledb: {
-          sql:
-            'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) avg_sal_dept from "employee" "e" where "dept_no" = ?',
+          sql: 'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) avg_sal_dept from "employee" "e" where "dept_no" = ?',
           bindings: ['e.dept_no'],
         },
         pg: {
-          sql:
-            'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) avg_sal_dept from "employee" as "e" where "dept_no" = ?',
+          sql: 'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) avg_sal_dept from "employee" as "e" where "dept_no" = ?',
           bindings: ['e.dept_no'],
         },
         'pg-redshift': {
-          sql:
-            'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) avg_sal_dept from "employee" as "e" where "dept_no" = ?',
+          sql: 'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) avg_sal_dept from "employee" as "e" where "dept_no" = ?',
           bindings: ['e.dept_no'],
         },
       }
@@ -7391,28 +7016,23 @@ describe('QueryBuilder', () => {
         .where('dept_no', '=', 'e.dept_no'),
       {
         mysql: {
-          sql:
-            'select `e`.`lastname`, `e`.`salary`, (select `avg(salary)` from `employee` where dept_no = e.dept_no) as `avg_sal_dept` from `employee` as `e` where `dept_no` = ?',
+          sql: 'select `e`.`lastname`, `e`.`salary`, (select `avg(salary)` from `employee` where dept_no = e.dept_no) as `avg_sal_dept` from `employee` as `e` where `dept_no` = ?',
           bindings: ['e.dept_no'],
         },
         mssql: {
-          sql:
-            'select [e].[lastname], [e].[salary], (select [avg(salary)] from [employee] where dept_no = e.dept_no) as [avg_sal_dept] from [employee] as [e] where [dept_no] = ?',
+          sql: 'select [e].[lastname], [e].[salary], (select [avg(salary)] from [employee] where dept_no = e.dept_no) as [avg_sal_dept] from [employee] as [e] where [dept_no] = ?',
           bindings: ['e.dept_no'],
         },
         oracledb: {
-          sql:
-            'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) "avg_sal_dept" from "employee" "e" where "dept_no" = ?',
+          sql: 'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) "avg_sal_dept" from "employee" "e" where "dept_no" = ?',
           bindings: ['e.dept_no'],
         },
         pg: {
-          sql:
-            'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) as "avg_sal_dept" from "employee" as "e" where "dept_no" = ?',
+          sql: 'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) as "avg_sal_dept" from "employee" as "e" where "dept_no" = ?',
           bindings: ['e.dept_no'],
         },
         'pg-redshift': {
-          sql:
-            'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) as "avg_sal_dept" from "employee" as "e" where "dept_no" = ?',
+          sql: 'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) as "avg_sal_dept" from "employee" as "e" where "dept_no" = ?',
           bindings: ['e.dept_no'],
         },
       }
@@ -7433,28 +7053,23 @@ describe('QueryBuilder', () => {
         .where('dept_no', '=', 'e.dept_no'),
       {
         mysql: {
-          sql:
-            'select `e`.`lastname`, `e`.`salary`, (select `avg(salary)` from `employee` where dept_no = e.dept_no) as `avg_sal_dept` from `employee` as `e` where `dept_no` = ?',
+          sql: 'select `e`.`lastname`, `e`.`salary`, (select `avg(salary)` from `employee` where dept_no = e.dept_no) as `avg_sal_dept` from `employee` as `e` where `dept_no` = ?',
           bindings: ['e.dept_no'],
         },
         mssql: {
-          sql:
-            'select [e].[lastname], [e].[salary], (select [avg(salary)] from [employee] where dept_no = e.dept_no) as [avg_sal_dept] from [employee] as [e] where [dept_no] = ?',
+          sql: 'select [e].[lastname], [e].[salary], (select [avg(salary)] from [employee] where dept_no = e.dept_no) as [avg_sal_dept] from [employee] as [e] where [dept_no] = ?',
           bindings: ['e.dept_no'],
         },
         oracledb: {
-          sql:
-            'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) "avg_sal_dept" from "employee" "e" where "dept_no" = ?',
+          sql: 'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) "avg_sal_dept" from "employee" "e" where "dept_no" = ?',
           bindings: ['e.dept_no'],
         },
         pg: {
-          sql:
-            'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) as "avg_sal_dept" from "employee" as "e" where "dept_no" = ?',
+          sql: 'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) as "avg_sal_dept" from "employee" as "e" where "dept_no" = ?',
           bindings: ['e.dept_no'],
         },
         'pg-redshift': {
-          sql:
-            'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) as "avg_sal_dept" from "employee" as "e" where "dept_no" = ?',
+          sql: 'select "e"."lastname", "e"."salary", (select "avg(salary)" from "employee" where dept_no = e.dept_no) as "avg_sal_dept" from "employee" as "e" where "dept_no" = ?',
           bindings: ['e.dept_no'],
         },
       }
@@ -7478,23 +7093,19 @@ describe('QueryBuilder', () => {
         .where('dept_no', '=', 'e.dept_no'),
       {
         mysql: {
-          sql:
-            'select `e`.`lastname`, `e`.`salary`, (select `salary` from `employee` where dept_no = e.dept_no order by `salary` desc limit ?) as `top_dept_salary` from `employee` as `e` where `dept_no` = ?',
+          sql: 'select `e`.`lastname`, `e`.`salary`, (select `salary` from `employee` where dept_no = e.dept_no order by `salary` desc limit ?) as `top_dept_salary` from `employee` as `e` where `dept_no` = ?',
           bindings: [1, 'e.dept_no'],
         },
         mssql: {
-          sql:
-            'select [e].[lastname], [e].[salary], (select top (?) [salary] from [employee] where dept_no = e.dept_no order by [salary] desc) as [top_dept_salary] from [employee] as [e] where [dept_no] = ?',
+          sql: 'select [e].[lastname], [e].[salary], (select top (?) [salary] from [employee] where dept_no = e.dept_no order by [salary] desc) as [top_dept_salary] from [employee] as [e] where [dept_no] = ?',
           bindings: [1, 'e.dept_no'],
         },
         pg: {
-          sql:
-            'select "e"."lastname", "e"."salary", (select "salary" from "employee" where dept_no = e.dept_no order by "salary" desc limit ?) as "top_dept_salary" from "employee" as "e" where "dept_no" = ?',
+          sql: 'select "e"."lastname", "e"."salary", (select "salary" from "employee" where dept_no = e.dept_no order by "salary" desc limit ?) as "top_dept_salary" from "employee" as "e" where "dept_no" = ?',
           bindings: [1, 'e.dept_no'],
         },
         'pg-redshift': {
-          sql:
-            'select "e"."lastname", "e"."salary", (select "salary" from "employee" where dept_no = e.dept_no order by "salary" desc limit ?) as "top_dept_salary" from "employee" as "e" where "dept_no" = ?',
+          sql: 'select "e"."lastname", "e"."salary", (select "salary" from "employee" where dept_no = e.dept_no order by "salary" desc limit ?) as "top_dept_salary" from "employee" as "e" where "dept_no" = ?',
           bindings: [1, 'e.dept_no'],
         },
       }
@@ -7520,23 +7131,19 @@ describe('QueryBuilder', () => {
 
     testsql(chain, {
       mysql: {
-        sql:
-          'select * from `places` where ST_DWithin((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?), ?) AND ST_Distance((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?)) > ? AND places.id IN ?',
+        sql: 'select * from `places` where ST_DWithin((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?), ?) AND ST_Distance((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?)) > ? AND places.id IN ?',
         bindings: [-10, 10, 4326, 100000, -5, 5, 4326, 50000, [1, 2, 3]],
       },
       mssql: {
-        sql:
-          'select * from [places] where ST_DWithin((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?), ?) AND ST_Distance((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?)) > ? AND places.id IN ?',
+        sql: 'select * from [places] where ST_DWithin((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?), ?) AND ST_Distance((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?)) > ? AND places.id IN ?',
         bindings: [-10, 10, 4326, 100000, -5, 5, 4326, 50000, [1, 2, 3]],
       },
       pg: {
-        sql:
-          'select * from "places" where ST_DWithin((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?), ?) AND ST_Distance((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?)) > ? AND places.id IN ?',
+        sql: 'select * from "places" where ST_DWithin((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?), ?) AND ST_Distance((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?)) > ? AND places.id IN ?',
         bindings: [-10, 10, 4326, 100000, -5, 5, 4326, 50000, [1, 2, 3]],
       },
       'pg-redshift': {
-        sql:
-          'select * from "places" where ST_DWithin((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?), ?) AND ST_Distance((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?)) > ? AND places.id IN ?',
+        sql: 'select * from "places" where ST_DWithin((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?), ?) AND ST_Distance((places.address).xy, ST_SetSRID(ST_MakePoint(?,?),?)) > ? AND places.id IN ?',
         bindings: [-10, 10, 4326, 100000, -5, 5, 4326, 50000, [1, 2, 3]],
       },
     });
@@ -7551,23 +7158,19 @@ describe('QueryBuilder', () => {
         .where('id', 1),
       {
         mysql: {
-          sql:
-            'select * from `accounts` natural full join table1 where `id` = ?',
+          sql: 'select * from `accounts` natural full join table1 where `id` = ?',
           bindings: [1],
         },
         mssql: {
-          sql:
-            'select * from [accounts] natural full join table1 where [id] = ?',
+          sql: 'select * from [accounts] natural full join table1 where [id] = ?',
           bindings: [1],
         },
         pg: {
-          sql:
-            'select * from "accounts" natural full join table1 where "id" = ?',
+          sql: 'select * from "accounts" natural full join table1 where "id" = ?',
           bindings: [1],
         },
         'pg-redshift': {
-          sql:
-            'select * from "accounts" natural full join table1 where "id" = ?',
+          sql: 'select * from "accounts" natural full join table1 where "id" = ?',
           bindings: [1],
         },
       }
@@ -7587,20 +7190,16 @@ describe('QueryBuilder', () => {
         ),
       {
         mysql: {
-          sql:
-            'select * from `accounts` inner join `table1` on ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))',
+          sql: 'select * from `accounts` inner join `table1` on ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))',
         },
         mssql: {
-          sql:
-            'select * from [accounts] inner join [table1] on ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))',
+          sql: 'select * from [accounts] inner join [table1] on ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))',
         },
         pg: {
-          sql:
-            'select * from "accounts" inner join "table1" on ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))',
+          sql: 'select * from "accounts" inner join "table1" on ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))',
         },
         'pg-redshift': {
-          sql:
-            'select * from "accounts" inner join "table1" on ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))',
+          sql: 'select * from "accounts" inner join "table1" on ST_Contains(buildings_pluto.geom, ST_Centroid(buildings_building.geom))',
         },
       }
     );
@@ -7640,21 +7239,17 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'select * from `accounts` inner join `table1` using (`id`, `test`)',
+          sql: 'select * from `accounts` inner join `table1` using (`id`, `test`)',
         },
         mssql: {
           //sql: 'select * from [accounts] inner join [table1] on [accounts].[id] = [table1].[id]'
-          sql:
-            'select * from [accounts] inner join [table1] using ([id], [test])',
+          sql: 'select * from [accounts] inner join [table1] using ([id], [test])',
         },
         pg: {
-          sql:
-            'select * from "accounts" inner join "table1" using ("id", "test")',
+          sql: 'select * from "accounts" inner join "table1" using ("id", "test")',
         },
         'pg-redshift': {
-          sql:
-            'select * from "accounts" inner join "table1" using ("id", "test")',
+          sql: 'select * from "accounts" inner join "table1" using ("id", "test")',
         },
       }
     );
@@ -7710,16 +7305,13 @@ describe('QueryBuilder', () => {
         .denseRank('test_alias', ['email', 'name']),
       {
         mssql: {
-          sql:
-            'select *, dense_rank() over (order by [email], [name]) as test_alias from [accounts]',
+          sql: 'select *, dense_rank() over (order by [email], [name]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, dense_rank() over (order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (order by "email", "name") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, dense_rank() over (order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (order by "email", "name") as test_alias from "accounts"',
         },
       }
     );
@@ -7733,16 +7325,13 @@ describe('QueryBuilder', () => {
         .denseRank(null, ['email'], ['address', 'phone']),
       {
         mssql: {
-          sql:
-            'select *, dense_rank() over (partition by [address], [phone] order by [email]) from [accounts]',
+          sql: 'select *, dense_rank() over (partition by [address], [phone] order by [email]) from [accounts]',
         },
         pg: {
-          sql:
-            'select *, dense_rank() over (partition by "address", "phone" order by "email") from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address", "phone" order by "email") from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, dense_rank() over (partition by "address", "phone" order by "email") from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address", "phone" order by "email") from "accounts"',
         },
       }
     );
@@ -7753,16 +7342,13 @@ describe('QueryBuilder', () => {
       qb().select('*').from('accounts').denseRank(null, 'email', 'address'),
       {
         mssql: {
-          sql:
-            'select *, dense_rank() over (partition by [address] order by [email]) from [accounts]',
+          sql: 'select *, dense_rank() over (partition by [address] order by [email]) from [accounts]',
         },
         pg: {
-          sql:
-            'select *, dense_rank() over (partition by "address" order by "email") from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address" order by "email") from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, dense_rank() over (partition by "address" order by "email") from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address" order by "email") from "accounts"',
         },
       }
     );
@@ -7776,16 +7362,13 @@ describe('QueryBuilder', () => {
         .denseRank('test_alias', ['email'], ['address', 'phone']),
       {
         mssql: {
-          sql:
-            'select *, dense_rank() over (partition by [address], [phone] order by [email]) as test_alias from [accounts]',
+          sql: 'select *, dense_rank() over (partition by [address], [phone] order by [email]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, dense_rank() over (partition by "address", "phone" order by "email") as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address", "phone" order by "email") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, dense_rank() over (partition by "address", "phone" order by "email") as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address", "phone" order by "email") as test_alias from "accounts"',
         },
       }
     );
@@ -7799,16 +7382,13 @@ describe('QueryBuilder', () => {
         .denseRank('test_alias', 'email', 'address'),
       {
         mssql: {
-          sql:
-            'select *, dense_rank() over (partition by [address] order by [email]) as test_alias from [accounts]',
+          sql: 'select *, dense_rank() over (partition by [address] order by [email]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, dense_rank() over (partition by "address" order by "email") as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address" order by "email") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, dense_rank() over (partition by "address" order by "email") as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address" order by "email") as test_alias from "accounts"',
         },
       }
     );
@@ -7846,16 +7426,13 @@ describe('QueryBuilder', () => {
         }),
       {
         mssql: {
-          sql:
-            'select *, dense_rank() over (partition by [address] order by [email]) as test_alias from [accounts]',
+          sql: 'select *, dense_rank() over (partition by [address] order by [email]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, dense_rank() over (partition by "address" order by "email") as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address" order by "email") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, dense_rank() over (partition by "address" order by "email") as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address" order by "email") as test_alias from "accounts"',
         },
       }
     );
@@ -7871,16 +7448,13 @@ describe('QueryBuilder', () => {
         }),
       {
         mssql: {
-          sql:
-            'select *, dense_rank() over (partition by [address], [phone] order by [email], [name]) as test_alias from [accounts]',
+          sql: 'select *, dense_rank() over (partition by [address], [phone] order by [email], [name]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, dense_rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, dense_rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
         },
       }
     );
@@ -7899,16 +7473,13 @@ describe('QueryBuilder', () => {
         }),
       {
         mssql: {
-          sql:
-            'select *, dense_rank() over (partition by [address], [phone] order by [email], [name]) as test_alias from [accounts]',
+          sql: 'select *, dense_rank() over (partition by [address], [phone] order by [email], [name]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, dense_rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, dense_rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
         },
       }
     );
@@ -7923,16 +7494,13 @@ describe('QueryBuilder', () => {
         .denseRank('second_alias', 'address'),
       {
         mssql: {
-          sql:
-            'select *, dense_rank() over (order by [email]) as first_alias, dense_rank() over (order by [address]) as second_alias from [accounts]',
+          sql: 'select *, dense_rank() over (order by [email]) as first_alias, dense_rank() over (order by [address]) as second_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, dense_rank() over (order by "email") as first_alias, dense_rank() over (order by "address") as second_alias from "accounts"',
+          sql: 'select *, dense_rank() over (order by "email") as first_alias, dense_rank() over (order by "address") as second_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, dense_rank() over (order by "email") as first_alias, dense_rank() over (order by "address") as second_alias from "accounts"',
+          sql: 'select *, dense_rank() over (order by "email") as first_alias, dense_rank() over (order by "address") as second_alias from "accounts"',
         },
       }
     );
@@ -7946,16 +7514,13 @@ describe('QueryBuilder', () => {
         .denseRank(null, raw('partition by address order by email')),
       {
         mssql: {
-          sql:
-            'select *, dense_rank() over (partition by address order by email) from [accounts]',
+          sql: 'select *, dense_rank() over (partition by address order by email) from [accounts]',
         },
         pg: {
-          sql:
-            'select *, dense_rank() over (partition by address order by email) from "accounts"',
+          sql: 'select *, dense_rank() over (partition by address order by email) from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, dense_rank() over (partition by address order by email) from "accounts"',
+          sql: 'select *, dense_rank() over (partition by address order by email) from "accounts"',
         },
       }
     );
@@ -7969,16 +7534,13 @@ describe('QueryBuilder', () => {
         .denseRank('test_alias', raw('partition by address order by email')),
       {
         mssql: {
-          sql:
-            'select *, dense_rank() over (partition by address order by email) as test_alias from [accounts]',
+          sql: 'select *, dense_rank() over (partition by address order by email) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, dense_rank() over (partition by address order by email) as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (partition by address order by email) as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, dense_rank() over (partition by address order by email) as test_alias from "accounts"',
+          sql: 'select *, dense_rank() over (partition by address order by email) as test_alias from "accounts"',
         },
       }
     );
@@ -8003,16 +7565,13 @@ describe('QueryBuilder', () => {
       qb().select('*').from('accounts').rank('test_alias', ['email', 'name']),
       {
         mssql: {
-          sql:
-            'select *, rank() over (order by [email], [name]) as test_alias from [accounts]',
+          sql: 'select *, rank() over (order by [email], [name]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, rank() over (order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, rank() over (order by "email", "name") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, rank() over (order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, rank() over (order by "email", "name") as test_alias from "accounts"',
         },
       }
     );
@@ -8026,16 +7585,13 @@ describe('QueryBuilder', () => {
         .rank(null, ['email'], ['address', 'phone']),
       {
         mssql: {
-          sql:
-            'select *, rank() over (partition by [address], [phone] order by [email]) from [accounts]',
+          sql: 'select *, rank() over (partition by [address], [phone] order by [email]) from [accounts]',
         },
         pg: {
-          sql:
-            'select *, rank() over (partition by "address", "phone" order by "email") from "accounts"',
+          sql: 'select *, rank() over (partition by "address", "phone" order by "email") from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, rank() over (partition by "address", "phone" order by "email") from "accounts"',
+          sql: 'select *, rank() over (partition by "address", "phone" order by "email") from "accounts"',
         },
       }
     );
@@ -8044,16 +7600,13 @@ describe('QueryBuilder', () => {
   it('rank with string', function () {
     testsql(qb().select('*').from('accounts').rank(null, 'email', 'address'), {
       mssql: {
-        sql:
-          'select *, rank() over (partition by [address] order by [email]) from [accounts]',
+        sql: 'select *, rank() over (partition by [address] order by [email]) from [accounts]',
       },
       pg: {
-        sql:
-          'select *, rank() over (partition by "address" order by "email") from "accounts"',
+        sql: 'select *, rank() over (partition by "address" order by "email") from "accounts"',
       },
       oracledb: {
-        sql:
-          'select *, rank() over (partition by "address" order by "email") from "accounts"',
+        sql: 'select *, rank() over (partition by "address" order by "email") from "accounts"',
       },
     });
   });
@@ -8066,16 +7619,13 @@ describe('QueryBuilder', () => {
         .rank('test_alias', ['email'], ['address', 'phone']),
       {
         mssql: {
-          sql:
-            'select *, rank() over (partition by [address], [phone] order by [email]) as test_alias from [accounts]',
+          sql: 'select *, rank() over (partition by [address], [phone] order by [email]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, rank() over (partition by "address", "phone" order by "email") as test_alias from "accounts"',
+          sql: 'select *, rank() over (partition by "address", "phone" order by "email") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, rank() over (partition by "address", "phone" order by "email") as test_alias from "accounts"',
+          sql: 'select *, rank() over (partition by "address", "phone" order by "email") as test_alias from "accounts"',
         },
       }
     );
@@ -8086,16 +7636,13 @@ describe('QueryBuilder', () => {
       qb().select('*').from('accounts').rank('test_alias', 'email', 'address'),
       {
         mssql: {
-          sql:
-            'select *, rank() over (partition by [address] order by [email]) as test_alias from [accounts]',
+          sql: 'select *, rank() over (partition by [address] order by [email]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, rank() over (partition by "address" order by "email") as test_alias from "accounts"',
+          sql: 'select *, rank() over (partition by "address" order by "email") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, rank() over (partition by "address" order by "email") as test_alias from "accounts"',
+          sql: 'select *, rank() over (partition by "address" order by "email") as test_alias from "accounts"',
         },
       }
     );
@@ -8133,16 +7680,13 @@ describe('QueryBuilder', () => {
         }),
       {
         mssql: {
-          sql:
-            'select *, rank() over (partition by [address] order by [email]) as test_alias from [accounts]',
+          sql: 'select *, rank() over (partition by [address] order by [email]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, rank() over (partition by "address" order by "email") as test_alias from "accounts"',
+          sql: 'select *, rank() over (partition by "address" order by "email") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, rank() over (partition by "address" order by "email") as test_alias from "accounts"',
+          sql: 'select *, rank() over (partition by "address" order by "email") as test_alias from "accounts"',
         },
       }
     );
@@ -8158,16 +7702,13 @@ describe('QueryBuilder', () => {
         }),
       {
         mssql: {
-          sql:
-            'select *, rank() over (partition by [address], [phone] order by [email], [name]) as test_alias from [accounts]',
+          sql: 'select *, rank() over (partition by [address], [phone] order by [email], [name]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
         },
       }
     );
@@ -8186,16 +7727,13 @@ describe('QueryBuilder', () => {
         }),
       {
         mssql: {
-          sql:
-            'select *, rank() over (partition by [address], [phone] order by [email], [name]) as test_alias from [accounts]',
+          sql: 'select *, rank() over (partition by [address], [phone] order by [email], [name]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, rank() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
         },
       }
     );
@@ -8210,16 +7748,13 @@ describe('QueryBuilder', () => {
         .rank('second_alias', 'address'),
       {
         mssql: {
-          sql:
-            'select *, rank() over (order by [email]) as first_alias, rank() over (order by [address]) as second_alias from [accounts]',
+          sql: 'select *, rank() over (order by [email]) as first_alias, rank() over (order by [address]) as second_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, rank() over (order by "email") as first_alias, rank() over (order by "address") as second_alias from "accounts"',
+          sql: 'select *, rank() over (order by "email") as first_alias, rank() over (order by "address") as second_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, rank() over (order by "email") as first_alias, rank() over (order by "address") as second_alias from "accounts"',
+          sql: 'select *, rank() over (order by "email") as first_alias, rank() over (order by "address") as second_alias from "accounts"',
         },
       }
     );
@@ -8233,16 +7768,13 @@ describe('QueryBuilder', () => {
         .rank(null, raw('partition by address order by email')),
       {
         mssql: {
-          sql:
-            'select *, rank() over (partition by address order by email) from [accounts]',
+          sql: 'select *, rank() over (partition by address order by email) from [accounts]',
         },
         pg: {
-          sql:
-            'select *, rank() over (partition by address order by email) from "accounts"',
+          sql: 'select *, rank() over (partition by address order by email) from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, rank() over (partition by address order by email) from "accounts"',
+          sql: 'select *, rank() over (partition by address order by email) from "accounts"',
         },
       }
     );
@@ -8256,16 +7788,13 @@ describe('QueryBuilder', () => {
         .rank('test_alias', raw('partition by address order by email')),
       {
         mssql: {
-          sql:
-            'select *, rank() over (partition by address order by email) as test_alias from [accounts]',
+          sql: 'select *, rank() over (partition by address order by email) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, rank() over (partition by address order by email) as test_alias from "accounts"',
+          sql: 'select *, rank() over (partition by address order by email) as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, rank() over (partition by address order by email) as test_alias from "accounts"',
+          sql: 'select *, rank() over (partition by address order by email) as test_alias from "accounts"',
         },
       }
     );
@@ -8293,16 +7822,13 @@ describe('QueryBuilder', () => {
         .rowNumber('test_alias', ['email', 'name']),
       {
         mssql: {
-          sql:
-            'select *, row_number() over (order by [email], [name]) as test_alias from [accounts]',
+          sql: 'select *, row_number() over (order by [email], [name]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, row_number() over (order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, row_number() over (order by "email", "name") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, row_number() over (order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, row_number() over (order by "email", "name") as test_alias from "accounts"',
         },
       }
     );
@@ -8316,16 +7842,13 @@ describe('QueryBuilder', () => {
         .rowNumber(null, ['email'], ['address', 'phone']),
       {
         mssql: {
-          sql:
-            'select *, row_number() over (partition by [address], [phone] order by [email]) from [accounts]',
+          sql: 'select *, row_number() over (partition by [address], [phone] order by [email]) from [accounts]',
         },
         pg: {
-          sql:
-            'select *, row_number() over (partition by "address", "phone" order by "email") from "accounts"',
+          sql: 'select *, row_number() over (partition by "address", "phone" order by "email") from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, row_number() over (partition by "address", "phone" order by "email") from "accounts"',
+          sql: 'select *, row_number() over (partition by "address", "phone" order by "email") from "accounts"',
         },
       }
     );
@@ -8336,16 +7859,13 @@ describe('QueryBuilder', () => {
       qb().select('*').from('accounts').rowNumber(null, 'email', 'address'),
       {
         mssql: {
-          sql:
-            'select *, row_number() over (partition by [address] order by [email]) from [accounts]',
+          sql: 'select *, row_number() over (partition by [address] order by [email]) from [accounts]',
         },
         pg: {
-          sql:
-            'select *, row_number() over (partition by "address" order by "email") from "accounts"',
+          sql: 'select *, row_number() over (partition by "address" order by "email") from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, row_number() over (partition by "address" order by "email") from "accounts"',
+          sql: 'select *, row_number() over (partition by "address" order by "email") from "accounts"',
         },
       }
     );
@@ -8359,16 +7879,13 @@ describe('QueryBuilder', () => {
         .rowNumber('test_alias', ['email'], ['address', 'phone']),
       {
         mssql: {
-          sql:
-            'select *, row_number() over (partition by [address], [phone] order by [email]) as test_alias from [accounts]',
+          sql: 'select *, row_number() over (partition by [address], [phone] order by [email]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, row_number() over (partition by "address", "phone" order by "email") as test_alias from "accounts"',
+          sql: 'select *, row_number() over (partition by "address", "phone" order by "email") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, row_number() over (partition by "address", "phone" order by "email") as test_alias from "accounts"',
+          sql: 'select *, row_number() over (partition by "address", "phone" order by "email") as test_alias from "accounts"',
         },
       }
     );
@@ -8382,16 +7899,13 @@ describe('QueryBuilder', () => {
         .rowNumber('test_alias', 'email', 'address'),
       {
         mssql: {
-          sql:
-            'select *, row_number() over (partition by [address] order by [email]) as test_alias from [accounts]',
+          sql: 'select *, row_number() over (partition by [address] order by [email]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, row_number() over (partition by "address" order by "email") as test_alias from "accounts"',
+          sql: 'select *, row_number() over (partition by "address" order by "email") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, row_number() over (partition by "address" order by "email") as test_alias from "accounts"',
+          sql: 'select *, row_number() over (partition by "address" order by "email") as test_alias from "accounts"',
         },
       }
     );
@@ -8429,16 +7943,13 @@ describe('QueryBuilder', () => {
         }),
       {
         mssql: {
-          sql:
-            'select *, row_number() over (partition by [address] order by [email]) as test_alias from [accounts]',
+          sql: 'select *, row_number() over (partition by [address] order by [email]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, row_number() over (partition by "address" order by "email") as test_alias from "accounts"',
+          sql: 'select *, row_number() over (partition by "address" order by "email") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, row_number() over (partition by "address" order by "email") as test_alias from "accounts"',
+          sql: 'select *, row_number() over (partition by "address" order by "email") as test_alias from "accounts"',
         },
       }
     );
@@ -8454,16 +7965,13 @@ describe('QueryBuilder', () => {
         }),
       {
         mssql: {
-          sql:
-            'select *, row_number() over (partition by [address], [phone] order by [email], [name]) as test_alias from [accounts]',
+          sql: 'select *, row_number() over (partition by [address], [phone] order by [email], [name]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, row_number() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, row_number() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, row_number() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, row_number() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
         },
       }
     );
@@ -8482,16 +7990,13 @@ describe('QueryBuilder', () => {
         }),
       {
         mssql: {
-          sql:
-            'select *, row_number() over (partition by [address], [phone] order by [email], [name]) as test_alias from [accounts]',
+          sql: 'select *, row_number() over (partition by [address], [phone] order by [email], [name]) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, row_number() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, row_number() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, row_number() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
+          sql: 'select *, row_number() over (partition by "address", "phone" order by "email", "name") as test_alias from "accounts"',
         },
       }
     );
@@ -8506,16 +8011,13 @@ describe('QueryBuilder', () => {
         .rowNumber('second_alias', 'address'),
       {
         mssql: {
-          sql:
-            'select *, row_number() over (order by [email]) as first_alias, row_number() over (order by [address]) as second_alias from [accounts]',
+          sql: 'select *, row_number() over (order by [email]) as first_alias, row_number() over (order by [address]) as second_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, row_number() over (order by "email") as first_alias, row_number() over (order by "address") as second_alias from "accounts"',
+          sql: 'select *, row_number() over (order by "email") as first_alias, row_number() over (order by "address") as second_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, row_number() over (order by "email") as first_alias, row_number() over (order by "address") as second_alias from "accounts"',
+          sql: 'select *, row_number() over (order by "email") as first_alias, row_number() over (order by "address") as second_alias from "accounts"',
         },
       }
     );
@@ -8529,16 +8031,13 @@ describe('QueryBuilder', () => {
         .rowNumber(null, raw('partition by address order by email')),
       {
         mssql: {
-          sql:
-            'select *, row_number() over (partition by address order by email) from [accounts]',
+          sql: 'select *, row_number() over (partition by address order by email) from [accounts]',
         },
         pg: {
-          sql:
-            'select *, row_number() over (partition by address order by email) from "accounts"',
+          sql: 'select *, row_number() over (partition by address order by email) from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, row_number() over (partition by address order by email) from "accounts"',
+          sql: 'select *, row_number() over (partition by address order by email) from "accounts"',
         },
       }
     );
@@ -8552,16 +8051,13 @@ describe('QueryBuilder', () => {
         .rowNumber('test_alias', raw('partition by address order by email')),
       {
         mssql: {
-          sql:
-            'select *, row_number() over (partition by address order by email) as test_alias from [accounts]',
+          sql: 'select *, row_number() over (partition by address order by email) as test_alias from [accounts]',
         },
         pg: {
-          sql:
-            'select *, row_number() over (partition by address order by email) as test_alias from "accounts"',
+          sql: 'select *, row_number() over (partition by address order by email) as test_alias from "accounts"',
         },
         oracledb: {
-          sql:
-            'select *, row_number() over (partition by address order by email) as test_alias from "accounts"',
+          sql: 'select *, row_number() over (partition by address order by email) as test_alias from "accounts"',
         },
       }
     );
@@ -8634,28 +8130,23 @@ describe('QueryBuilder', () => {
         ),
       {
         mysql: {
-          sql:
-            'select `A`.`nid` as `id` from nidmap2 AS A inner join (SELECT MIN(nid) AS location_id FROM nidmap2) AS B on `A`.`x` = `B`.`x`',
+          sql: 'select `A`.`nid` as `id` from nidmap2 AS A inner join (SELECT MIN(nid) AS location_id FROM nidmap2) AS B on `A`.`x` = `B`.`x`',
           bindings: [],
         },
         mssql: {
-          sql:
-            'select [A].[nid] as [id] from nidmap2 AS A inner join (SELECT MIN(nid) AS location_id FROM nidmap2) AS B on [A].[x] = [B].[x]',
+          sql: 'select [A].[nid] as [id] from nidmap2 AS A inner join (SELECT MIN(nid) AS location_id FROM nidmap2) AS B on [A].[x] = [B].[x]',
           bindings: [],
         },
         oracledb: {
-          sql:
-            'select "A"."nid" "id" from nidmap2 AS A inner join (SELECT MIN(nid) AS location_id FROM nidmap2) AS B on "A"."x" = "B"."x"',
+          sql: 'select "A"."nid" "id" from nidmap2 AS A inner join (SELECT MIN(nid) AS location_id FROM nidmap2) AS B on "A"."x" = "B"."x"',
           bindings: [],
         },
         pg: {
-          sql:
-            'select "A"."nid" as "id" from nidmap2 AS A inner join (SELECT MIN(nid) AS location_id FROM nidmap2) AS B on "A"."x" = "B"."x"',
+          sql: 'select "A"."nid" as "id" from nidmap2 AS A inner join (SELECT MIN(nid) AS location_id FROM nidmap2) AS B on "A"."x" = "B"."x"',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select "A"."nid" as "id" from nidmap2 AS A inner join (SELECT MIN(nid) AS location_id FROM nidmap2) AS B on "A"."x" = "B"."x"',
+          sql: 'select "A"."nid" as "id" from nidmap2 AS A inner join (SELECT MIN(nid) AS location_id FROM nidmap2) AS B on "A"."x" = "B"."x"',
           bindings: [],
         },
       }
@@ -8672,23 +8163,19 @@ describe('QueryBuilder', () => {
         }),
       {
         mysql: {
-          sql:
-            'insert into `entries` (`secret`, `sequence`) values (?, (select count(*) from `entries` where `secret` = ?))',
+          sql: 'insert into `entries` (`secret`, `sequence`) values (?, (select count(*) from `entries` where `secret` = ?))',
           bindings: [123, 123],
         },
         mssql: {
-          sql:
-            'insert into [entries] ([secret], [sequence]) values (?, (select count(*) from [entries] where [secret] = ?))',
+          sql: 'insert into [entries] ([secret], [sequence]) values (?, (select count(*) from [entries] where [secret] = ?))',
           bindings: [123, 123],
         },
         pg: {
-          sql:
-            'insert into "entries" ("secret", "sequence") values (?, (select count(*) from "entries" where "secret" = ?))',
+          sql: 'insert into "entries" ("secret", "sequence") values (?, (select count(*) from "entries" where "secret" = ?))',
           bindings: [123, 123],
         },
         'pg-redshift': {
-          sql:
-            'insert into "entries" ("secret", "sequence") values (?, (select count(*) from "entries" where "secret" = ?))',
+          sql: 'insert into "entries" ("secret", "sequence") values (?, (select count(*) from "entries" where "secret" = ?))',
           bindings: [123, 123],
         },
       }
@@ -8737,28 +8224,23 @@ describe('QueryBuilder', () => {
         .where('g.secret', 123),
       {
         mysql: {
-          sql:
-            'select ?, `g`.`f` from (select ? as f) as `g` where `g`.`secret` = ?',
+          sql: 'select ?, `g`.`f` from (select ? as f) as `g` where `g`.`secret` = ?',
           bindings: ['outer raw select', 'inner raw select', 123],
         },
         mssql: {
-          sql:
-            'select ?, [g].[f] from (select ? as f) as [g] where [g].[secret] = ?',
+          sql: 'select ?, [g].[f] from (select ? as f) as [g] where [g].[secret] = ?',
           bindings: ['outer raw select', 'inner raw select', 123],
         },
         oracledb: {
-          sql:
-            'select ?, "g"."f" from (select ? as f) "g" where "g"."secret" = ?',
+          sql: 'select ?, "g"."f" from (select ? as f) "g" where "g"."secret" = ?',
           bindings: ['outer raw select', 'inner raw select', 123],
         },
         pg: {
-          sql:
-            'select ?, "g"."f" from (select ? as f) as "g" where "g"."secret" = ?',
+          sql: 'select ?, "g"."f" from (select ? as f) as "g" where "g"."secret" = ?',
           bindings: ['outer raw select', 'inner raw select', 123],
         },
         'pg-redshift': {
-          sql:
-            'select ?, "g"."f" from (select ? as f) as "g" where "g"."secret" = ?',
+          sql: 'select ?, "g"."f" from (select ? as f) as "g" where "g"."secret" = ?',
           bindings: ['outer raw select', 'inner raw select', 123],
         },
       }
@@ -8798,23 +8280,19 @@ describe('QueryBuilder', () => {
       }),
       {
         mysql: {
-          sql:
-            'select * from `accounts` where `id` = ? and `name` in (?, ?, ?)',
+          sql: 'select * from `accounts` where `id` = ? and `name` in (?, ?, ?)',
           bindings: [1, 'a', 'b', 'c'],
         },
         mssql: {
-          sql:
-            'select * from [accounts] where [id] = ? and [name] in (?, ?, ?)',
+          sql: 'select * from [accounts] where [id] = ? and [name] in (?, ?, ?)',
           bindings: [1, 'a', 'b', 'c'],
         },
         pg: {
-          sql:
-            'select * from "accounts" where "id" = ? and "name" in (?, ?, ?)',
+          sql: 'select * from "accounts" where "id" = ? and "name" in (?, ?, ?)',
           bindings: [1, 'a', 'b', 'c'],
         },
         'pg-redshift': {
-          sql:
-            'select * from "accounts" where "id" = ? and "name" in (?, ?, ?)',
+          sql: 'select * from "accounts" where "id" = ? and "name" in (?, ?, ?)',
           bindings: [1, 'a', 'b', 'c'],
         },
       }
@@ -8835,20 +8313,16 @@ describe('QueryBuilder', () => {
       qb().select('foo_id').from('foos').modify(withBars, 'foos', 'bar_id'),
       {
         mysql: {
-          sql:
-            'select `foo_id`, `bars`.* from `foos` left join `bars` on `foos`.`bar_id` = `bars`.`id`',
+          sql: 'select `foo_id`, `bars`.* from `foos` left join `bars` on `foos`.`bar_id` = `bars`.`id`',
         },
         mssql: {
-          sql:
-            'select [foo_id], [bars].* from [foos] left join [bars] on [foos].[bar_id] = [bars].[id]',
+          sql: 'select [foo_id], [bars].* from [foos] left join [bars] on [foos].[bar_id] = [bars].[id]',
         },
         pg: {
-          sql:
-            'select "foo_id", "bars".* from "foos" left join "bars" on "foos"."bar_id" = "bars"."id"',
+          sql: 'select "foo_id", "bars".* from "foos" left join "bars" on "foos"."bar_id" = "bars"."id"',
         },
         'pg-redshift': {
-          sql:
-            'select "foo_id", "bars".* from "foos" left join "bars" on "foos"."bar_id" = "bars"."id"',
+          sql: 'select "foo_id", "bars".* from "foos" left join "bars" on "foos"."bar_id" = "bars"."id"',
         },
       }
     );
@@ -9045,23 +8519,19 @@ describe('QueryBuilder', () => {
       }),
       {
         mysql: {
-          sql:
-            'select * from `users` where `id` = ? or (`email` = ? and `id` = ?)',
+          sql: 'select * from `users` where `id` = ? or (`email` = ? and `id` = ?)',
           bindings: [1, 'foo', 2],
         },
         mssql: {
-          sql:
-            'select * from [users] where [id] = ? or ([email] = ? and [id] = ?)',
+          sql: 'select * from [users] where [id] = ? or ([email] = ? and [id] = ?)',
           bindings: [1, 'foo', 2],
         },
         pg: {
-          sql:
-            'select * from "users" where "id" = ? or ("email" = ? and "id" = ?)',
+          sql: 'select * from "users" where "id" = ? or ("email" = ? and "id" = ?)',
           bindings: [1, 'foo', 2],
         },
         'pg-redshift': {
-          sql:
-            'select * from "users" where "id" = ? or ("email" = ? and "id" = ?)',
+          sql: 'select * from "users" where "id" = ? or ("email" = ? and "id" = ?)',
           bindings: [1, 'foo', 2],
         },
       }
@@ -9156,28 +8626,23 @@ describe('QueryBuilder', () => {
         .into('users'),
       {
         mysql: {
-          sql:
-            'insert into `users` (`id`, `name`, `occupation`) values (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+          sql: 'insert into `users` (`id`, `name`, `occupation`) values (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
           bindings: ['test', 1, 'none'],
         },
         oracledb: {
-          sql:
-            'begin execute immediate \'insert into "users" ("id", "name", "occupation") values (DEFAULT, :1, DEFAULT)\' using ?; execute immediate \'insert into "users" ("id", "name", "occupation") values (:1, DEFAULT, :2)\' using ?, ?;end;',
+          sql: 'begin execute immediate \'insert into "users" ("id", "name", "occupation") values (DEFAULT, :1, DEFAULT)\' using ?; execute immediate \'insert into "users" ("id", "name", "occupation") values (:1, DEFAULT, :2)\' using ?, ?;end;',
           bindings: ['test', 1, 'none'],
         },
         mssql: {
-          sql:
-            'insert into [users] ([id], [name], [occupation]) values (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+          sql: 'insert into [users] ([id], [name], [occupation]) values (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
           bindings: ['test', 1, 'none'],
         },
         pg: {
-          sql:
-            'insert into "users" ("id", "name", "occupation") values (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+          sql: 'insert into "users" ("id", "name", "occupation") values (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
           bindings: ['test', 1, 'none'],
         },
         'pg-redshift': {
-          sql:
-            'insert into "users" ("id", "name", "occupation") values (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
+          sql: 'insert into "users" ("id", "name", "occupation") values (DEFAULT, ?, DEFAULT), (?, DEFAULT, ?)',
           bindings: ['test', 1, 'none'],
         },
       }
@@ -9292,28 +8757,23 @@ describe('QueryBuilder', () => {
         .hintComment('hint1()'),
       {
         mysql: {
-          sql:
-            'select /*+ hint1() */ `c1` as `c1`, (select /*+ hint2() */ `c2` from `t2` limit ?) as `c2` from `t1`',
+          sql: 'select /*+ hint1() */ `c1` as `c1`, (select /*+ hint2() */ `c2` from `t2` limit ?) as `c2` from `t1`',
           bindings: [1],
         },
         oracledb: {
-          sql:
-            'select /*+ hint1() */ "c1" "c1", (select * from (select /*+ hint2() */ "c2" from "t2") where rownum <= ?) "c2" from "t1"',
+          sql: 'select /*+ hint1() */ "c1" "c1", (select * from (select /*+ hint2() */ "c2" from "t2") where rownum <= ?) "c2" from "t1"',
           bindings: [1],
         },
         mssql: {
-          sql:
-            'select /*+ hint1() */ [c1] as [c1], (select /*+ hint2() */ top (?) [c2] from [t2]) as [c2] from [t1]',
+          sql: 'select /*+ hint1() */ [c1] as [c1], (select /*+ hint2() */ top (?) [c2] from [t2]) as [c2] from [t1]',
           bindings: [1],
         },
         pg: {
-          sql:
-            'select /*+ hint1() */ "c1" as "c1", (select /*+ hint2() */ "c2" from "t2" limit ?) as "c2" from "t1"',
+          sql: 'select /*+ hint1() */ "c1" as "c1", (select /*+ hint2() */ "c2" from "t2" limit ?) as "c2" from "t1"',
           bindings: [1],
         },
         'pg-redshift': {
-          sql:
-            'select /*+ hint1() */ "c1" as "c1", (select /*+ hint2() */ "c2" from "t2" limit ?) as "c2" from "t1"',
+          sql: 'select /*+ hint1() */ "c1" as "c1", (select /*+ hint2() */ "c2" from "t2" limit ?) as "c2" from "t1"',
           bindings: [1],
         },
       }
@@ -9328,28 +8788,23 @@ describe('QueryBuilder', () => {
         .unionAll(qb().from('t2').hintComment('hint2()')),
       {
         mysql: {
-          sql:
-            'select /*+ hint1() */ * from `t1` union all select /*+ hint2() */ * from `t2`',
+          sql: 'select /*+ hint1() */ * from `t1` union all select /*+ hint2() */ * from `t2`',
           bindings: [],
         },
         oracledb: {
-          sql:
-            'select /*+ hint1() */ * from "t1" union all select /*+ hint2() */ * from "t2"',
+          sql: 'select /*+ hint1() */ * from "t1" union all select /*+ hint2() */ * from "t2"',
           bindings: [],
         },
         mssql: {
-          sql:
-            'select /*+ hint1() */ * from [t1] union all select /*+ hint2() */ * from [t2]',
+          sql: 'select /*+ hint1() */ * from [t1] union all select /*+ hint2() */ * from [t2]',
           bindings: [],
         },
         pg: {
-          sql:
-            'select /*+ hint1() */ * from "t1" union all select /*+ hint2() */ * from "t2"',
+          sql: 'select /*+ hint1() */ * from "t1" union all select /*+ hint2() */ * from "t2"',
           bindings: [],
         },
         'pg-redshift': {
-          sql:
-            'select /*+ hint1() */ * from "t1" union all select /*+ hint2() */ * from "t2"',
+          sql: 'select /*+ hint1() */ * from "t1" union all select /*+ hint2() */ * from "t2"',
           bindings: [],
         },
       }
@@ -9593,8 +9048,7 @@ describe('QueryBuilder', () => {
       {
         mysql:
           "select * from `users` where `id` = 1 and `jsonColumn` ? 'jsonKey?'",
-        pg:
-          'select * from "users" where "id" = 1 and "jsonColumn" ? \'jsonKey?\'',
+        pg: 'select * from "users" where "id" = 1 and "jsonColumn" ? \'jsonKey?\'',
       }
     );
   });
@@ -9625,8 +9079,7 @@ describe('QueryBuilder', () => {
           'with [withClause] as (select [foo] from [users]) select * from [withClause]',
         sqlite3:
           'with `withClause` as (select `foo` from `users`) select * from `withClause`',
-        pg:
-          'with "withClause" as (select "foo" from "users") select * from "withClause"',
+        pg: 'with "withClause" as (select "foo" from "users") select * from "withClause"',
         'pg-redshift':
           'with "withClause" as (select "foo" from "users") select * from "withClause"',
         oracledb:
@@ -9648,8 +9101,7 @@ describe('QueryBuilder', () => {
           'with [withClause] as (select [foo] from [users]) insert into [users] select * from "withClause"',
         sqlite3:
           'with `withClause` as (select `foo` from `users`) insert into `users` select * from "withClause"',
-        pg:
-          'with "withClause" as (select "foo" from "users") insert into "users" select * from "withClause"',
+        pg: 'with "withClause" as (select "foo" from "users") insert into "users" select * from "withClause"',
       }
     );
   });
@@ -9667,23 +9119,19 @@ describe('QueryBuilder', () => {
         .into('users'),
       {
         mssql: {
-          sql:
-            'with [withClause] as (select [foo] from [users] where [name] = ?) insert into [users] ([email], [name]) values (?, ?), (?, ?)',
+          sql: 'with [withClause] as (select [foo] from [users] where [name] = ?) insert into [users] ([email], [name]) values (?, ?), (?, ?)',
           bindings: ['bob', 'thisMail', 'sam', 'thatMail', 'jack'],
         },
         sqlite3: {
-          sql:
-            'with `withClause` as (select `foo` from `users` where `name` = ?) insert into `users` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name`',
+          sql: 'with `withClause` as (select `foo` from `users` where `name` = ?) insert into `users` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name`',
           bindings: ['bob', 'thisMail', 'sam', 'thatMail', 'jack'],
         },
         pg: {
-          sql:
-            'with "withClause" as (select "foo" from "users" where "name" = ?) insert into "users" ("email", "name") values (?, ?), (?, ?)',
+          sql: 'with "withClause" as (select "foo" from "users" where "name" = ?) insert into "users" ("email", "name") values (?, ?), (?, ?)',
           bindings: ['bob', 'thisMail', 'sam', 'thatMail', 'jack'],
         },
         'pg-redshift': {
-          sql:
-            'with "withClause" as (select "foo" from "users" where "name" = ?) insert into "users" ("email", "name") values (?, ?), (?, ?)',
+          sql: 'with "withClause" as (select "foo" from "users" where "name" = ?) insert into "users" ("email", "name") values (?, ?), (?, ?)',
           bindings: ['bob', 'thisMail', 'sam', 'thatMail', 'jack'],
         },
       }
@@ -9704,8 +9152,7 @@ describe('QueryBuilder', () => {
           'with [withClause] as (select [foo] from [users]) update [users] set [foo] = ? where [email] = ?;select @@rowcount',
         sqlite3:
           'with `withClause` as (select `foo` from `users`) update `users` set `foo` = ? where `email` = ?',
-        pg:
-          'with "withClause" as (select "foo" from "users") update "users" set "foo" = ? where "email" = ?',
+        pg: 'with "withClause" as (select "foo" from "users") update "users" set "foo" = ? where "email" = ?',
       }
     );
   });
@@ -9724,8 +9171,7 @@ describe('QueryBuilder', () => {
           'with [withClause] as (select [email] from [users]) delete from [users] where [foo] = ?;select @@rowcount',
         sqlite3:
           'with `withClause` as (select `email` from `users`) delete from `users` where `foo` = ?',
-        pg:
-          'with "withClause" as (select "email" from "users") delete from "users" where "foo" = ?',
+        pg: 'with "withClause" as (select "email" from "users") delete from "users" where "foo" = ?',
       }
     );
   });
@@ -9741,8 +9187,7 @@ describe('QueryBuilder', () => {
           'with [withRawClause] as (select "foo" as "baz" from "users") select * from [withRawClause]',
         sqlite3:
           'with `withRawClause` as (select "foo" as "baz" from "users") select * from `withRawClause`',
-        pg:
-          'with "withRawClause" as (select "foo" as "baz" from "users") select * from "withRawClause"',
+        pg: 'with "withRawClause" as (select "foo" as "baz" from "users") select * from "withRawClause"',
         'pg-redshift':
           'with "withRawClause" as (select "foo" as "baz" from "users") select * from "withRawClause"',
         oracledb:
@@ -9767,8 +9212,7 @@ describe('QueryBuilder', () => {
           'with [firstWithClause] as (select [foo] from [users]), [secondWithClause] as (select [bar] from [users]) select * from [secondWithClause]',
         sqlite3:
           'with `firstWithClause` as (select `foo` from `users`), `secondWithClause` as (select `bar` from `users`) select * from `secondWithClause`',
-        pg:
-          'with "firstWithClause" as (select "foo" from "users"), "secondWithClause" as (select "bar" from "users") select * from "secondWithClause"',
+        pg: 'with "firstWithClause" as (select "foo" from "users"), "secondWithClause" as (select "bar" from "users") select * from "secondWithClause"',
         'pg-redshift':
           'with "firstWithClause" as (select "foo" from "users"), "secondWithClause" as (select "bar" from "users") select * from "secondWithClause"',
         oracledb:
@@ -9794,8 +9238,7 @@ describe('QueryBuilder', () => {
           'with [withClause] as (with [withSubClause] as ((select [foo] from [users]) as [baz]) select * from [withSubClause]) select * from [withClause]',
         sqlite3:
           'with `withClause` as (with `withSubClause` as ((select `foo` from `users`) as `baz`) select * from `withSubClause`) select * from `withClause`',
-        pg:
-          'with "withClause" as (with "withSubClause" as ((select "foo" from "users") as "baz") select * from "withSubClause") select * from "withClause"',
+        pg: 'with "withClause" as (with "withSubClause" as ((select "foo" from "users") as "baz") select * from "withSubClause") select * from "withClause"',
         'pg-redshift':
           'with "withClause" as (with "withSubClause" as ((select "foo" from "users") as "baz") select * from "withSubClause") select * from "withClause"',
         oracledb:
@@ -9823,28 +9266,23 @@ describe('QueryBuilder', () => {
         .where({ id: 10 }),
       {
         mssql: {
-          sql:
-            'with [withClause] as (with [withSubClause] as (select "foo" as "baz" from "users" where "baz" > ? and "baz" < ?) select * from [withSubClause]) select * from [withClause] where [id] = ?',
+          sql: 'with [withClause] as (with [withSubClause] as (select "foo" as "baz" from "users" where "baz" > ? and "baz" < ?) select * from [withSubClause]) select * from [withClause] where [id] = ?',
           bindings: [1, 20, 10],
         },
         sqlite3: {
-          sql:
-            'with `withClause` as (with `withSubClause` as (select "foo" as "baz" from "users" where "baz" > ? and "baz" < ?) select * from `withSubClause`) select * from `withClause` where `id` = ?',
+          sql: 'with `withClause` as (with `withSubClause` as (select "foo" as "baz" from "users" where "baz" > ? and "baz" < ?) select * from `withSubClause`) select * from `withClause` where `id` = ?',
           bindings: [1, 20, 10],
         },
         pg: {
-          sql:
-            'with "withClause" as (with "withSubClause" as (select "foo" as "baz" from "users" where "baz" > ? and "baz" < ?) select * from "withSubClause") select * from "withClause" where "id" = ?',
+          sql: 'with "withClause" as (with "withSubClause" as (select "foo" as "baz" from "users" where "baz" > ? and "baz" < ?) select * from "withSubClause") select * from "withClause" where "id" = ?',
           bindings: [1, 20, 10],
         },
         'pg-redshift': {
-          sql:
-            'with "withClause" as (with "withSubClause" as (select "foo" as "baz" from "users" where "baz" > ? and "baz" < ?) select * from "withSubClause") select * from "withClause" where "id" = ?',
+          sql: 'with "withClause" as (with "withSubClause" as (select "foo" as "baz" from "users" where "baz" > ? and "baz" < ?) select * from "withSubClause") select * from "withClause" where "id" = ?',
           bindings: [1, 20, 10],
         },
         oracledb: {
-          sql:
-            'with "withClause" as (with "withSubClause" as (select "foo" as "baz" from "users" where "baz" > ? and "baz" < ?) select * from "withSubClause") select * from "withClause" where "id" = ?',
+          sql: 'with "withClause" as (with "withSubClause" as (select "foo" as "baz" from "users" where "baz" > ? and "baz" < ?) select * from "withSubClause") select * from "withClause" where "id" = ?',
           bindings: [1, 20, 10],
         },
       }
@@ -9900,8 +9338,7 @@ describe('QueryBuilder', () => {
           'with [firstWithClause] as (with [firstWithSubClause] as ((select [foo] from [users]) as [foz]) select * from [firstWithSubClause]), [secondWithClause] as (with [secondWithSubClause] as ((select [bar] from [users]) as [baz]) select * from [secondWithSubClause]) select * from [secondWithClause]',
         sqlite3:
           'with `firstWithClause` as (with `firstWithSubClause` as ((select `foo` from `users`) as `foz`) select * from `firstWithSubClause`), `secondWithClause` as (with `secondWithSubClause` as ((select `bar` from `users`) as `baz`) select * from `secondWithSubClause`) select * from `secondWithClause`',
-        pg:
-          'with "firstWithClause" as (with "firstWithSubClause" as ((select "foo" from "users") as "foz") select * from "firstWithSubClause"), "secondWithClause" as (with "secondWithSubClause" as ((select "bar" from "users") as "baz") select * from "secondWithSubClause") select * from "secondWithClause"',
+        pg: 'with "firstWithClause" as (with "firstWithSubClause" as ((select "foo" from "users") as "foz") select * from "firstWithSubClause"), "secondWithClause" as (with "secondWithSubClause" as ((select "bar" from "users") as "baz") select * from "secondWithSubClause") select * from "secondWithClause"',
         'pg-redshift':
           'with "firstWithClause" as (with "firstWithSubClause" as ((select "foo" from "users") as "foz") select * from "firstWithSubClause"), "secondWithClause" as (with "secondWithSubClause" as ((select "bar" from "users") as "baz") select * from "secondWithSubClause") select * from "secondWithClause"',
         oracledb:
@@ -9934,8 +9371,7 @@ describe('QueryBuilder', () => {
           'with recursive [firstWithClause] as (with recursive [firstWithSubClause] as ((select [foo] from [users]) as [foz]) select * from [firstWithSubClause]), [secondWithClause] as (with recursive [secondWithSubClause] as ((select [bar] from [users]) as [baz]) select * from [secondWithSubClause]) select * from [secondWithClause]',
         sqlite3:
           'with recursive `firstWithClause` as (with recursive `firstWithSubClause` as ((select `foo` from `users`) as `foz`) select * from `firstWithSubClause`), `secondWithClause` as (with recursive `secondWithSubClause` as ((select `bar` from `users`) as `baz`) select * from `secondWithSubClause`) select * from `secondWithClause`',
-        pg:
-          'with recursive "firstWithClause" as (with recursive "firstWithSubClause" as ((select "foo" from "users") as "foz") select * from "firstWithSubClause"), "secondWithClause" as (with recursive "secondWithSubClause" as ((select "bar" from "users") as "baz") select * from "secondWithSubClause") select * from "secondWithClause"',
+        pg: 'with recursive "firstWithClause" as (with recursive "firstWithSubClause" as ((select "foo" from "users") as "foz") select * from "firstWithSubClause"), "secondWithClause" as (with recursive "secondWithSubClause" as ((select "bar" from "users") as "baz") select * from "secondWithSubClause") select * from "secondWithClause"',
         'pg-redshift':
           'with recursive "firstWithClause" as (with recursive "firstWithSubClause" as ((select "foo" from "users") as "foz") select * from "firstWithSubClause"), "secondWithClause" as (with recursive "secondWithSubClause" as ((select "bar" from "users") as "baz") select * from "secondWithSubClause") select * from "secondWithClause"',
         oracledb:
@@ -10055,8 +9491,7 @@ describe('QueryBuilder', () => {
         .from('sometable')
         .where('array_field', '&&', ['abc', 'def']),
       {
-        pg:
-          'select * from "sometable" where "array_field" && \'{"abc","def"}\'',
+        pg: 'select * from "sometable" where "array_field" && \'{"abc","def"}\'',
       }
     );
     testquery(
@@ -10065,8 +9500,7 @@ describe('QueryBuilder', () => {
         .from('sometable')
         .where('array_field', '&&', ['abc', 'def', ['g', 2]]),
       {
-        pg:
-          'select * from "sometable" where "array_field" && \'{"abc","def",{"g",2}}\'',
+        pg: 'select * from "sometable" where "array_field" && \'{"abc","def",{"g",2}}\'',
       }
     );
   });
@@ -10128,8 +9562,7 @@ describe('QueryBuilder', () => {
           .where('sometable.column', ref('someothertable.someothercolumn'))
           .select(),
         {
-          pg:
-            'select * from "sometable" where "sometable"."column" = "someothertable"."someothercolumn"',
+          pg: 'select * from "sometable" where "sometable"."column" = "someothertable"."someothercolumn"',
           mysql:
             'select * from `sometable` where `sometable`.`column` = `someothertable`.`someothercolumn`',
           mssql:
@@ -10254,8 +9687,7 @@ describe('QueryBuilder', () => {
         )
         .select('departments.*', 'trainee_cnts.count as trainee_cnt'),
       {
-        pg:
-          'select "departments".*, "trainee_cnts"."count" as "trainee_cnt" from "foo"."departments" inner join (select "department_id", count(*) from "foo"."trainees" group by "department_id") as "trainee_cnts" on "trainee_cnts"."department_id" = "departments"."id"',
+        pg: 'select "departments".*, "trainee_cnts"."count" as "trainee_cnt" from "foo"."departments" inner join (select "department_id", count(*) from "foo"."trainees" group by "department_id") as "trainee_cnts" on "trainee_cnts"."department_id" = "departments"."id"',
         mysql:
           'select `departments`.*, `trainee_cnts`.`count` as `trainee_cnt` from `foo`.`departments` inner join (select `department_id`, count(*) from `foo`.`trainees` group by `department_id`) as `trainee_cnts` on `trainee_cnts`.`department_id` = `departments`.`id`',
         mssql:
@@ -10284,8 +9716,7 @@ describe('QueryBuilder', () => {
           'select * from [schema].[foo] inner join (select [f_id] from [baz]) as [bar] on [bar].[f_id] = [foo].[id]',
         oracledb:
           'select * from "schema"."foo" inner join (select "f_id" from "baz") "bar" on "bar"."f_id" = "foo"."id"',
-        pg:
-          'select * from "schema"."foo" inner join (select "f_id" from "baz") as "bar" on "bar"."f_id" = "foo"."id"',
+        pg: 'select * from "schema"."foo" inner join (select "f_id" from "baz") as "bar" on "bar"."f_id" = "foo"."id"',
         'pg-redshift':
           'select * from "schema"."foo" inner join (select "f_id" from "baz") as "bar" on "bar"."f_id" = "foo"."id"',
         sqlite3:
@@ -10311,8 +9742,7 @@ describe('QueryBuilder', () => {
           'select * from [schema].[foo] inner join (select [f_id] from [baz]) as [bar] on [bar].[f_id] = [foo].[id]',
         oracledb:
           'select * from "schema"."foo" inner join (select "f_id" from "baz") "bar" on "bar"."f_id" = "foo"."id"',
-        pg:
-          'select * from "schema"."foo" inner join (select "f_id" from "baz") as "bar" on "bar"."f_id" = "foo"."id"',
+        pg: 'select * from "schema"."foo" inner join (select "f_id" from "baz") as "bar" on "bar"."f_id" = "foo"."id"',
         'pg-redshift':
           'select * from "schema"."foo" inner join (select "f_id" from "baz") as "bar" on "bar"."f_id" = "foo"."id"',
         sqlite3:
@@ -10329,8 +9759,7 @@ describe('QueryBuilder', () => {
         .from(qb().from('foo').select().as('bar'))
         .join('baz', 'foo.id', 'bar.foo_id'),
       {
-        pg:
-          'select * from (select * from "foo") as "bar" inner join "schema"."baz" on "foo"."id" = "bar"."foo_id"',
+        pg: 'select * from (select * from "foo") as "bar" inner join "schema"."baz" on "foo"."id" = "bar"."foo_id"',
         'pg-redshift':
           'select * from (select * from "foo") as "bar" inner join "schema"."baz" on "foo"."id" = "bar"."foo_id"',
         mysql:
@@ -10353,8 +9782,7 @@ describe('QueryBuilder', () => {
         .from((q) => q.from('foo').select().as('bar'))
         .join('baz', 'foo.id', 'bar.foo_id'),
       {
-        pg:
-          'select * from (select * from "foo") as "bar" inner join "schema"."baz" on "foo"."id" = "bar"."foo_id"',
+        pg: 'select * from (select * from "foo") as "bar" inner join "schema"."baz" on "foo"."id" = "bar"."foo_id"',
         'pg-redshift':
           'select * from (select * from "foo") as "bar" inner join "schema"."baz" on "foo"."id" = "bar"."foo_id"',
         mysql:
@@ -10377,8 +9805,7 @@ describe('QueryBuilder', () => {
         .from(raw('bar'))
         .join('baz', 'foo.id', 'bar.foo_id'),
       {
-        pg:
-          'select * from bar inner join "schema"."baz" on "foo"."id" = "bar"."foo_id"',
+        pg: 'select * from bar inner join "schema"."baz" on "foo"."id" = "bar"."foo_id"',
         'pg-redshift':
           'select * from bar inner join "schema"."baz" on "foo"."id" = "bar"."foo_id"',
         mysql:
@@ -10401,8 +9828,7 @@ describe('QueryBuilder', () => {
         .from('bar')
         .join(raw('baz'), 'foo.id', 'bar.foo_id'),
       {
-        pg:
-          'select * from "schema"."bar" inner join baz on "foo"."id" = "bar"."foo_id"',
+        pg: 'select * from "schema"."bar" inner join baz on "foo"."id" = "bar"."foo_id"',
         'pg-redshift':
           'select * from "schema"."bar" inner join baz on "foo"."id" = "bar"."foo_id"',
         mysql:
@@ -10444,28 +9870,23 @@ describe('QueryBuilder', () => {
         }),
       {
         pg: {
-          sql:
-            'select "p"."ID" as "id", "p"."post_status" as "status", "p"."post_title" as "name", "price"."meta_value" as "price", "p"."post_date_gmt" as "createdAt", "p"."post_modified_gmt" as "updatedAt" from "wp_posts" as "p" left join "wp_postmeta" as "price" on "p"."id" = "price"."post_id" and ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
+          sql: 'select "p"."ID" as "id", "p"."post_status" as "status", "p"."post_title" as "name", "price"."meta_value" as "price", "p"."post_date_gmt" as "createdAt", "p"."post_modified_gmt" as "updatedAt" from "wp_posts" as "p" left join "wp_postmeta" as "price" on "p"."id" = "price"."post_id" and ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
           bindings: ['_regular_price', '_regular_price', '_regular_price'],
         },
         mysql: {
-          sql:
-            'select `p`.`ID` as `id`, `p`.`post_status` as `status`, `p`.`post_title` as `name`, `price`.`meta_value` as `price`, `p`.`post_date_gmt` as `createdAt`, `p`.`post_modified_gmt` as `updatedAt` from `wp_posts` as `p` left join `wp_postmeta` as `price` on `p`.`id` = `price`.`post_id` and (`price`.`meta_key` = ? and `price_meta_key` = ?) or (`price_meta`.`key` = ?)',
+          sql: 'select `p`.`ID` as `id`, `p`.`post_status` as `status`, `p`.`post_title` as `name`, `price`.`meta_value` as `price`, `p`.`post_date_gmt` as `createdAt`, `p`.`post_modified_gmt` as `updatedAt` from `wp_posts` as `p` left join `wp_postmeta` as `price` on `p`.`id` = `price`.`post_id` and (`price`.`meta_key` = ? and `price_meta_key` = ?) or (`price_meta`.`key` = ?)',
           bindings: ['_regular_price', '_regular_price', '_regular_price'],
         },
         mssql: {
-          sql:
-            'select [p].[ID] as [id], [p].[post_status] as [status], [p].[post_title] as [name], [price].[meta_value] as [price], [p].[post_date_gmt] as [createdAt], [p].[post_modified_gmt] as [updatedAt] from [wp_posts] as [p] left join [wp_postmeta] as [price] on [p].[id] = [price].[post_id] and ([price].[meta_key] = ? and [price_meta_key] = ?) or ([price_meta].[key] = ?)',
+          sql: 'select [p].[ID] as [id], [p].[post_status] as [status], [p].[post_title] as [name], [price].[meta_value] as [price], [p].[post_date_gmt] as [createdAt], [p].[post_modified_gmt] as [updatedAt] from [wp_posts] as [p] left join [wp_postmeta] as [price] on [p].[id] = [price].[post_id] and ([price].[meta_key] = ? and [price_meta_key] = ?) or ([price_meta].[key] = ?)',
           bindings: ['_regular_price', '_regular_price', '_regular_price'],
         },
         'pg-redshift': {
-          sql:
-            'select "p"."ID" as "id", "p"."post_status" as "status", "p"."post_title" as "name", "price"."meta_value" as "price", "p"."post_date_gmt" as "createdAt", "p"."post_modified_gmt" as "updatedAt" from "wp_posts" as "p" left join "wp_postmeta" as "price" on "p"."id" = "price"."post_id" and ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
+          sql: 'select "p"."ID" as "id", "p"."post_status" as "status", "p"."post_title" as "name", "price"."meta_value" as "price", "p"."post_date_gmt" as "createdAt", "p"."post_modified_gmt" as "updatedAt" from "wp_posts" as "p" left join "wp_postmeta" as "price" on "p"."id" = "price"."post_id" and ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
           bindings: ['_regular_price', '_regular_price', '_regular_price'],
         },
         oracledb: {
-          sql:
-            'select "p"."ID" "id", "p"."post_status" "status", "p"."post_title" "name", "price"."meta_value" "price", "p"."post_date_gmt" "createdAt", "p"."post_modified_gmt" "updatedAt" from "wp_posts" "p" left join "wp_postmeta" "price" on "p"."id" = "price"."post_id" and ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
+          sql: 'select "p"."ID" "id", "p"."post_status" "status", "p"."post_title" "name", "price"."meta_value" "price", "p"."post_date_gmt" "createdAt", "p"."post_modified_gmt" "updatedAt" from "wp_posts" "p" left join "wp_postmeta" "price" on "p"."id" = "price"."post_id" and ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
           bindings: ['_regular_price', '_regular_price', '_regular_price'],
         },
       }
@@ -10497,29 +9918,76 @@ describe('QueryBuilder', () => {
         }),
       {
         pg: {
-          sql:
-            'select "p"."ID" as "id", "p"."post_status" as "status", "p"."post_title" as "name", "price"."meta_value" as "price", "p"."post_date_gmt" as "createdAt", "p"."post_modified_gmt" as "updatedAt" from "wp_posts" as "p" left join "wp_postmeta" as "price" on ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
+          sql: 'select "p"."ID" as "id", "p"."post_status" as "status", "p"."post_title" as "name", "price"."meta_value" as "price", "p"."post_date_gmt" as "createdAt", "p"."post_modified_gmt" as "updatedAt" from "wp_posts" as "p" left join "wp_postmeta" as "price" on ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
           bindings: ['_regular_price', '_regular_price', '_regular_price'],
         },
         mysql: {
-          sql:
-            'select `p`.`ID` as `id`, `p`.`post_status` as `status`, `p`.`post_title` as `name`, `price`.`meta_value` as `price`, `p`.`post_date_gmt` as `createdAt`, `p`.`post_modified_gmt` as `updatedAt` from `wp_posts` as `p` left join `wp_postmeta` as `price` on (`price`.`meta_key` = ? and `price_meta_key` = ?) or (`price_meta`.`key` = ?)',
+          sql: 'select `p`.`ID` as `id`, `p`.`post_status` as `status`, `p`.`post_title` as `name`, `price`.`meta_value` as `price`, `p`.`post_date_gmt` as `createdAt`, `p`.`post_modified_gmt` as `updatedAt` from `wp_posts` as `p` left join `wp_postmeta` as `price` on (`price`.`meta_key` = ? and `price_meta_key` = ?) or (`price_meta`.`key` = ?)',
           bindings: ['_regular_price', '_regular_price', '_regular_price'],
         },
         mssql: {
-          sql:
-            'select [p].[ID] as [id], [p].[post_status] as [status], [p].[post_title] as [name], [price].[meta_value] as [price], [p].[post_date_gmt] as [createdAt], [p].[post_modified_gmt] as [updatedAt] from [wp_posts] as [p] left join [wp_postmeta] as [price] on ([price].[meta_key] = ? and [price_meta_key] = ?) or ([price_meta].[key] = ?)',
+          sql: 'select [p].[ID] as [id], [p].[post_status] as [status], [p].[post_title] as [name], [price].[meta_value] as [price], [p].[post_date_gmt] as [createdAt], [p].[post_modified_gmt] as [updatedAt] from [wp_posts] as [p] left join [wp_postmeta] as [price] on ([price].[meta_key] = ? and [price_meta_key] = ?) or ([price_meta].[key] = ?)',
           bindings: ['_regular_price', '_regular_price', '_regular_price'],
         },
         'pg-redshift': {
-          sql:
-            'select "p"."ID" as "id", "p"."post_status" as "status", "p"."post_title" as "name", "price"."meta_value" as "price", "p"."post_date_gmt" as "createdAt", "p"."post_modified_gmt" as "updatedAt" from "wp_posts" as "p" left join "wp_postmeta" as "price" on ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
+          sql: 'select "p"."ID" as "id", "p"."post_status" as "status", "p"."post_title" as "name", "price"."meta_value" as "price", "p"."post_date_gmt" as "createdAt", "p"."post_modified_gmt" as "updatedAt" from "wp_posts" as "p" left join "wp_postmeta" as "price" on ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
           bindings: ['_regular_price', '_regular_price', '_regular_price'],
         },
         oracledb: {
-          sql:
-            'select "p"."ID" "id", "p"."post_status" "status", "p"."post_title" "name", "price"."meta_value" "price", "p"."post_date_gmt" "createdAt", "p"."post_modified_gmt" "updatedAt" from "wp_posts" "p" left join "wp_postmeta" "price" on ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
+          sql: 'select "p"."ID" "id", "p"."post_status" "status", "p"."post_title" "name", "price"."meta_value" "price", "p"."post_date_gmt" "createdAt", "p"."post_modified_gmt" "updatedAt" from "wp_posts" "p" left join "wp_postmeta" "price" on ("price"."meta_key" = ? and "price_meta_key" = ?) or ("price_meta"."key" = ?)',
           bindings: ['_regular_price', '_regular_price', '_regular_price'],
+        },
+      }
+    );
+  });
+
+  it('should include join when deleting', () => {
+    testsql(
+      qb()
+        .del()
+        .from('users')
+        .join('photos', 'photos.id', 'users.id')
+        .where({ 'user.email': 'mock@test.com' }),
+      {
+        mysql: {
+          sql: 'delete `users` from `users` inner join `photos` on `photos`.`id` = `users`.`id` where `user`.`email` = ?',
+          bindings: ['mock@test.com'],
+        },
+        mssql: {
+          sql: 'delete [users] from [users] inner join [photos] on [photos].[id] = [users].[id] where [user].[email] = ?;select @@rowcount',
+          bindings: ['mock@test.com'],
+        },
+        oracledb: {
+          sql: 'delete "users" from "users" inner join "photos" on "photos"."id" = "users"."id" where "user"."email" = ?',
+          bindings: ['mock@test.com'],
+        },
+        pg: {
+          sql: 'delete "users" from "users" inner join "photos" on "photos"."id" = "users"."id" where "user"."email" = ?',
+          bindings: ['mock@test.com'],
+        },
+        'pg-redshift': {
+          sql: 'delete "users" from "users" inner join "photos" on "photos"."id" = "users"."id" where "user"."email" = ?',
+          bindings: ['mock@test.com'],
+        },
+        sqlite3: {
+          sql: 'delete `users` from `users` inner join `photos` on `photos`.`id` = `users`.`id` where `user`.`email` = ?',
+          bindings: ['mock@test.com'],
+        },
+      }
+    );
+  });
+  it('should include join when deleting with mssql triggers', () => {
+    const triggerOptions = { includeTriggerModifications: true };
+    testsql(
+      qb()
+        .del('*', triggerOptions)
+        .from('users')
+        .join('photos', 'photos.id', 'users.id')
+        .where({ 'user.email': 'mock@test.com' }),
+      {
+        mssql: {
+          sql: 'select top(0) [t].* into #out from [users] as t left join [users] on 0=1;delete [users] output deleted.* into #out from [users] inner join [photos] on [photos].[id] = [users].[id] where [user].[email] = ?; select * from #out; drop table #out;',
+          bindings: ['mock@test.com'],
         },
       }
     );


### PR DESCRIPTION
Fix for the issue https://github.com/knex/knex/issues/873
The issue is that joins are not included in delete queries.
Examples can be found in tests: https://github.com/knex/knex/compare/master...Egor-Koldasov:fix/873-delete-join?expand=1#diff-9a54bb8c91fbb672179c076a18af9db40b73bc5c4a3e3ea7cc89c48ea8ebeadfR9944

Notes on the solution:
1. Solution does not include the ability to delete multiple tables. To me, it is not clear, how the interface should be expanded to include this option. It would be great to have a recommendation from collaborators: https://github.com/knex/knex/issues/873#issuecomment-877761010
It does solve other issues, allowing to delete values from a table by filtering values from another joined table.
It also helps with unexpected queries and potential data loss mentioned here: https://github.com/knex/knex/issues/873#issuecomment-808735961

2. Postgres, SQLite and Oracle do not support joins on delete. I did not include any custom error throws for them, instead, I allowed the query to build the same way and let the database report the error. Tests for error are included.

3. The project has a linter added to the commit hook. It updated the whole file: https://github.com/knex/knex/compare/master...Egor-Koldasov:fix/873-delete-join?expand=1#diff-9a54bb8c91fbb672179c076a18af9db40b73bc5c4a3e3ea7cc89c48ea8ebeadf
I'm not sure why previous commits have not done this, since it is automatic.

4. I'm having issues with successfully running 1 test: https://github.com/knex/knex/blob/master/test/integration/query/selects.js#L1361
The timeout error is not being caught properly leading to a general "Timeout of 5000ms exceeded." error.
It is not related to this update, but it's better to let know.

Thanks.