### PR TITLE
feat(mssql): Support comments as MS_Description properties [fixes #4204]

### DIFF
--- a/lib/dialects/mssql/mssql-formatter.js
+++ b/lib/dialects/mssql/mssql-formatter.js
@@ -12,6 +12,23 @@ class MSSQL_Formatter extends Formatter {
     }
     return str;
   }
+
+  /**
+   * Returns its argument with single quotes escaped, so it can be included into a single-quoted string.
+   *
+   * For example, it converts "has'quote" to "has''quote".
+   *
+   * This assumes QUOTED_IDENTIFIER ON so it is only ' that need escaping,
+   * never ", because " cannot be used to quote a string when that's on;
+   * otherwise we'd need to be aware of whether the string is quoted with " or '.
+   *
+   * This assumption is consistent with the SQL Knex generates.
+   * @param {string} string
+   * @returns {string}
+   */
+  escapingStringDelimiters(string) {
+    return (string || '').replace(/'/g, "''");
+  }
 }
 
 module.exports = MSSQL_Formatter;

--- a/lib/dialects/mssql/schema/mssql-columncompiler.js
+++ b/lib/dialects/mssql/schema/mssql-columncompiler.js
@@ -92,7 +92,11 @@ class ColumnCompiler_MSSQL extends ColumnCompiler {
     )} DEFAULT ${formattedValue}`;
   }
 
-  comment(comment) {
+  comment(/** @type {string} */ comment) {
+    if (!comment) {
+      return;
+    }
+
     // XXX: This is a byte limit, not character, so we cannot definitively say they'll exceed the limit without database collation info.
     // (Yes, even if the column has its own collation, the sqlvariant still uses the database collation.)
     // I'm not sure we even need to raise a warning, as MSSQL will return an error when the limit is exceeded itself.
@@ -101,6 +105,25 @@ class ColumnCompiler_MSSQL extends ColumnCompiler {
         'Your comment might be longer than the max comment length for MSSQL of 7,500 bytes.'
       );
     }
+
+    // See: https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-addextendedproperty-transact-sql?view=sql-server-ver15#b-adding-an-extended-property-to-a-column-in-a-table
+    const value = this.formatter.escapingStringDelimiters(comment);
+    const level0name = this.tableCompiler.schemaNameRaw || 'dbo';
+    const level1name = this.formatter.escapingStringDelimiters(
+      this.tableCompiler.tableNameRaw
+    );
+    const level2name = this.formatter.escapingStringDelimiters(
+      this.args[0] || this.defaults('columnName')
+    );
+
+    const args = `N'MS_Description', N'${value}', N'Schema', N'${level0name}', N'Table', N'${level1name}', N'Column', N'${level2name}'`;
+
+    this.pushAdditional(function () {
+      const isAlreadyDefined = `EXISTS(SELECT * FROM sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'${level0name}', N'Table', N'${level1name}', N'Column', N'${level2name}'))`;
+      this.pushQuery(
+        `IF ${isAlreadyDefined}\n  EXEC sys.sp_updateextendedproperty ${args}\nELSE\n  EXEC sys.sp_addextendedproperty ${args}`
+      );
+    });
     return '';
   }
 }

--- a/lib/dialects/mssql/schema/mssql-tablecompiler.js
+++ b/lib/dialects/mssql/schema/mssql-tablecompiler.js
@@ -24,16 +24,39 @@ class TableCompiler_MSSQL extends TableCompiler {
       columns.sql.join(this._formatting ? ',\n    ' : ', ') +
       ')';
 
+    this.pushQuery(sql);
+
     if (this.single.comment) {
-      const { comment } = this.single;
-      // XXX: This is a byte limit, not character, so we cannot definitively say they'll exceed the limit without database collation info.
-      if (comment.length > 7500 / 2)
-        this.client.logger.warn(
-          'Your comment might be longer than the max comment length for MSSQL of 7,500 bytes.'
-        );
+      this.comment(this.single.comment);
+    }
+  }
+
+  comment(/** @type {string} */ comment) {
+    if (!comment) {
+      return;
     }
 
-    this.pushQuery(sql);
+    // XXX: This is a byte limit, not character, so we cannot definitively say they'll exceed the limit without server collation info.
+    // When I checked in SQL Server 2019, the ctext column in sys.syscomments is defined as a varbinary(8000), so it doesn't even have its own defined collation.
+    if (comment.length > 7500 / 2) {
+      this.client.logger.warn(
+        'Your comment might be longer than the max comment length for MSSQL of 7,500 bytes.'
+      );
+    }
+
+    // See: https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-addextendedproperty-transact-sql?view=sql-server-ver15#f-adding-an-extended-property-to-a-table
+    const value = this.formatter.escapingStringDelimiters(comment);
+    const level0name = this.formatter.escapingStringDelimiters(
+      this.schemaNameRaw || 'dbo'
+    );
+    const level1name = this.formatter.escapingStringDelimiters(
+      this.tableNameRaw
+    );
+    const args = `N'MS_Description', N'${value}', N'Schema', N'${level0name}', N'Table', N'${level1name}'`;
+    const isAlreadyDefined = `EXISTS(SELECT * FROM sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'${level0name}', N'Table', N'${level1name}', NULL, NULL))`;
+    this.pushQuery(
+      `IF ${isAlreadyDefined}\n  EXEC sys.sp_updateextendedproperty ${args}\nELSE\n  EXEC sys.sp_addextendedproperty ${args}`
+    );
   }
 
   // Compiles column add.  Multiple columns need only one ADD clause (not one ADD per column) so core addColumns doesn't work.  #1348
@@ -128,9 +151,6 @@ class TableCompiler_MSSQL extends TableCompiler {
         drops.join(', ')
     );
   }
-
-  // Compiles the comment on the table.
-  comment() {}
 
   changeType() {}
 

--- a/test/integration/schema/index.js
+++ b/test/integration/schema/index.js
@@ -4,7 +4,15 @@ const { expect } = require('chai');
 
 const _ = require('lodash');
 const { isString, isObject } = require('../../../lib/util/is');
-const { isPgBased, isMysql, isOracle, isPostgreSQL, isSQLite, isRedshift, isMssql } = require('../../util/db-helpers');
+const {
+  isPgBased,
+  isMysql,
+  isOracle,
+  isPostgreSQL,
+  isSQLite,
+  isRedshift,
+  isMssql,
+} = require('../../util/db-helpers');
 
 const wrapIdentifier = (value, wrap) => {
   return wrap(value ? value.toUpperCase() : value);
@@ -475,6 +483,8 @@ module.exports = (knex) => {
             ]);
             tester('mssql', [
               "CREATE TABLE [test_table_one] ([id] bigint identity(1,1) not null primary key, [first_name] nvarchar(255), [last_name] nvarchar(255), [email] nvarchar(255) null, [logins] int CONSTRAINT [test_table_one_logins_default] DEFAULT '1', [balance] float CONSTRAINT [test_table_one_balance_default] DEFAULT '0', [about] nvarchar(max), [created_at] datetime2, [updated_at] datetime2)",
+              "IF EXISTS(SELECT * FROM sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'test_table_one', NULL, NULL))\n  EXEC sys.sp_updateextendedproperty N'MS_Description', N'A table comment.', N'Schema', N'dbo', N'Table', N'test_table_one'\nELSE\n  EXEC sys.sp_addextendedproperty N'MS_Description', N'A table comment.', N'Schema', N'dbo', N'Table', N'test_table_one'",
+              "IF EXISTS(SELECT * FROM sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'test_table_one', N'Column', N'about'))\n  EXEC sys.sp_updateextendedproperty N'MS_Description', N'A comment.', N'Schema', N'dbo', N'Table', N'test_table_one', N'Column', N'about'\nELSE\n  EXEC sys.sp_addextendedproperty N'MS_Description', N'A comment.', N'Schema', N'dbo', N'Table', N'test_table_one', N'Column', N'about'",
               'CREATE INDEX [test_table_one_first_name_index] ON [test_table_one] ([first_name])',
               'CREATE UNIQUE INDEX [test_table_one_email_unique] ON [test_table_one] ([email]) WHERE [email] IS NOT NULL',
               'CREATE INDEX [test_table_one_logins_index] ON [test_table_one] ([logins])',
@@ -921,7 +931,12 @@ module.exports = (knex) => {
           .then(() => knex.schema.dropTable('test_table_numerics2')));
 
       it('allows alter column syntax', function () {
-        if (isSQLite(knex) || isRedshift(knex) || isMssql(knex) || isOracle(knex)) {
+        if (
+          isSQLite(knex) ||
+          isRedshift(knex) ||
+          isMssql(knex) ||
+          isOracle(knex)
+        ) {
           return;
         }
 


### PR DESCRIPTION
Table and column comments are now compiled into MS_Description
extended properties.

[fixes #4204]