### PR TITLE
Allowing for alternate naming of Pg CLI version reporting

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -127,7 +127,7 @@ class Client_PG extends Client {
   }
 
   _parseVersion(versionString) {
-    return /^PostgreSQL (.*?)( |$)/.exec(versionString)[1];
+    return /^(PostgreSQL|psql) (.*?)( |$)/.exec(versionString)[1];
   }
 
   // Position the bindings for the query. The escape sequence for question mark


### PR DESCRIPTION
My entire directus.io install fails because of this line. It's trying to read

```
psql --version
psql (PostgreSQL) 12.5 (Ubuntu 12.5-1.pgdg20.04+1)
```