### PR TITLE
0.21 mssql trust certificate

### DIFF
--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -110,6 +110,8 @@ Object.assign(Client_MSSQL.prototype, {
         cfg.options.rowCollectionOnRequestCompletion = false;
         cfg.options.useColumnNames = false;
         cfg.options.appName = cfg.options.appName || 'node-mssql';
+        cfg.options.trustServerCertificate =
+          cfg.options.trustServerCertificate || false;
 
         // tedious always connect via tcp when port is specified
         if (cfg.options.instanceName) delete cfg.options.port;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1928,6 +1928,7 @@ declare namespace Knex {
       maxRetriesOnTransientErrors?: number;
       multiSubnetFailover?: boolean;
       packetSize?: number;
+      trustServerCertificate?: boolean;
     }>;
     pool?: Readonly<{
       min?: number;


### PR DESCRIPTION
Description:

This is a back-port of the change already integrated in the 0.95 developer stream. The PR for that stream can be [found here](https://github.com/knex/knex/pull/4500).

Tests:

There do not appear to be any tests that cover the connection config options schema for mssql that has been changed in my PR. If I missed the place where such a test should go, please feel free to point this out to me and I will be happy to re-submit. The PR for the 0.95 stream also does not appear to include tests.

Documentation

Still needs to be updated. That will be a separate PR if this PR is accepted.