### PR TITLE
fix(mssql): Generate valid SQL for withRecursive() [#4514]

### DIFF
--- a/lib/dialects/mssql/query/mssql-querycompiler.js
+++ b/lib/dialects/mssql/query/mssql-querycompiler.js
@@ -31,6 +31,30 @@ class QueryCompiler_MSSQL extends QueryCompiler {
     this._emptyInsertValue = 'default values';
   }
 
+  with() {
+    // WITH RECURSIVE is a syntax error:
+    // SQL Server does not syntactically distinguish recursive and non-recursive CTEs.
+    // So mark all statements as non-recursive, generate the SQL, then restore.
+    // This approach ensures any changes in base class with() get propagated here.
+    const undoList = [];
+    if (this.grouped.with) {
+      for (const stmt of this.grouped.with) {
+        if (stmt.recursive) {
+          undoList.push(stmt);
+          stmt.recursive = false;
+        }
+      }
+    }
+
+    const result = super.with();
+
+    // Restore the recursive markings, in case this same query gets cloned and passed to other drivers.
+    for (const stmt of undoList) {
+      stmt.recursive = true;
+    }
+    return result;
+  }
+
   select() {
     const sql = this.with();
     const statements = components.map((component) => this[component](this));

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -9367,13 +9367,16 @@ describe('QueryBuilder', () => {
         .select('*')
         .from('secondWithClause'),
       {
+        // mssql does not allow the RECURSIVE keyword.
         mssql:
-          'with recursive [firstWithClause] as (with recursive [firstWithSubClause] as ((select [foo] from [users]) as [foz]) select * from [firstWithSubClause]), [secondWithClause] as (with recursive [secondWithSubClause] as ((select [bar] from [users]) as [baz]) select * from [secondWithSubClause]) select * from [secondWithClause]',
+          'with [firstWithClause] as (with [firstWithSubClause] as ((select [foo] from [users]) as [foz]) select * from [firstWithSubClause]), [secondWithClause] as (with [secondWithSubClause] as ((select [bar] from [users]) as [baz]) select * from [secondWithSubClause]) select * from [secondWithClause]',
         sqlite3:
           'with recursive `firstWithClause` as (with recursive `firstWithSubClause` as ((select `foo` from `users`) as `foz`) select * from `firstWithSubClause`), `secondWithClause` as (with recursive `secondWithSubClause` as ((select `bar` from `users`) as `baz`) select * from `secondWithSubClause`) select * from `secondWithClause`',
         pg: 'with recursive "firstWithClause" as (with recursive "firstWithSubClause" as ((select "foo" from "users") as "foz") select * from "firstWithSubClause"), "secondWithClause" as (with recursive "secondWithSubClause" as ((select "bar" from "users") as "baz") select * from "secondWithSubClause") select * from "secondWithClause"',
         'pg-redshift':
           'with recursive "firstWithClause" as (with recursive "firstWithSubClause" as ((select "foo" from "users") as "foz") select * from "firstWithSubClause"), "secondWithClause" as (with recursive "secondWithSubClause" as ((select "bar" from "users") as "baz") select * from "secondWithSubClause") select * from "secondWithClause"',
+        // FIXME: oracledb does not allow the RECURSIVE keyword, but does require a list of column aliases for a recursive query. [#4514]
+        // https://github.com/knex/knex/issues/4514#issuecomment-903727391
         oracledb:
           'with recursive "firstWithClause" as (with recursive "firstWithSubClause" as ((select "foo" from "users") "foz") select * from "firstWithSubClause"), "secondWithClause" as (with recursive "secondWithSubClause" as ((select "bar" from "users") "baz") select * from "secondWithSubClause") select * from "secondWithClause"',
       }


### PR DESCRIPTION
mssql forbids use of the RECURSIVE keyword required by some other
dialects.

The approach taken here maximizes subclass reuse and leaking
changes to the query outside `with` generation. If we skipped
restoring the recursive labels using `undoList`, the SQL would
generate fine here, but the test suite fails:
The next-tested driver fails its test, because clone() preserves the
top-level statement's `recursive = false` change, so it's shy one
`RECURSIVE` in the generated SQL.

This addresses the mssql portion of [#4514], but not the oracledb issues.
If this approach to omitting RECURSIVE looks good, I can apply the same to the
oracledb dialect. (Supporting a column alias list as separate argument, as Oracle
requires for recursive CTEs, would require deeper changes.)