### PR TITLE
Fixing posgres datetime and timestamp column created with wrong format

### DIFF
--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -64,10 +64,12 @@ class ColumnCompiler_PG extends ColumnCompiler {
     return jsonColumn(this.client, true);
   }
 
-  datetime(withTz = true, precision) {
-    let useTz = withTz;
-    if (isObject(withTz)) {
-      ({ useTz, precision } = withTz);
+  datetime(withoutTz = false, precision) {
+    let useTz;
+    if (isObject(withoutTz)) {
+      ({ useTz, precision } = withoutTz);
+    } else {
+      useTz = !withoutTz;
     }
     useTz = typeof useTz === 'boolean' ? useTz : true;
     precision = precision ? '(' + precision + ')' : '';
@@ -75,10 +77,12 @@ class ColumnCompiler_PG extends ColumnCompiler {
     return `${useTz ? 'timestamptz' : 'timestamp'}${precision}`;
   }
 
-  timestamp(withTz = true, precision) {
-    let useTz = withTz;
-    if (isObject(withTz)) {
-      ({ useTz, precision } = withTz);
+  timestamp(withoutTz = false, precision) {
+    let useTz;
+    if (isObject(withoutTz)) {
+      ({ useTz, precision } = withoutTz);
+    } else {
+      useTz = !withoutTz;
     }
     useTz = typeof useTz === 'boolean' ? useTz : true;
     precision = precision ? '(' + precision + ')' : '';

--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -64,30 +64,26 @@ class ColumnCompiler_PG extends ColumnCompiler {
     return jsonColumn(this.client, true);
   }
 
-  datetime(withoutTz = false, precision) {
+  datetime(withoutTz = true, precision) {
     let useTz;
     if (isObject(withoutTz)) {
       ({ useTz, precision } = withoutTz);
-    } else {
-      useTz = !withoutTz;
     }
+    useTz = typeof useTz === 'boolean' ? useTz : true;
+    precision = precision ? '(' + precision + ')' : '';
 
-    return `${useTz ? 'timestamptz' : 'timestamp'}${
-      precision ? '(' + precision + ')' : ''
-    }`;
+    return `${useTz ? 'timestamptz' : 'timestamp'}${precision}`;
   }
 
-  timestamp(withoutTz = false, precision) {
+  timestamp(withoutTz = true, precision) {
     let useTz;
     if (isObject(withoutTz)) {
       ({ useTz, precision } = withoutTz);
-    } else {
-      useTz = !withoutTz;
     }
+    useTz = typeof useTz === 'boolean' ? useTz : true;
+    precision = precision ? '(' + precision + ')' : '';
 
-    return `${useTz ? 'timestamptz' : 'timestamp'}${
-      precision ? '(' + precision + ')' : ''
-    }`;
+    return `${useTz ? 'timestamptz' : 'timestamp'}${precision}`;
   }
 
   // Modifiers:

--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -64,10 +64,10 @@ class ColumnCompiler_PG extends ColumnCompiler {
     return jsonColumn(this.client, true);
   }
 
-  datetime(withoutTz = true, precision) {
-    let useTz = withoutTz;
-    if (isObject(withoutTz)) {
-      ({ useTz, precision } = withoutTz);
+  datetime(withTz = true, precision) {
+    let useTz = withTz;
+    if (isObject(withTz)) {
+      ({ useTz, precision } = withTz);
     }
     useTz = typeof useTz === 'boolean' ? useTz : true;
     precision = precision ? '(' + precision + ')' : '';
@@ -75,10 +75,10 @@ class ColumnCompiler_PG extends ColumnCompiler {
     return `${useTz ? 'timestamptz' : 'timestamp'}${precision}`;
   }
 
-  timestamp(withoutTz = true, precision) {
-    let useTz = withoutTz;
-    if (isObject(withoutTz)) {
-      ({ useTz, precision } = withoutTz);
+  timestamp(withTz = true, precision) {
+    let useTz = withTz;
+    if (isObject(withTz)) {
+      ({ useTz, precision } = withTz);
     }
     useTz = typeof useTz === 'boolean' ? useTz : true;
     precision = precision ? '(' + precision + ')' : '';

--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -65,7 +65,7 @@ class ColumnCompiler_PG extends ColumnCompiler {
   }
 
   datetime(withoutTz = true, precision) {
-    let useTz;
+    let useTz = withoutTz;
     if (isObject(withoutTz)) {
       ({ useTz, precision } = withoutTz);
     }
@@ -76,7 +76,7 @@ class ColumnCompiler_PG extends ColumnCompiler {
   }
 
   timestamp(withoutTz = true, precision) {
-    let useTz;
+    let useTz = withoutTz;
     if (isObject(withoutTz)) {
       ({ useTz, precision } = withoutTz);
     }

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -1155,11 +1155,37 @@ describe('PostgreSQL SchemaBuilder', function () {
     );
   });
 
+  it('adding default datetime', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.datetime('foo');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamptz'
+    );
+  });
+
   it('adding timestamp with timezone', () => {
     tableSql = client
       .schemaBuilder()
       .table('users', (table) => {
-        table.timestamp('foo', false);
+        table.timestamp('foo', true);
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamptz'
+    );
+  });
+
+  it('adding datetime with timezone', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.datetime('foo', true);
       })
       .toSQL();
     equal(1, tableSql.length);
@@ -1172,7 +1198,20 @@ describe('PostgreSQL SchemaBuilder', function () {
     tableSql = client
       .schemaBuilder()
       .table('users', (table) => {
-        table.timestamp('foo', true);
+        table.timestamp('foo', false);
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamp'
+    );
+  });
+
+  it('adding datetime without timezone', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.datetime('foo', false);
       })
       .toSQL();
     equal(1, tableSql.length);
@@ -1194,6 +1233,19 @@ describe('PostgreSQL SchemaBuilder', function () {
     );
   });
 
+  it('adding datetime with precision', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.datetime('foo', undefined, 3);
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamptz(3)'
+    );
+  });
+
   it('adding timestamp with options object', () => {
     tableSql = client
       .schemaBuilder()
@@ -1207,6 +1259,32 @@ describe('PostgreSQL SchemaBuilder', function () {
     );
   });
 
+  it('adding timestamp with options object but no timestamp', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.timestamp('foo', { precision: 3 });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamptz(3)'
+    );
+  });
+
+  it('adding timestamp with empty options object', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.timestamp('foo', { precision: 3 });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamptz'
+    );
+  });
+
   it('adding datetime with options object', () => {
     tableSql = client
       .schemaBuilder()
@@ -1217,6 +1295,32 @@ describe('PostgreSQL SchemaBuilder', function () {
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
       'alter table "users" add column "foo" timestamp(3)'
+    );
+  });
+
+  it('adding datetime with options object but no timestamp', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.datetime('foo', { precision: 3 });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamptz(3)'
+    );
+  });
+
+  it('adding datetime with options object', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.datetime('foo', {});
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamptz'
     );
   });
 

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -1276,7 +1276,7 @@ describe('PostgreSQL SchemaBuilder', function () {
     tableSql = client
       .schemaBuilder()
       .table('users', (table) => {
-        table.timestamp('foo', { precision: 3 });
+        table.timestamp('foo', {});
       })
       .toSQL();
     equal(1, tableSql.length);
@@ -1311,7 +1311,7 @@ describe('PostgreSQL SchemaBuilder', function () {
     );
   });
 
-  it('adding datetime with options object', () => {
+  it('adding datetime with empty options object', () => {
     tableSql = client
       .schemaBuilder()
       .table('users', (table) => {

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -1172,7 +1172,7 @@ describe('PostgreSQL SchemaBuilder', function () {
     tableSql = client
       .schemaBuilder()
       .table('users', (table) => {
-        table.timestamp('foo', true);
+        table.timestamp('foo', false);
       })
       .toSQL();
     equal(1, tableSql.length);
@@ -1185,7 +1185,7 @@ describe('PostgreSQL SchemaBuilder', function () {
     tableSql = client
       .schemaBuilder()
       .table('users', (table) => {
-        table.datetime('foo', true);
+        table.datetime('foo', false);
       })
       .toSQL();
     equal(1, tableSql.length);
@@ -1198,7 +1198,7 @@ describe('PostgreSQL SchemaBuilder', function () {
     tableSql = client
       .schemaBuilder()
       .table('users', (table) => {
-        table.timestamp('foo', false);
+        table.timestamp('foo', true);
       })
       .toSQL();
     equal(1, tableSql.length);
@@ -1211,7 +1211,7 @@ describe('PostgreSQL SchemaBuilder', function () {
     tableSql = client
       .schemaBuilder()
       .table('users', (table) => {
-        table.datetime('foo', false);
+        table.datetime('foo', true);
       })
       .toSQL();
     equal(1, tableSql.length);


### PR DESCRIPTION
- Why:
See issue #4577 

- How: 
1. Change default useTz option of datetime and timezone to true in pg column compiler. 
2. Adding additional test to check when empty option object or option object wihout timezone is passed.

