### PR TITLE
nguymin4/improve types

### DIFF
--- a/test-tsd/common.ts
+++ b/test-tsd/common.ts
@@ -6,3 +6,31 @@ export const clientConfig: Knex.Config = {
     filename: './mydb.sqlite',
   },
 };
+
+export interface User {
+  id: number;
+  age: number;
+  name: string;
+  active: boolean;
+  departmentId: number;
+}
+
+export interface Department {
+  id: number;
+  departmentName: string;
+}
+
+export interface Article {
+  id: number;
+  subject: string;
+  body?: string;
+  authorId?: string;
+}
+
+export interface Ticket {
+  name: string;
+  from: string;
+  to: string;
+  at: Date;
+}
+

--- a/test-tsd/select.test-d.ts
+++ b/test-tsd/select.test-d.ts
@@ -1,16 +1,8 @@
 import Knex from '../types';
-import { clientConfig } from './common';
+import { clientConfig, User } from './common';
 import { expectType } from 'tsd';
 
 const knex = Knex(clientConfig);
-
-interface User {
-  id: number;
-  age: number;
-  name: string;
-  active: boolean;
-  departmentId: number;
-}
 
 const main = async () => {
   expectType<any[]>(await knex('users').select('id').select('age'));

--- a/test-tsd/tables.test-d.ts
+++ b/test-tsd/tables.test-d.ts
@@ -1,35 +1,8 @@
 import { knex, Knex } from '../types';
-import { clientConfig } from './common';
+import { clientConfig, User, Department, Article } from './common';
 import { expectType } from 'tsd';
 
 const knexInstance = knex(clientConfig);
-
-interface User {
-  id: number;
-  age: number;
-  name: string;
-  active: boolean;
-  departmentId: number;
-}
-
-interface Department {
-  id: number;
-  departmentName: string;
-}
-
-interface Article {
-  id: number;
-  subject: string;
-  body?: string;
-  authorId?: string;
-}
-
-interface Ticket {
-  name: string;
-  from: string;
-  to: string;
-  at: Date;
-}
 
 declare module '../types/tables' {
   interface Tables {

--- a/test-tsd/transaction.test-d.ts
+++ b/test-tsd/transaction.test-d.ts
@@ -1,15 +1,8 @@
 import knexDefault, { Knex } from '../types';
-import { clientConfig } from './common';
+import { clientConfig, Article } from './common';
 import { expectType } from 'tsd';
 
 const knexInstance = knexDefault(clientConfig);
-
-interface Article {
-  id: number;
-  subject: string;
-  body?: string;
-  authorId?: string;
-}
 
 const main = async () => {
   // # Select:

--- a/test-tsd/types.test-d.ts
+++ b/test-tsd/types.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable, expectType } from 'tsd';
-import { clientConfig } from './common';
+import { clientConfig, User } from './common';
 
 import knexDefault, { Knex, knex } from '../types';
 import * as knexStar from '../types';
@@ -60,14 +60,6 @@ type DeferredKeySelection<
   _intersectProps: TIntersectProps;
   _unionProps: TUnionProps;
 };
-
-interface User {
-  id: number;
-  age: number;
-  name: string;
-  active: boolean;
-  departmentId: number;
-}
 
 // # Insert onConflict
 expectType<

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1464,8 +1464,15 @@ export declare namespace Knex {
   }
 
   interface AnalyticFunction<TRecord = any, TResult = unknown[]> {
-    <TResult2 = AggregationQueryResult<TResult, Dict<number>>>(alias: string, raw: Raw | QueryCallback<TRecord, TResult>): QueryBuilder<TRecord, TResult2>;
-    <TResult2 = AggregationQueryResult<TResult, Dict<number>>>(alias: string, orderBy: string | string[], partitionBy?: string | string[]): QueryBuilder<
+    <
+      TAlias extends string,
+      TResult2 = AggregationQueryResult<TResult, {[x in TAlias]: number}>
+    >(alias: TAlias, raw: Raw | QueryCallback<TRecord, TResult>): QueryBuilder<TRecord, TResult2>;
+    <
+      TAlias extends string,
+      TKey extends keyof ResolveTableType<TRecord>,
+      TResult2 = AggregationQueryResult<TResult, {[x in TAlias]: number}>
+    >(alias: TAlias, orderBy: TKey | TKey[], partitionBy?: TKey | TKey[]): QueryBuilder<
       TRecord,
       TResult2
     >;

--- a/types/test.ts
+++ b/types/test.ts
@@ -1282,24 +1282,34 @@ const main = async () => {
     .from('users_composite');
 
   // Analytic
-  // $ExpectType (Pick<User, "age"> & Dict<number>)[]
+  // $ExpectType (Pick<User, "age"> & { rowNum: number; })[]
   await knexInstance<User>('users').select('age').rowNumber('rowNum', 'age');
 
-  // $ExpectType (Pick<User, "age"> & Dict<number>)[]
+  await knexInstance<User>('users')
+    .select('age')
+    // $ExpectError
+    .rowNumber('rowNum', 'non_existing_field');
+
+  // $ExpectType (Pick<User, "age"> & { rowNum: number; })[]
   await knexInstance<User>('users').select('age').rowNumber('rowNum', ['age']);
 
-  // $ExpectType (Pick<User, "age"> & Dict<number>)[]
+  // $ExpectType (Pick<User, "age"> & { rowNum: number; })[]
   await knexInstance<User>('users').select('age').rowNumber('rowNum', (builder) => {
     builder.orderBy('age');
   });
 
-  // $ExpectType (Pick<User, "age"> & Dict<number>)[]
+  // $ExpectType (Pick<User, "age"> & { rowNum: number; })[]
   await knexInstance<User>('users').select('age').rowNumber('rowNum', 'age', 'departmentId');
 
-  // $ExpectType (Pick<User, "age"> & Dict<number>)[]
+  await knexInstance<User>('users')
+    .select('age')
+    // $ExpectError
+    .rowNumber('rowNum', 'age', 'non_existing_field');
+
+  // $ExpectType (Pick<User, "age"> & { rowNum: number; })[]
   await knexInstance<User>('users').select('age').rowNumber('rowNum', 'age', ['departmentId', 'active']);
 
-  // $ExpectType (Pick<User, "age"> & Dict<number>)[]
+  // $ExpectType (Pick<User, "age"> & { rowNum: number; })[]
   await knexInstance<User>('users').select('age').rowNumber('rowNum', (builder) => {
     builder.orderBy('age').partitionBy('departmentId');
   });


### PR DESCRIPTION
- Improve type support for analytic functions (See tests for more detail)
- Extract common interfaces for tsd

Important note: I intended to migrate analytic-function-types testing to tsd but I found a problem with the tsd library
For example
```typescript
  expectType<Pick<User, 'id'>>(
    await knex<User>('users').select('foo')
  );
```
I expect this test fails but the test somehow passes. I think this is a tsd issue. Thus we need to be more careful before migrating from `dtslint` to `tsd`. I will try to debug this if I have time but in my opinion `dtslint` is still doing a good job for us
