### PR TITLE
fix pluck typing issue when CompositeTableType is used

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -640,9 +640,9 @@ export declare namespace Knex {
     // Others
     first: Select<TRecord, DeferredKeySelection.AddUnionMember<UnwrapArrayMember<TResult>, undefined>>;
 
-    pluck<K extends keyof TRecord>(
+    pluck<K extends keyof ResolveTableType<TRecord>>(
       column: K
-    ): QueryBuilder<TRecord, TRecord[K][]>;
+    ): QueryBuilder<TRecord, ResolveTableType<TRecord>[K][]>;
     pluck<TResult2 extends {}>(column: string): QueryBuilder<TRecord, TResult2>;
 
     insert(


### PR DESCRIPTION
When a `CompositeTableType` is used, `keyof TRecord` will result in `base`, `insert`, and `update`, instead of the real database column names. This change fixes this issue.

Table definitions:

```typescript
import { Knex } from 'knex'

declare module 'knex/types/tables' {
  interface User {
    id: string
    name: string
    createdAt: Date
    updatedAt: Date
  }

  interface UserInsert {
    id?: string
    name: string
    createdAt?: Date
    updatedAt?: Date
  }

  interface UserUpdate {
    id?: string
    name?: string
    createdAt?: Date
    updatedAt?: Date
  }

  interface Tables {
    users:  Knex.CompositeTableType<User, UserInsert, UserUpdate>
  }
}
```

When using:

```typescript
import knex as 'knex'
import knexConfig from './knexfile'

const db = knex(knexConfig)

/* 
  *  Currently shows type as `{}`, 
  *  and autocomplete suggests: `base`, `insert`, `update`.
  *  This is because those are the keys of `CompositeTableType`.
  * 
  *  With the fix, it shows the type as `string[]`,
  *   and autocomplete suggests `id`, `name`, `createdAt`, `updatedAt`.
  *  This is because `ResolveTableType` can pull out `User` interface.
  */
db('users').pluck('id') 

```