### PR TITLE
fix typing deferrable and withkeyName should not be in ColumnBuilder

### DIFF
--- a/test-tsd/tables.test-d.ts
+++ b/test-tsd/tables.test-d.ts
@@ -1,6 +1,6 @@
 import { knex, Knex } from '../types';
 import { clientConfig, User, Department, Article } from './common';
-import { expectType } from 'tsd';
+import { expectType, expectAssignable } from 'tsd';
 
 const knexInstance = knex(clientConfig);
 
@@ -65,4 +65,17 @@ const main = async () => {
   expectType<Pick<User, 'id'> | undefined>(
     await knexInstance.first('id').from('users_composite')
   );
+
+  //These tests simply check if type work by showing that it does not throw syntax error
+
+  knexInstance.schema.createTable('testTable',(table) => {
+    table.foreign('fkey_three').references('non_exist.id').withKeyName('non_for1').deferrable('deferred');
+    table.foreign('fkey_threee').references('non_exist.id').deferrable('deferred').withKeyName('non_for2');
+    table.integer('num').references('non_exist.id').deferrable('immediate').withKeyName('non_for3');
+    table.integer('num').references('non_exist.id').withKeyName('non_for4').deferrable('deferred').onDelete('CASCADE');
+    table.integer('num').references('non_exist.id').withKeyName('non_for5').deferrable('deferred').onDelete('CASCADE');
+    table.integer('num').references('id').inTable('non_exist').withKeyName('non_for6').deferrable('deferred').onDelete('CASCADE');
+    table.integer('num').references('id').withKeyName('non_for7').deferrable('deferred').inTable('non_exist').onDelete('CASCADE');
+  })
 };
+

--- a/test-tsd/tables.test-d.ts
+++ b/test-tsd/tables.test-d.ts
@@ -76,6 +76,9 @@ const main = async () => {
     table.integer('num').references('non_exist.id').withKeyName('non_for5').deferrable('deferred').onDelete('CASCADE');
     table.integer('num').references('id').inTable('non_exist').withKeyName('non_for6').deferrable('deferred').onDelete('CASCADE');
     table.integer('num').references('id').withKeyName('non_for7').deferrable('deferred').inTable('non_exist').onDelete('CASCADE');
+    table.integer('num').references('id').inTable('non_exist').onDelete('CASCADE').withKeyName('non_for6').deferrable('deferred');
+    table.integer('num').references('id').withKeyName('non_for7').onDelete('CASCADE').deferrable('deferred').inTable('non_exist');
+    table.integer('num').references('id').withKeyName('non_for7').onDelete('CASCADE').deferrable('deferred').inTable('non_exist');
   })
 };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1980,6 +1980,8 @@ export declare namespace Knex {
     inTable(tableName: string): ReferencingColumnBuilder;
     deferrable(type: deferrableType): ReferencingColumnBuilder;
     withKeyName(keyName: string): ReferencingColumnBuilder;
+    onDelete(command: string): ReferencingColumnBuilder;
+    onUpdate(command: string): ReferencingColumnBuilder;
   }
 
   interface AlterColumnBuilder extends ColumnBuilder {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1961,10 +1961,8 @@ export declare namespace Knex {
     comment(value: string): ColumnBuilder;
     alter(): ColumnBuilder;
     queryContext(context: any): ColumnBuilder;
-    withKeyName(keyName: string): ColumnBuilder;
     after(columnName: string): ColumnBuilder;
     first(): ColumnBuilder;
-    deferrable(type: deferrableType): ColumnBuilder;
   }
 
   interface ForeignConstraintBuilder {
@@ -1981,6 +1979,8 @@ export declare namespace Knex {
 
   interface ReferencingColumnBuilder extends ColumnBuilder {
     inTable(tableName: string): ColumnBuilder;
+    deferrable(type: deferrableType): ColumnBuilder;
+    withKeyName(keyName: string): ColumnBuilder;
   }
 
   interface AlterColumnBuilder extends ColumnBuilder {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1965,7 +1965,12 @@ export declare namespace Knex {
     first(): ColumnBuilder;
   }
 
-  interface ForeignConstraintBuilder {
+  interface ForeignKeyBuilder extends ColumnBuilder{
+    deferrable(type: deferrableType): ForeignKeyBuilder;
+    withKeyName(keyName: string): ForeignKeyBuilder;
+  }
+
+  interface ForeignConstraintBuilder{
     references(columnName: string): ReferencingColumnBuilder;
   }
 
@@ -1977,10 +1982,8 @@ export declare namespace Knex {
     index(indexName?: string, indexType?: string): ColumnBuilder;
   }
 
-  interface ReferencingColumnBuilder extends ColumnBuilder {
+  interface ReferencingColumnBuilder extends ColumnBuilder, ForeignKeyBuilder {
     inTable(tableName: string): ColumnBuilder;
-    deferrable(type: deferrableType): ColumnBuilder;
-    withKeyName(keyName: string): ColumnBuilder;
   }
 
   interface AlterColumnBuilder extends ColumnBuilder {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1964,7 +1964,7 @@ export declare namespace Knex {
     after(columnName: string): ColumnBuilder;
     first(): ColumnBuilder;
   }
-  interface ForeignConstraintBuilder{
+  interface ForeignConstraintBuilder {
     references(columnName: string): ReferencingColumnBuilder;
   }
 
@@ -1976,7 +1976,7 @@ export declare namespace Knex {
     index(indexName?: string, indexType?: string): ColumnBuilder;
   }
 
-  interface ReferencingColumnBuilder extends ColumnBuilder{
+  interface ReferencingColumnBuilder extends ColumnBuilder {
     inTable(tableName: string): ReferencingColumnBuilder;
     deferrable(type: deferrableType): ReferencingColumnBuilder;
     withKeyName(keyName: string): ReferencingColumnBuilder;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1964,12 +1964,6 @@ export declare namespace Knex {
     after(columnName: string): ColumnBuilder;
     first(): ColumnBuilder;
   }
-
-  interface ForeignKeyBuilder extends ColumnBuilder{
-    deferrable(type: deferrableType): ForeignKeyBuilder;
-    withKeyName(keyName: string): ForeignKeyBuilder;
-  }
-
   interface ForeignConstraintBuilder{
     references(columnName: string): ReferencingColumnBuilder;
   }
@@ -1982,8 +1976,10 @@ export declare namespace Knex {
     index(indexName?: string, indexType?: string): ColumnBuilder;
   }
 
-  interface ReferencingColumnBuilder extends ColumnBuilder, ForeignKeyBuilder {
-    inTable(tableName: string): ColumnBuilder;
+  interface ReferencingColumnBuilder extends ColumnBuilder{
+    inTable(tableName: string): ReferencingColumnBuilder;
+    deferrable(type: deferrableType): ReferencingColumnBuilder;
+    withKeyName(keyName: string): ReferencingColumnBuilder;
   }
 
   interface AlterColumnBuilder extends ColumnBuilder {}


### PR DESCRIPTION
I came across this PR: https://github.com/knex/knex/pull/3556. since it hasn't been actived for a long time so i want to conttinue it and also to fix my last Pull Request where i also put ```deferrable``` inside ```ColumnBuilder```