### PR TITLE
Zero precision in timestamp/datetime #4784

### DIFF
--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -72,22 +72,13 @@ class ColumnCompiler_PG extends ColumnCompiler {
       useTz = !withoutTz;
     }
     useTz = typeof useTz === 'boolean' ? useTz : true;
-    precision = precision ? '(' + precision + ')' : '';
+    precision = precision !== undefined ? '(' + precision + ')' : '';
 
     return `${useTz ? 'timestamptz' : 'timestamp'}${precision}`;
   }
 
   timestamp(withoutTz = false, precision) {
-    let useTz;
-    if (isObject(withoutTz)) {
-      ({ useTz, precision } = withoutTz);
-    } else {
-      useTz = !withoutTz;
-    }
-    useTz = typeof useTz === 'boolean' ? useTz : true;
-    precision = precision ? '(' + precision + ')' : '';
-
-    return `${useTz ? 'timestamptz' : 'timestamp'}${precision}`;
+    return this.datetime(withoutTz, precision);
   }
 
   // Modifiers:

--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -72,7 +72,10 @@ class ColumnCompiler_PG extends ColumnCompiler {
       useTz = !withoutTz;
     }
     useTz = typeof useTz === 'boolean' ? useTz : true;
-    precision = precision !== undefined ? '(' + precision + ')' : '';
+    precision =
+      precision !== undefined && precision !== null
+        ? '(' + precision + ')'
+        : '';
 
     return `${useTz ? 'timestamptz' : 'timestamp'}${precision}`;
   }

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -1528,6 +1528,19 @@ describe('PostgreSQL SchemaBuilder', function () {
     );
   });
 
+  it('adding timestamp with options object but precision 0 - #4784', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.timestamp('foo', { useTz: false, precision: 0 });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamp(0)'
+    );
+  });
+
   it('adding datetime with options object', () => {
     tableSql = client
       .schemaBuilder()
@@ -1564,6 +1577,19 @@ describe('PostgreSQL SchemaBuilder', function () {
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
       'alter table "users" add column "foo" timestamptz'
+    );
+  });
+
+  it('adding datetime with options object but precision 0 - #4784', () => {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', (table) => {
+        table.datetime('foo', { useTz: false, precision: 0 });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "users" add column "foo" timestamp(0)'
     );
   });
 


### PR DESCRIPTION
- Fixes https://github.com/knex/knex/issues/4784
- Remove duplicate (actually timestamp == datetime implementation in PG) and so correct datetime precision = 0 too.