### PR TITLE
Avoid inserting multiple locks if a lock already exists

### DIFF
--- a/lib/migrations/migrate/table-creator.js
+++ b/lib/migrations/migrate/table-creator.js
@@ -7,7 +7,6 @@ const {
 
 function ensureTable(tableName, schemaName, trxOrKnex) {
   const lockTable = getLockTableName(tableName);
-  const lockTableWithSchema = getLockTableNameWithSchema(tableName, schemaName);
   return getSchemaBuilder(trxOrKnex, schemaName)
     .hasTable(tableName)
     .then((exists) => {
@@ -26,8 +25,7 @@ function ensureTable(tableName, schemaName, trxOrKnex) {
     })
     .then((data) => {
       return (
-        !data.length &&
-        trxOrKnex.into(lockTableWithSchema).insert({ is_locked: 0 })
+        !data.length && _insertLockRowIfNeeded(tableName, schemaName, trxOrKnex)
       );
     });
 }
@@ -52,6 +50,17 @@ function _createMigrationLockTable(tableName, schemaName, trxOrKnex) {
       t.integer('is_locked');
     }
   );
+}
+
+function _insertLockRowIfNeeded(tableName, schemaName, trxOrKnex) {
+  const lockTableWithSchema = getLockTableNameWithSchema(tableName, schemaName);
+  return trxOrKnex
+    .from(trxOrKnex.raw('?? (??)', [lockTableWithSchema, 'is_locked']))
+    .insert(function () {
+      return this.select(trxOrKnex.raw('?', [0])).whereNotExists(function () {
+        return this.select('*').from(lockTableWithSchema);
+      });
+    });
 }
 
 //Get schema-aware schema builder for a given schema nam


### PR DESCRIPTION
There is currently a race in ensureTable function that could result in multiple rows being insert into the locks table. Multiple locks in the lock table is a non-recoverable state where no lock can later
be acquired.

The reason for the race is that the number of locks are first retrieved from the lock table, and a new lock is then inserted if that number
is zero. It is possible that a lock is inserted into the locks table right after the number of locks were first retrived, resulting in another lock being inserted.

This is fixed by using an insert into select where no row is inserted if
there is already a row in table, which is the desired end state.