### PR TITLE
Fix Union all + first syntax error (#4364)

### DIFF
--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -702,7 +702,11 @@ class QueryCompiler {
   // If we haven't specified any columns or a `tableName`, we're assuming this
   // is only being used for unions.
   onlyUnions() {
-    return !this.grouped.columns && this.grouped.union && !this.tableName;
+    return (
+      (!this.grouped.columns || !!this.grouped.columns[0].value) &&
+      this.grouped.union &&
+      !this.tableName
+    );
   }
 
   limit() {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -2205,6 +2205,36 @@ describe('QueryBuilder', () => {
         bindings: [1, 2, 3],
       },
     });
+
+    // Issue #4364
+    const firstUnionAll = qb()
+      .unionAll([
+        function () {
+          this.select().from('users').where({ id: 1 });
+        },
+        function () {
+          this.select().from('users').where({ id: 2 });
+        },
+      ])
+      .first();
+    testsql(firstUnionAll, {
+      mysql: {
+        sql: 'select * from `users` where `id` = ? union all select * from `users` where `id` = ? limit ?',
+        bindings: [1, 2, 1],
+      },
+      mssql: {
+        sql: 'select * from [users] where [id] = ? union all select * from [users] where [id] = ?',
+        bindings: [1, 2],
+      },
+      pg: {
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? limit ?',
+        bindings: [1, 2, 1],
+      },
+      'pg-redshift': {
+        sql: 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? limit ?',
+        bindings: [1, 2, 1],
+      },
+    });
   });
 
   it('multiple unions', () => {


### PR DESCRIPTION
- Fix a syntax bug with union all and first because the (old) onlyUnion function is always false (we have a columns array with empty array for values).
- Fixes #4364