### PR TITLE
fix(mssql): columnInfo() now works with case-sensitive database [fixes #4573]

### DIFF
--- a/lib/dialects/mssql/query/mssql-querycompiler.js
+++ b/lib/dialects/mssql/query/mssql-querycompiler.js
@@ -429,7 +429,8 @@ class QueryCompiler_MSSQL extends QueryCompiler {
       schema = this.client.customWrapIdentifier(schema, identity);
     }
 
-    let sql = `select [COLUMN_NAME], [COLUMN_DEFAULT], [DATA_TYPE], [CHARACTER_MAXIMUM_LENGTH], [IS_NULLABLE] from information_schema.columns where table_name = ? and table_catalog = ?`;
+    // GOTCHA: INFORMATION_SCHEMA.COLUMNS must be capitalized to work when the database has a case-sensitive collation. [#4573]
+    let sql = `select [COLUMN_NAME], [COLUMN_DEFAULT], [DATA_TYPE], [CHARACTER_MAXIMUM_LENGTH], [IS_NULLABLE] from INFORMATION_SCHEMA.COLUMNS where table_name = ? and table_catalog = ?`;
     const bindings = [table, this.client.database()];
 
     if (schema) {

--- a/test/integration/query/additional.js
+++ b/test/integration/query/additional.js
@@ -300,7 +300,7 @@ module.exports = function (knex) {
         [drivers.SQLite]: "SELECT name FROM sqlite_master WHERE type='table';",
         [drivers.Oracle]: 'select TABLE_NAME from USER_TABLES',
         [drivers.MsSQL]:
-          "SELECT table_name FROM information_schema.tables WHERE table_schema='dbo'",
+          "SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_schema='dbo'",
       };
       return knex
         .raw(tables[knex.client.driverName])
@@ -417,7 +417,7 @@ module.exports = function (knex) {
           );
           tester(
             'mssql',
-            "select [COLUMN_NAME], [COLUMN_DEFAULT], [DATA_TYPE], [CHARACTER_MAXIMUM_LENGTH], [IS_NULLABLE] from information_schema.columns where table_name = ? and table_catalog = ? and table_schema = 'dbo'",
+            "select [COLUMN_NAME], [COLUMN_DEFAULT], [DATA_TYPE], [CHARACTER_MAXIMUM_LENGTH], [IS_NULLABLE] from INFORMATION_SCHEMA.COLUMNS where table_name = ? and table_catalog = ? and table_schema = 'dbo'",
             ['datatype_test', 'knex_test'],
             {
               enum_value: {
@@ -493,7 +493,7 @@ module.exports = function (knex) {
           );
           tester(
             'mssql',
-            "select [COLUMN_NAME], [COLUMN_DEFAULT], [DATA_TYPE], [CHARACTER_MAXIMUM_LENGTH], [IS_NULLABLE] from information_schema.columns where table_name = ? and table_catalog = ? and table_schema = 'dbo'",
+            "select [COLUMN_NAME], [COLUMN_DEFAULT], [DATA_TYPE], [CHARACTER_MAXIMUM_LENGTH], [IS_NULLABLE] from INFORMATION_SCHEMA.COLUMNS where table_name = ? and table_catalog = ? and table_schema = 'dbo'",
             null,
             {
               defaultValue: null,


### PR DESCRIPTION
Before, the SQL used to implement `columnInfo()` for the mssql driver referenced `information_schema.columns`.

But in a database with a case-sensitive collation, both of those parts must be capitalized, as `INFORMATION_SCHEMA.COLUMNS`, or you just get an error [#4573]. (It doesn't seem sensitive to how you capitalize the column names, though. 🤷 )

Now, that capitalized form is used when interacting with mssql.

# Question for Reviewer: Should I just switch the default mssql test database to use a case-sensitive collation?
In order to test this change, I needed to create a new database with a case-sensitive collation, then tear it down. This required digging around to grab the database config used in the integration test suite.

It would be cleaner to change the default test database for MSSQL to be created with a case-sensitive collation, in which case, every test would be a test of case-sensitive behavior. This does create a risk of writing SQL that relies on case-sensitivity in its function, which then fails under case-insensitive collations, but I consider that rather less likely than case-insensitive code that fails when case-sensitivity is enabled.

If we did change it to use a case-sensitive collation, I _think_ we could remove the dedicated test suite I added, though each of those tests did turn out to be required to beat this functionality into shape, because I repeatedly missed various ways this could go wrong:

- "I'll just addproperty": fails during alter that updates the comment
- "I'll base add/update on whether we're creating or altering": fails when a table/column is created without any comment, and the alter needs to add, not update

Finally I came around to, "We just have to check and add/update based on what we find each time," which is the implementation you see here.