### PR TITLE
Implement nullability modification via schema builder

### DIFF
--- a/lib/dialects/postgres/schema/pg-tablecompiler.js
+++ b/lib/dialects/postgres/schema/pg-tablecompiler.js
@@ -21,6 +21,16 @@ class TableCompiler_PG extends TableCompiler {
     });
   }
 
+  _setNullableState(column, isNullable) {
+    const constraintAction = isNullable ? 'drop not null' : 'set not null';
+    const sql = `alter table ${this.tableName()} alter column ${this.formatter.wrap(
+      column
+    )} ${constraintAction}`;
+    return this.pushQuery({
+      sql: sql,
+    });
+  }
+
   compileAdd(builder) {
     const table = this.formatter.wrap(builder);
     const columns = this.prefixArray('add column', this.getColumns(builder));

--- a/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
@@ -265,6 +265,11 @@ class TableCompiler_SQLite3 extends TableCompiler {
     });
   }
 
+  _setNullableState(column, isNullable) {
+    const fnCalled = isNullable ? '.setNullable' : '.dropNullable';
+    throw new Error(`${fnCalled} is not supported for SQLite.`);
+  }
+
   dropColumn() {
     const compiler = this;
     const columns = values(arguments);

--- a/lib/schema/tablebuilder.js
+++ b/lib/schema/tablebuilder.js
@@ -284,6 +284,26 @@ const AlterMethods = {
     return this.dropColumns(['created_at', 'updated_at']);
   },
 
+  setNullable(column) {
+    this._statements.push({
+      grouping: 'alterTable',
+      method: 'setNullable',
+      args: [column],
+    });
+
+    return this;
+  },
+
+  dropNullable(column) {
+    this._statements.push({
+      grouping: 'alterTable',
+      method: 'dropNullable',
+      args: [column],
+    });
+
+    return this;
+  },
+
   // TODO: changeType
 };
 

--- a/lib/schema/tablecompiler.js
+++ b/lib/schema/tablecompiler.js
@@ -286,6 +286,49 @@ class TableCompiler {
     );
   }
 
+  //Default implementation of setNullable. Overwrite on dialect-specific tablecompiler when needed
+  //(See postgres/mssql for reference)
+  _setNullableState(column, nullable) {
+    const tableName = this.tableName();
+    const columnName = this.formatter.columnize(column);
+    const alterColumnPrefix = this.alterColumnsPrefix;
+    return this.pushQuery({
+      sql: 'SELECT 1',
+      output: () => {
+        return this.client
+          .queryBuilder()
+          .from(this.tableNameRaw)
+          .columnInfo(column)
+          .then((columnInfo) => {
+            if (isEmpty(columnInfo)) {
+              throw new Error(
+                `.setNullable: Column ${columnName} does not exist in table ${tableName}.`
+              );
+            }
+            const nullableType = nullable ? 'null' : 'not null';
+            const columnType =
+              columnInfo.type +
+              (columnInfo.maxLength ? `(${columnInfo.maxLength})` : '');
+            const defaultValue =
+              columnInfo.defaultValue !== null &&
+              columnInfo.defaultValue !== void 0
+                ? `default '${columnInfo.defaultValue}'`
+                : '';
+            const sql = `alter table ${tableName} ${alterColumnPrefix} ${columnName} ${columnType} ${nullableType} ${defaultValue}`;
+            return this.client.raw(sql);
+          });
+      },
+    });
+  }
+
+  setNullable(column) {
+    return this._setNullableState(column, true);
+  }
+
+  dropNullable(column) {
+    return this._setNullableState(column, false);
+  }
+
   // If no name was specified for this index, we will create one using a basic
   // convention of the table name, followed by the columns, followed by an
   // index type, such as primary or index, which makes the index unique.
@@ -310,6 +353,7 @@ TableCompiler.prototype.lowerCase = true;
 TableCompiler.prototype.createAlterTableMethods = null;
 TableCompiler.prototype.addColumnsPrefix = 'add column ';
 TableCompiler.prototype.alterColumnsPrefix = 'alter column ';
+TableCompiler.prototype.modifyColumnPrefix = 'modify column ';
 TableCompiler.prototype.dropColumnPrefix = 'drop column ';
 
 module.exports = TableCompiler;

--- a/test/integration2/schema/set-nullable.spec.js
+++ b/test/integration2/schema/set-nullable.spec.js
@@ -1,0 +1,73 @@
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
+const { isSQLite, isPostgreSQL, isMysql } = require('../../util/db-helpers');
+const { getAllDbs, getKnexForDb } = require('../util/knex-instance-provider');
+
+describe('Schema', () => {
+  describe('alter nullable', () => {
+    getAllDbs().forEach((db) => {
+      describe(db, () => {
+        let knex;
+
+        before(function () {
+          knex = getKnexForDb(db);
+          if (isSQLite(knex)) {
+            return this.skip();
+          }
+        });
+
+        after(() => {
+          return knex.destroy();
+        });
+
+        beforeEach(async () => {
+          await knex.schema.createTable('primary_table', (table) => {
+            table.integer('id_nullable').nullable();
+            table.integer('id_not_nullable').notNull();
+          });
+        });
+
+        afterEach(async () => {
+          await knex.schema.dropTable('primary_table');
+        });
+
+        describe('setNullable', () => {
+          it('sets column to be nullable', async () => {
+            await knex.schema.table('primary_table', (table) => {
+              table.setNullable('id_not_nullable');
+            });
+
+            await knex('primary_table').insert({
+              id_nullable: null,
+              id_not_nullable: null,
+            });
+          });
+        });
+
+        describe('dropNullable', () => {
+          it('sets column to be not nullable', async () => {
+            await knex.schema.table('primary_table', (table) => {
+              table.dropNullable('id_nullable');
+            });
+
+            let errorMessage;
+            if (isPostgreSQL()) {
+              errorMessage = 'violates not-null constraint';
+            }
+            if (isMysql()) {
+              errorMessage = 'cannot be null';
+            }
+
+            await expect(
+              knex('primary_table').insert({
+                id_nullable: null,
+                id_not_nullable: 1,
+              })
+            ).to.eventually.be.rejectedWith(errorMessage);
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Refreshed version of #1327 by @wubzz 

fixes #1218

Note that old solution of `table.string('checksum').nullable().alter();` is not particularly flexible, because it attempts to switch type from itself to itself, which works by a happy accident in majority databases, but breaks for the others (such as CockroachDB). It was also quite different from how other schema operations worked.