### PR TITLE
drop onDelete/onUpdate for ColumnBuilder

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1952,8 +1952,6 @@ export declare namespace Knex {
     /** @deprecated */
     unique(indexName?: string): ColumnBuilder;
     references(columnName: string): ReferencingColumnBuilder;
-    onDelete(command: string): ColumnBuilder;
-    onUpdate(command: string): ColumnBuilder;
     defaultTo(value: Value | null, options?: DefaultToOptions): ColumnBuilder;
     unsigned(): ColumnBuilder;
     notNullable(): ColumnBuilder;


### PR DESCRIPTION
fixes #4620
This breaks wrong code, when onDelete/onUpdate called not in context of foreign constraints.
But also breaks valid code, i.e.:
```ts
table.integer('num').references('non_exist.id').index('num_idx').onDelete('CASCADE');
 ```
(index() method return `ColumnBuilder` interface, not `ReferencingColumnBuilder`)

This probably could be fixed with rewriting code to extending previous interface with new methods instead of current approach, idk is it worth it?


@lorefnon 