### PR TITLE
Improve connection string handling for SQLite3 and Postgresql.

### DIFF
--- a/lib/knex-builder/internal/parse-connection.js
+++ b/lib/knex-builder/internal/parse-connection.js
@@ -32,24 +32,45 @@ module.exports = function parseConnectionString(str) {
 
   const isPG = ['postgresql', 'postgres'].includes(protocol);
 
-  return {
+  const result = {
     client: protocol,
-    connection: isPG ? parsePG(str) : connectionObject(parsed),
+    connection: isPG ? parsePG(str) : connectionObject(protocol, parsed),
   };
+  if (
+    result.client === 'sqlite3' &&
+    result.connection != null &&
+    result.connection.useNullAsDefault
+  ) {
+    delete result.connection['useNullAsDefault'];
+    result['useNullAsDefault'] = true;
+  }
+  if (
+    result.client === 'postgresql' ||
+    (result.client === 'postgres' && result.connection.searchPath != null)
+  ) {
+    const path = result.connection.searchPath;
+    delete result.connection.searchPath;
+    result.searchPath = path;
+  }
+  return result;
 };
 
 /**
  * @param {URL} parsed
  * @returns {{}}
  */
-function connectionObject(parsed) {
+function connectionObject(protocol, parsed) {
   const connection = {};
   let db = parsed.pathname;
   if (db[0] === '/') {
     db = db.slice(1);
   }
 
-  connection.database = db;
+  if (protocol === 'sqlite3') {
+    connection.filename = db;
+  } else {
+    connection.database = db;
+  }
 
   if (parsed.hostname) {
     if (parsed.protocol.indexOf('mssql') === 0) {


### PR DESCRIPTION
Allow the use null as default option for sqlite3 to be specified in a connection string
by including it in the query parameters.  An example is:

`sqlite3:///:memory:?useNullAsDefault=true`

Additionally, improve PostgreSQL connection string handling by allowing
the searchPath to be specified in the connection string.  An example is:

`postgresql:///?searchPath=pg_temp`

Without these changes, it is impossible to allow users to specify these options
using connection strings.