### PR TITLE
fix(oracledb): Support setNullable, dropNullable

### DIFF
--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -10,6 +10,7 @@ const values = require('lodash/values');
 
 const Formatter = require('../../formatter');
 const QueryCompiler = require('./query/oracledb-querycompiler');
+const TableCompiler = require('./schema/oracledb-tablecompiler');
 const ColumnCompiler = require('./schema/oracledb-columncompiler');
 const { BlobHelper, ReturningHelper, isConnectionError } = require('./utils');
 const Transaction = require('./transaction');
@@ -56,6 +57,10 @@ class Client_Oracledb extends Client_Oracle {
 
   queryCompiler(builder, formatter) {
     return new QueryCompiler(this, builder, formatter);
+  }
+
+  tableCompiler() {
+    return new TableCompiler(this, ...arguments);
   }
 
   columnCompiler() {

--- a/lib/dialects/oracledb/schema/oracledb-tablecompiler.js
+++ b/lib/dialects/oracledb/schema/oracledb-tablecompiler.js
@@ -1,0 +1,19 @@
+const TableCompiler_Oracle = require('../../oracle/schema/oracle-tablecompiler');
+
+class TableCompiler_Oracledb extends TableCompiler_Oracle {
+  constructor(client, tableBuilder) {
+    super(client, tableBuilder);
+  }
+
+  _setNullableState(column, isNullable) {
+    const nullability = isNullable ? 'NULL' : 'NOT NULL';
+    const sql = `alter table ${this.tableName()} modify (${this.formatter.wrap(
+      column
+    )} ${nullability})`;
+    return this.pushQuery({
+      sql: sql,
+    });
+  }
+}
+
+module.exports = TableCompiler_Oracledb;

--- a/test/integration2/schema/set-nullable.spec.js
+++ b/test/integration2/schema/set-nullable.spec.js
@@ -52,10 +52,9 @@ describe('Schema', () => {
             });
 
             let errorMessage;
-            if (isPostgreSQL()) {
+            if (isPostgreSQL(knex)) {
               errorMessage = 'violates not-null constraint';
-            }
-            if (isMysql()) {
+            } else if (isMysql(knex)) {
               errorMessage = 'cannot be null';
             }
 

--- a/test/integration2/schema/set-nullable.spec.js
+++ b/test/integration2/schema/set-nullable.spec.js
@@ -1,7 +1,12 @@
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
 const expect = chai.expect;
-const { isSQLite, isPostgreSQL, isMysql } = require('../../util/db-helpers');
+const {
+  isSQLite,
+  isPostgreSQL,
+  isMysql,
+  isOracle,
+} = require('../../util/db-helpers');
 const { getAllDbs, getKnexForDb } = require('../util/knex-instance-provider');
 
 describe('Schema', () => {
@@ -56,6 +61,8 @@ describe('Schema', () => {
               errorMessage = 'violates not-null constraint';
             } else if (isMysql(knex)) {
               errorMessage = 'cannot be null';
+            } else if (isOracle(knex)) {
+              errorMessage = 'ORA-01400: cannot insert NULL into';
             }
 
             await expect(


### PR DESCRIPTION
Before, these functions would fail when run, as indicated by test suite failures when testing against oracledb.

Now, they work.

The existing tests were also not checking the error message as intended, so I have corrected that. (I originally thought to include a "make sure errorMessage is a string" check, but since only a fraction of the drivers had spec'd error messages, I backed that out.)