### PR TITLE
Fix overzealous warning on use of whereNot with "in" or "between"

### DIFF
--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -429,7 +429,7 @@ class Builder extends EventEmitter {
 
   // Adds an `not where` clause to the query.
   whereNot(column, ...args) {
-    if (args.length >= 1) {
+    if (args.length >= 2) {
       if (args[0] === 'in' || args[0] === 'between') {
         this.client.logger.warn(
           'whereNot is not suitable for "in" and "between" type subqueries. You should use "not in" and "not between" instead.'

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -1050,6 +1050,36 @@ describe('QueryBuilder', () => {
     }
   });
 
+  it('where not should not throw warning when used with "in" or "between" as equality', function () {
+    testquery(
+      clientsWithCustomLoggerForTestWarnings.pg
+        .queryBuilder()
+        .select('*')
+        .from('users')
+        .whereNot('id', 'in'),
+      {
+        mysql: "select * from `users` where not `id` = 'in'",
+        pg: 'select * from "users" where not "id" = \'in\'',
+        'pg-redshift': 'select * from "users" where not "id" = \'in\'',
+        mssql: "select * from [users] where not [id] = 'in'",
+      }
+    );
+
+    testquery(
+      clientsWithCustomLoggerForTestWarnings.pg
+        .queryBuilder()
+        .select('*')
+        .from('users')
+        .whereNot('id', 'between'),
+      {
+        mysql: "select * from `users` where not `id` = 'between'",
+        pg: 'select * from "users" where not "id" = \'between\'',
+        'pg-redshift': 'select * from "users" where not "id" = \'between\'',
+        mssql: "select * from [users] where not [id] = 'between'",
+      }
+    );
+  });
+
   it('where bool', () => {
     testquery(qb().select('*').from('users').where(true), {
       mysql: 'select * from `users` where 1 = 1',


### PR DESCRIPTION
I ran into this with a `whereNot('id', 'in')` clause producing a warning despite it only intending to occur when 'in' is an operator, not a value.

Please let me know if the test format isn't right, I'd be happy to change it!