### PR TITLE
fix: use sys info function instead of connection db name

### DIFF
--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -186,8 +186,8 @@ class QueryCompiler_PG extends QueryCompiler {
     }
 
     let sql =
-      'select * from information_schema.columns where table_name = ? and table_catalog = ?';
-    const bindings = [table, this.client.database()];
+      'select * from information_schema.columns where table_name = ? and table_catalog = current_database()';
+    const bindings = [table];
 
     if (schema) {
       sql += ' and table_schema = ?';

--- a/test/integration/query/additional.js
+++ b/test/integration/query/additional.js
@@ -346,7 +346,7 @@ module.exports = function (knex) {
           );
           tester(
             'pg',
-            'select * from information_schema.columns where table_name = ? and table_catalog = ? and table_schema = current_schema()',
+            'select * from information_schema.columns where table_name = ? and table_catalog = current_database() and table_schema = current_schema()',
             null,
             {
               enum_value: {
@@ -454,7 +454,7 @@ module.exports = function (knex) {
           );
           tester(
             'pg',
-            'select * from information_schema.columns where table_name = ? and table_catalog = ? and table_schema = current_schema()',
+            'select * from information_schema.columns where table_name = ? and table_catalog = current_database() and table_schema = current_schema()',
             null,
             {
               defaultValue: null,
@@ -940,7 +940,8 @@ module.exports = function (knex) {
 
       const getProcessesQuery = getProcessesQueries[driverName]();
 
-      return knex.transaction((trx) => addTimeout().transacting(trx))
+      return knex
+        .transaction((trx) => addTimeout().transacting(trx))
         .then(function () {
           expect(true).to.equal(false);
         })
@@ -1022,7 +1023,7 @@ module.exports = function (knex) {
       const getProcessesForDriver = {
         pg: async () => {
           const results = await knex.raw('SELECT * from pg_stat_activity');
-          return _.map(_.filter(results.rows, {state: 'active'}), 'query');
+          return _.map(_.filter(results.rows, { state: 'active' }), 'query');
         },
         mysql: async () => {
           const results = await knex.raw('SHOW PROCESSLIST');
@@ -1043,11 +1044,11 @@ module.exports = function (knex) {
       const getProcesses = getProcessesForDriver[driverName];
 
       try {
-        const promise = query.timeout(50, { cancel: true }).then(_.identity)
+        const promise = query.timeout(50, { cancel: true }).then(_.identity);
 
-        await delay(10)
+        await delay(10);
         const processesBeforeTimeout = await getProcesses();
-        expect(processesBeforeTimeout).to.include(query.toString())
+        expect(processesBeforeTimeout).to.include(query.toString());
 
         await expect(promise).to.eventually.be.rejected.and.to.deep.include({
           timeout: 50,
@@ -1056,7 +1057,7 @@ module.exports = function (knex) {
         });
 
         const processesAfterTimeout = await getProcesses();
-        expect(processesAfterTimeout).to.not.include(query.toString())
+        expect(processesAfterTimeout).to.not.include(query.toString());
       } finally {
         await knexDb.destroy();
       }


### PR DESCRIPTION
There is an edge case when getting proxied by for example PgBouncer that could result in client connection not being the same as the current database.
Using current_database() seems like a safer approach.