### PR TITLE
Passing all arguments to _promise.catch function #4665

### DIFF
--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -266,8 +266,8 @@ class Transaction extends EventEmitter {
     return this._promise.then(onResolve, onReject);
   }
 
-  catch(onReject) {
-    return this._promise.catch(onReject);
+  catch(...args) {
+    return this._promise.catch(...args);
   }
 
   asCallback(cb) {


### PR DESCRIPTION
This is a pull request to fix the issue concerning the use of filtered catch after a transaction (see [issue](https://github.com/knex/knex/issues/4665))