### PR TITLE
Fix Analytic orderBy and partitionBy to follow the SQL documentation

### DIFF
--- a/lib/query/analytic.js
+++ b/lib/query/analytic.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const { isObject } = require('../util/is');
 
 // Analytic
 // -------

--- a/lib/query/analytic.js
+++ b/lib/query/analytic.js
@@ -19,7 +19,7 @@ class Analytic {
     this.grouping = 'columns';
   }
 
-  partitionBy(column) {
+  partitionBy(column, direction) {
     assert(
       Array.isArray(column) || typeof column === 'string',
       `The argument to an analytic partitionBy function must be either a string
@@ -29,7 +29,7 @@ class Analytic {
     if (Array.isArray(column)) {
       this.partitions = this.partitions.concat(column);
     } else {
-      this.partitions.push(column);
+      this.partitions.push({ column: column, order: direction });
     }
     return this;
   }

--- a/lib/query/analytic.js
+++ b/lib/query/analytic.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { isObject } = require('../util/is');
 
 // Analytic
 // -------
@@ -33,7 +34,7 @@ class Analytic {
     return this;
   }
 
-  orderBy(column) {
+  orderBy(column, direction) {
     assert(
       Array.isArray(column) || typeof column === 'string',
       `The argument to an analytic orderBy function must be either a string
@@ -41,11 +42,15 @@ class Analytic {
     );
 
     if (Array.isArray(column)) {
-      this.order = this.order.concat(column);
+      this.order = this.order.concat(this._orderByArray(column));
     } else {
-      this.order.push(column);
+      this.order.push(column + (direction ? " " + direction : ""));
     }
     return this;
+  }
+  
+  _orderByArray(columnDefs){
+    return columnDefs.map(c => isObject(c) ? c.column + (c.order ? " " + c.order : "") : c).join(", ");
   }
 }
 

--- a/lib/query/analytic.js
+++ b/lib/query/analytic.js
@@ -42,15 +42,11 @@ class Analytic {
     );
 
     if (Array.isArray(column)) {
-      this.order = this.order.concat(this._orderByArray(column));
+      this.order = this.order.concat(column);
     } else {
-      this.order.push(column + (direction ? " " + direction : ""));
+      this.order.push({ column: column, order: direction });
     }
     return this;
-  }
-  
-  _orderByArray(columnDefs){
-    return columnDefs.map(c => isObject(c) ? c.column + (c.order ? " " + c.order : "") : c).join(", ");
   }
 }
 

--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -1247,15 +1247,18 @@ class Builder extends EventEmitter {
       typeof second === 'function' ||
         second.isRawInstance ||
         Array.isArray(second) ||
-        typeof second === 'string',
+        typeof second === 'string' ||
+        typeof second === 'object',
       `The second argument to an analytic function must be either a function, a raw,
-       an array of string or a single string.`
+       an array of string or object, an object or a single string.`
     );
 
     if (third) {
       assert(
-        Array.isArray(third) || typeof third === 'string',
-        'The third argument to an analytic function must be either a string or an array of string.'
+        Array.isArray(third) ||
+          typeof third === 'string' ||
+          typeof third === 'object',
+        'The third argument to an analytic function must be either a string, an array of string or object or an object.'
       );
     }
 
@@ -1272,9 +1275,9 @@ class Builder extends EventEmitter {
         alias: alias,
       };
     } else {
-      const order = typeof second === 'string' ? [second] : second;
+      const order = !Array.isArray(second) ? [second] : second;
       let partitions = third || [];
-      partitions = typeof partitions === 'string' ? [partitions] : partitions;
+      partitions = !Array.isArray(partitions) ? [partitions] : partitions;
       analytic = {
         grouping: 'columns',
         type: 'analytic',

--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -1035,23 +1035,17 @@ class QueryCompiler {
         sql += 'partition by ';
         sql +=
           map(stmt.partitions, function (partition) {
-            if (isString(partition)) return self.formatter.columnize(partition);
-            else
-              return (
-                self.formatter.columnize(partition.column) +
-                (partition.order ? ' ' + partition.order : '')
-              );
+            if (isString(partition)) {
+              return self.formatter.columnize(partition);
+            } else return self.formatter.columnize(partition.column) + (partition.order ? ' ' + partition.order : '');
           }).join(', ') + ' ';
       }
 
       sql += 'order by ';
       sql += map(stmt.order, function (order) {
-        if (isString(order)) return self.formatter.columnize(order);
-        else
-          return (
-            self.formatter.columnize(order.column) +
-            (order.order ? ' ' + order.order : '')
-          );
+        if (isString(order)) {
+          return self.formatter.columnize(order);
+        } else return self.formatter.columnize(order.column) + (order.order ? ' ' + order.order : '');
       }).join(', ');
     }
 

--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -1035,7 +1035,7 @@ class QueryCompiler {
         sql += 'partition by ';
         sql +=
           map(stmt.partitions, function (partition) {
-            if (isString(partition)) return self.formater.columnize(partition);
+            if (isString(partition)) return self.formatter.columnize(partition);
             else
               return (
                 self.formatter.columnize(partition.column) +
@@ -1046,7 +1046,7 @@ class QueryCompiler {
 
       sql += 'order by ';
       sql += map(stmt.order, function (order) {
-        if (isString(order)) return self.formater.columnize(order);
+        if (isString(order)) return self.formatter.columnize(order);
         else
           return (
             self.formatter.columnize(order.column) +

--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -1035,16 +1035,23 @@ class QueryCompiler {
         sql += 'partition by ';
         sql +=
           map(stmt.partitions, function (partition) {
-            return self.formatter.columnize(partition);
+            if (isString(partition)) return self.formater.columnize(partition);
+            else
+              return (
+                self.formatter.columnize(partition.column) +
+                (partition.order ? ' ' + partition.order : '')
+              );
           }).join(', ') + ' ';
       }
 
       sql += 'order by ';
       sql += map(stmt.order, function (order) {
-        if (isString(order))
-          return self.formater.columnize(order);
+        if (isString(order)) return self.formater.columnize(order);
         else
-          return self.formatter.columnize(order.column) + (order.order ? " " + order.order : "")
+          return (
+            self.formatter.columnize(order.column) +
+            (order.order ? ' ' + order.order : '')
+          );
       }).join(', ');
     }
 

--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -1041,7 +1041,10 @@ class QueryCompiler {
 
       sql += 'order by ';
       sql += map(stmt.order, function (order) {
-        return self.formatter.columnize(order);
+        if (isString(order))
+          return self.formater.columnize(order);
+        else
+          return self.formatter.columnize(order.column) + (order.order ? " " + order.order : "")
       }).join(', ');
     }
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -7854,6 +7854,29 @@ describe('QueryBuilder', () => {
     );
   });
 
+  it('row_number with object', function () {
+    testsql(
+      qb()
+        .select('*')
+        .from('accounts')
+        .rowNumber(null, { column: 'email', order: 'asc' }, [
+          { column: 'address', order: 'asc' },
+          'phone',
+        ]),
+      {
+        mssql: {
+          sql: 'select *, row_number() over (partition by [address] asc, [phone] order by [email] asc) from [accounts]',
+        },
+        pg: {
+          sql: 'select *, row_number() over (partition by "address" asc, "phone" order by "email" asc) from "accounts"',
+        },
+        oracledb: {
+          sql: 'select *, row_number() over (partition by "address" asc, "phone" order by "email" asc) from "accounts"',
+        },
+      }
+    );
+  });
+
   it('row_number with string', function () {
     testsql(
       qb().select('*').from('accounts').rowNumber(null, 'email', 'address'),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1083,15 +1083,15 @@ export declare namespace Knex {
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-    >(
+      >(
       raw: Raw
     ): QueryBuilder<TRecord2, TResult2>;
     <
       TTable extends TableNames,
       TRecord2 = ResolveTableType<TRecord> &
-        ResolveTableType<TableType<TTable>>,
+      ResolveTableType<TableType<TTable>>,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-    >(
+      >(
       tableName: TTable,
       clause: JoinCallback
     ): QueryBuilder<TRecord2, TResult2>;
@@ -1099,7 +1099,7 @@ export declare namespace Knex {
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-    >(
+      >(
       tableName: TableDescriptor | AliasDict | QueryCallback,
       clause: JoinCallback
     ): QueryBuilder<TRecord2, TResult2>;
@@ -1107,7 +1107,7 @@ export declare namespace Knex {
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-    >(
+      >(
       tableName: TableDescriptor | AliasDict | QueryCallback,
       columns: { [key: string]: string | number | boolean | Raw }
     ): QueryBuilder<TRecord2, TResult2>;
@@ -1115,7 +1115,7 @@ export declare namespace Knex {
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-    >(
+      >(
       tableName: TableDescriptor | AliasDict | QueryCallback,
       raw: Raw
     ): QueryBuilder<TRecord2, TResult2>;
@@ -1127,7 +1127,7 @@ export declare namespace Knex {
       TRecord1 = ResolveTableType<TRecord>,
       TRecord2 = TRecord1 & ResolveTableType<TableType<TTable2>>,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-    >(
+      >(
       tableName: TTable2,
       column1: `${TTable1}.${TKey1}`,
       column2: `${TTable2}.${TKey2}`
@@ -1140,7 +1140,7 @@ export declare namespace Knex {
       TRecord1 = ResolveTableType<TRecord>,
       TRecord2 = TRecord1 & ResolveTableType<TableType<TTable2>>,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-    >(
+      >(
       tableName: TTable2,
       column1: `${TTable2}.${TKey2}`,
       column2: `${TTable1}.${TKey1}`
@@ -1149,7 +1149,7 @@ export declare namespace Knex {
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-    >(
+      >(
       tableName: TableDescriptor | AliasDict | QueryCallback,
       column1: string,
       column2: string
@@ -1158,7 +1158,7 @@ export declare namespace Knex {
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-    >(
+      >(
       tableName: TableDescriptor | AliasDict | QueryCallback,
       column1: string,
       raw: Raw
@@ -1171,7 +1171,7 @@ export declare namespace Knex {
       TRecord1 = ResolveTableType<TRecord>,
       TRecord2 = TRecord1 & ResolveTableType<TableType<TTable2>>,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-    >(
+      >(
       tableName: TTable2,
       column1: `${TTable1}.${TKey1}`,
       operator: string,
@@ -1185,7 +1185,7 @@ export declare namespace Knex {
       TRecord1 = ResolveTableType<TRecord>,
       TRecord2 = TRecord1 & ResolveTableType<TableType<TTable2>>,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-    >(
+      >(
       tableName: TTable2,
       column1: `${TTable2}.${TKey2}`,
       operator: string,
@@ -1195,7 +1195,7 @@ export declare namespace Knex {
       TJoinTargetRecord extends {} = any,
       TRecord2 extends {} = TRecord & TJoinTargetRecord,
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
-    >(
+      >(
       tableName: TableDescriptor | AliasDict | QueryCallback,
       column1: string,
       operator: string,
@@ -1267,7 +1267,7 @@ export declare namespace Knex {
 
   interface With<TRecord = any, TResult = unknown[]>
     extends WithRaw<TRecord, TResult>,
-      WithWrapped<TRecord, TResult> {}
+    WithWrapped<TRecord, TResult> {}
 
   interface WithRaw<TRecord = any, TResult = unknown[]> {
     (alias: string, raw: Raw | QueryBuilder): QueryBuilder<TRecord, TResult>;
@@ -1415,7 +1415,7 @@ export declare namespace Knex {
     <
       TOptions extends { "as": string },
       TResult2 = AggregationQueryResult<TResult, {[k in TOptions["as"]]: TValue}>
-    >(
+      >(
       columnName: Readonly<keyof ResolveTableType<TRecord>>,
       options: Readonly<TOptions>
     ): QueryBuilder<TRecord, TResult2>;
@@ -1425,7 +1425,7 @@ export declare namespace Knex {
     <
       TAliases extends {} = Record<string, string | string[] | Knex.Raw>,
       TResult2 = AggregationQueryResult<TResult, {[k in keyof TAliases]?: TValue}>
-    >(aliases: TAliases): QueryBuilder<TRecord, TResult2>;
+      >(aliases: TAliases): QueryBuilder<TRecord, TResult2>;
     <TResult2 = AggregationQueryResult<TResult, Dict<TValue>>>(
       ...columnNames: ReadonlyArray<Readonly<Record<string, string | string[] | Knex.Raw>> | Knex.Raw | string>
     ): QueryBuilder<TRecord, TResult2>;
@@ -1438,14 +1438,14 @@ export declare namespace Knex {
       TResult2 = AggregationQueryResult<TResult, {
         [k in TOptions["as"]]: ResolveTableType<TRecord>[TKey]
       }>
-    >(
+      >(
       columnName: Readonly<TKey>,
       options: Readonly<TOptions>
     ): QueryBuilder<TRecord, TResult2>;
     <
       TKey extends keyof ResolveTableType<TRecord>,
       TResult2 = AggregationQueryResult<TResult, Dict<ResolveTableType<TRecord>[TKey]>>
-    >(
+      >(
       ...columnNames: readonly TKey[]
     ): QueryBuilder<TRecord, TResult2>;
     <
@@ -1454,10 +1454,10 @@ export declare namespace Knex {
         // We have optional here because in most dialects aggregating by multiple keys simultaneously
         // causes rest of the keys to be dropped and only first to be considered
         [K in keyof TAliases]?: K extends keyof TRecord ?
-          TRecord[K] :
-          TValue
+        TRecord[K] :
+        TValue
       }>
-    >(aliases: TAliases): QueryBuilder<TRecord, TResult2>;
+      >(aliases: TAliases): QueryBuilder<TRecord, TResult2>;
     <TResult2 = AggregationQueryResult<TResult, Dict<TValue>>>(
       ...columnNames: ReadonlyArray<Readonly<Record<string, string | readonly string[] | Knex.Raw>> | Knex.Raw | string>
     ): QueryBuilder<TRecord, TResult2>;
@@ -1467,20 +1467,20 @@ export declare namespace Knex {
     <
       TAlias extends string,
       TResult2 = AggregationQueryResult<TResult, {[x in TAlias]: number}>
-    >(alias: TAlias, raw: Raw | QueryCallback<TRecord, TResult>): QueryBuilder<TRecord, TResult2>;
+      >(alias: TAlias, raw: Raw | QueryCallback<TRecord, TResult>): QueryBuilder<TRecord, TResult2>;
     <
       TAlias extends string,
       TKey extends keyof ResolveTableType<TRecord>,
       TResult2 = AggregationQueryResult<TResult, {[x in TAlias]: number}>
-    >(alias: TAlias, orderBy: TKey | TKey[], partitionBy?: TKey | TKey[]): QueryBuilder<
-      TRecord,
-      TResult2
-    >;
+      >(alias: TAlias, orderBy: TKey | TKey[] | { columnName: TKey, order?: 'asc' | 'desc' }, partitionBy?: TKey | TKey[] | { columnName: TKey, order?: 'asc' | 'desc' }): QueryBuilder<
+        TRecord,
+        TResult2
+      >;
   }
 
   interface GroupBy<TRecord = any, TResult = unknown[]>
     extends RawQueryBuilder<TRecord, TResult>,
-      ColumnNameQueryBuilder<TRecord, TResult> {}
+    ColumnNameQueryBuilder<TRecord, TResult> {}
 
   interface OrderBy<TRecord = any, TResult = unknown[]> {
     (columnName: keyof TRecord | QueryBuilder, order?: 'asc' | 'desc'): QueryBuilder<
@@ -1505,8 +1505,7 @@ export declare namespace Knex {
   }
 
   interface PartitionBy<TRecord = any, TResult = unknown[]>
-    extends RawQueryBuilder<TRecord, TResult>,
-      ColumnNameQueryBuilder<TRecord, TResult> {}
+    extends OrderBy<TRecord, TResult> {}
 
   interface Intersect<TRecord = any, TResult = unknown[]> {
     (
@@ -1566,7 +1565,7 @@ export declare namespace Knex {
         ResolveTableType<TRecord>,
         ColNameUT & string
       >[]
-    >(
+      >(
       ...columnNames: readonly ColNameUT[]
     ): QueryBuilder<TRecord, TResult2>;
 
@@ -1577,7 +1576,7 @@ export declare namespace Knex {
         ResolveTableType<TRecord>,
         ColNameUT & string
       >[]
-    >(
+      >(
       columnNames: readonly ColNameUT[]
     ): QueryBuilder<TRecord, TResult2>;
 
@@ -1589,7 +1588,7 @@ export declare namespace Knex {
         SafePartial<TRecord>,
         keyof TRecord & string
       >[]
-    >(
+      >(
       ...columnNames: readonly ColumnDescriptor<TRecord, TResult>[]
     ): QueryBuilder<TRecord, TResult2>;
 
@@ -1599,7 +1598,7 @@ export declare namespace Knex {
         SafePartial<TRecord>,
         keyof TRecord & string
       >[]
-    >(
+      >(
       columnNames: readonly ColumnDescriptor<TRecord, TResult>[]
     ): QueryBuilder<TRecord, TResult2>;
   }
@@ -1621,7 +1620,7 @@ export declare namespace Knex {
 
   interface Raw<TResult = any>
     extends events.EventEmitter,
-      ChainableInterface<ResolveResult<TResult>> {
+    ChainableInterface<ResolveResult<TResult>> {
     timeout(ms: number, options?: {cancel?: boolean}): Raw<TResult>;
     wrap<TResult2 = TResult>(before: string, after: string): Raw<TResult>;
     toSQL(): Sql;
@@ -1638,27 +1637,27 @@ export declare namespace Knex {
   const RefMemberTag: unique symbol;
 
   interface Ref<TSrc extends string, TMapping extends {}> extends Raw<string> {
-      // TypeScript can behave weirdly if type parameters are not
-      // actually used in the members of type.
-      //
-      // See: https://github.com/knex/knex/issues/3932
-      //
-      // We simply need to propagate the type context so that we can extract
-      // them later, but we just add a "phantom" property so that typescript
-      // doesn't think that these parameters are unused
-      //
-      // Because unique symbol is used here, there is no way to actually
-      // access this at runtime
-      [RefMemberTag]: {
-        src: TSrc,
-        mapping: TMapping
-      };
-      withSchema(schema: string): this;
-      as<TAlias extends string>(alias: TAlias): Ref<TSrc, {[K in TAlias]: TSrc}>;
+    // TypeScript can behave weirdly if type parameters are not
+    // actually used in the members of type.
+    //
+    // See: https://github.com/knex/knex/issues/3932
+    //
+    // We simply need to propagate the type context so that we can extract
+    // them later, but we just add a "phantom" property so that typescript
+    // doesn't think that these parameters are unused
+    //
+    // Because unique symbol is used here, there is no way to actually
+    // access this at runtime
+    [RefMemberTag]: {
+      src: TSrc,
+      mapping: TMapping
+    };
+    withSchema(schema: string): this;
+    as<TAlias extends string>(alias: TAlias): Ref<TSrc, {[K in TAlias]: TSrc}>;
   }
 
   interface RefBuilder {
-      <TSrc extends string>(src: TSrc): Ref<TSrc, {[K in TSrc]: TSrc}>;
+    <TSrc extends string>(src: TSrc): Ref<TSrc, {[K in TSrc]: TSrc}>;
   }
 
   interface BatchInsertBuilder<TRecord extends {} = any, TResult = number[]> extends Promise<ResolveResult<TResult>> {
@@ -1671,18 +1670,18 @@ export declare namespace Knex {
         UnwrapArrayMember<TResult>,
         ResolveTableType<TRecord>,
         TKey
-        >[]
-      >(
-        column: TKey
+      >[]
+    >(
+      column: TKey
     ): BatchInsertBuilder<TRecord, TResult2>;
     returning<
       TKey extends StrKey<ResolveTableType<TRecord>>,
       TResult2 = DeferredKeySelection.SetSingle<
         DeferredKeySelection.Augment<UnwrapArrayMember<TResult>, ResolveTableType<TRecord>, TKey>,
         false
-        >[]
-      >(
-        columns: readonly TKey[]
+      >[]
+    >(
+      columns: readonly TKey[]
     ): BatchInsertBuilder<TRecord, TResult2>;
     // if data with specific type passed, exclude this method
     returning<TResult2 = SafePartial<TRecord>[]>(
@@ -1708,9 +1707,9 @@ export declare namespace Knex {
   interface QueryBuilder<
     TRecord extends {} = any,
     TResult = any
-  >
+    >
     extends QueryInterface<TRecord, TResult>,
-      ChainableInterface<ResolveResult<TResult>> {
+    ChainableInterface<ResolveResult<TResult>> {
     client: Client;
     or: QueryBuilder<TRecord, TResult>;
     not: QueryBuilder<TRecord, TResult>;
@@ -2059,105 +2058,105 @@ export declare namespace Knex {
     | 'azure-active-directory-msi-app-service'
     | 'azure-active-directory-service-principal-secret';
 
-interface MsSqlDefaultAuthenticationConfig extends MsSqlConnectionConfigBase {
-  type?: 'default' | never;
-}
+  interface MsSqlDefaultAuthenticationConfig extends MsSqlConnectionConfigBase {
+    type?: 'default' | never;
+  }
 
-interface MsSqlAzureActiveDirectoryMsiAppServiceAuthenticationConfig
-  extends MsSqlConnectionConfigBase {
-  type: 'azure-active-directory-msi-app-service';
-  /**
-   * If you user want to connect to an Azure app service using a specific client account
-   * they need to provide `clientId` asscoiate to their created idnetity.
-   *
-   * This is optional for retrieve token from azure web app service
-   */
-  clientId?: string;
-  /**
-   * A msi app service environment need to provide `msiEndpoint` for retriving the accesstoken.
-   */
-  msiEndpoint?: string;
-  /**
-   * A msi app service environment need to provide `msiSecret` for retriving the accesstoken.
-   */
-  msiSecret?: string;
-}
+  interface MsSqlAzureActiveDirectoryMsiAppServiceAuthenticationConfig
+    extends MsSqlConnectionConfigBase {
+    type: 'azure-active-directory-msi-app-service';
+    /**
+     * If you user want to connect to an Azure app service using a specific client account
+     * they need to provide `clientId` asscoiate to their created idnetity.
+     *
+     * This is optional for retrieve token from azure web app service
+     */
+    clientId?: string;
+    /**
+     * A msi app service environment need to provide `msiEndpoint` for retriving the accesstoken.
+     */
+    msiEndpoint?: string;
+    /**
+     * A msi app service environment need to provide `msiSecret` for retriving the accesstoken.
+     */
+    msiSecret?: string;
+  }
 
-interface MsSqlAzureActiveDirectoryMsiVmAuthenticationConfig
-  extends MsSqlConnectionConfigBase {
-  type: 'azure-active-directory-msi-vm';
-  /**
-   * If you user want to connect to an Azure app service using a specific client account
-   * they need to provide `clientId` asscoiate to their created idnetity.
-   *
-   * This is optional for retrieve token from azure web app service
-   */
-  clientId?: string;
-  /**
-   * A user need to provide `msiEndpoint` for retriving the accesstoken.
-   */
-  msiEndpoint?: string;
-}
+  interface MsSqlAzureActiveDirectoryMsiVmAuthenticationConfig
+    extends MsSqlConnectionConfigBase {
+    type: 'azure-active-directory-msi-vm';
+    /**
+     * If you user want to connect to an Azure app service using a specific client account
+     * they need to provide `clientId` asscoiate to their created idnetity.
+     *
+     * This is optional for retrieve token from azure web app service
+     */
+    clientId?: string;
+    /**
+     * A user need to provide `msiEndpoint` for retriving the accesstoken.
+     */
+    msiEndpoint?: string;
+  }
 
-interface MsSqlAzureActiveDirectoryAccessTokenAuthenticationConfig
-  extends MsSqlConnectionConfigBase {
-  type: 'azure-active-directory-access-token';
-  /**
-   * A user-provided access token
-   */
-  token: string;
-}
-interface MsSqlAzureActiveDirectoryPasswordAuthenticationConfig
-  extends MsSqlConnectionConfigBase {
-  type: 'azure-active-directory-password';
-  /**
-   * Optional parameter for specific Azure tenant ID
-   */
-  domain: string;
-  userName: string;
-  password: string;
-}
+  interface MsSqlAzureActiveDirectoryAccessTokenAuthenticationConfig
+    extends MsSqlConnectionConfigBase {
+    type: 'azure-active-directory-access-token';
+    /**
+     * A user-provided access token
+     */
+    token: string;
+  }
+  interface MsSqlAzureActiveDirectoryPasswordAuthenticationConfig
+    extends MsSqlConnectionConfigBase {
+    type: 'azure-active-directory-password';
+    /**
+     * Optional parameter for specific Azure tenant ID
+     */
+    domain: string;
+    userName: string;
+    password: string;
+  }
 
-interface MsSqlAzureActiveDirectoryServicePrincipalSecretConfig
-  extends MsSqlConnectionConfigBase {
-  type: 'azure-active-directory-service-principal-secret';
-  /**
-   * Application (`client`) ID from your registered Azure application
-   */
-  clientId: string;
-  /**
-   * The created `client secret` for this registered Azure application
-   */
-  clientSecret: string;
-  /**
-   * Directory (`tenant`) ID from your registered Azure application
-   */
-  tenantId: string;
-}
+  interface MsSqlAzureActiveDirectoryServicePrincipalSecretConfig
+    extends MsSqlConnectionConfigBase {
+    type: 'azure-active-directory-service-principal-secret';
+    /**
+     * Application (`client`) ID from your registered Azure application
+     */
+    clientId: string;
+    /**
+     * The created `client secret` for this registered Azure application
+     */
+    clientSecret: string;
+    /**
+     * Directory (`tenant`) ID from your registered Azure application
+     */
+    tenantId: string;
+  }
 
-interface MsSqlNtlmAuthenticationConfig extends MsSqlConnectionConfigBase {
-  type: 'ntlm';
-  /**
-   * Once you set domain for ntlm authentication type, driver will connect to SQL Server using domain login.
-   *
-   * This is necessary for forming a connection using ntlm type
-   */
-  domain: string;
-  userName: string;
-  password: string;
-}
+  interface MsSqlNtlmAuthenticationConfig extends MsSqlConnectionConfigBase {
+    type: 'ntlm';
+    /**
+     * Once you set domain for ntlm authentication type, driver will connect to SQL Server using domain login.
+     *
+     * This is necessary for forming a connection using ntlm type
+     */
+    domain: string;
+    userName: string;
+    password: string;
+  }
 
-type MsSqlConnectionConfig =
-  | MsSqlDefaultAuthenticationConfig
-  | MsSqlNtlmAuthenticationConfig
-  | MsSqlAzureActiveDirectoryAccessTokenAuthenticationConfig
-  | MsSqlAzureActiveDirectoryMsiAppServiceAuthenticationConfig
-  | MsSqlAzureActiveDirectoryMsiVmAuthenticationConfig
-  | MsSqlAzureActiveDirectoryPasswordAuthenticationConfig
-  | MsSqlAzureActiveDirectoryServicePrincipalSecretConfig;
+  type MsSqlConnectionConfig =
+    | MsSqlDefaultAuthenticationConfig
+    | MsSqlNtlmAuthenticationConfig
+    | MsSqlAzureActiveDirectoryAccessTokenAuthenticationConfig
+    | MsSqlAzureActiveDirectoryMsiAppServiceAuthenticationConfig
+    | MsSqlAzureActiveDirectoryMsiVmAuthenticationConfig
+    | MsSqlAzureActiveDirectoryPasswordAuthenticationConfig
+    | MsSqlAzureActiveDirectoryServicePrincipalSecretConfig;
 
   // Config object for tedious: see http://tediousjs.github.io/tedious/api-connection.html
-interface MsSqlConnectionConfigBase {
+  interface MsSqlConnectionConfigBase {
     type?: MsSqlAuthenticationTypeOptions;
 
     driver?: string;
@@ -2366,14 +2365,14 @@ interface MsSqlConnectionConfigBase {
   }
 
   interface Migration {
-      up: (knex: Knex) => PromiseLike<any>;
-      down?: (kenx: Knex) => PromiseLike<any>;
+    up: (knex: Knex) => PromiseLike<any>;
+    down?: (kenx: Knex) => PromiseLike<any>;
   }
 
   interface MigrationSource<TMigrationSpec> {
-      getMigrations(loadExtensions: readonly string[]): Promise<TMigrationSpec[]>;
-      getMigrationName(migration: TMigrationSpec): string;
-      getMigration(migration: TMigrationSpec): Migration;
+    getMigrations(loadExtensions: readonly string[]): Promise<TMigrationSpec[]>;
+    getMigrationName(migration: TMigrationSpec): string;
+    getMigration(migration: TMigrationSpec): Migration;
   }
 
   interface MigratorConfig {
@@ -2477,9 +2476,9 @@ interface MsSqlConnectionConfigBase {
     initializeDriver(): void;
     driver: any;
     poolDefaults(): {
-        min: number;
-        max: number;
-        propagateCreateError: boolean;
+      min: number;
+      max: number;
+      propagateCreateError: boolean;
     };
     getPoolSettings(poolConfig: any): any;
     initializePool(config?: {}): void;


### PR DESCRIPTION
This is a little annoyance I found while writing query calls using `rowNumber` as the typescript types shows you are allowed to do this but if you try to use an array of objects the SQL request fail with `column ?? does not exist` where ?? is the array of objects columnized.