### PR TITLE
Support Joins and Using syntax for PostgreSQL Delete Statement (#4591)

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -7,6 +7,7 @@ const Client = require('../../client');
 
 const Transaction = require('./execution/pg-transaction');
 const QueryCompiler = require('./query/pg-querycompiler');
+const QueryBuilder = require('./query/pg-querybuilder');
 const ColumnCompiler = require('./schema/pg-columncompiler');
 const TableCompiler = require('./schema/pg-tablecompiler');
 const ViewCompiler = require('./schema/pg-viewcompiler');
@@ -28,6 +29,10 @@ class Client_PG extends Client {
   }
   transaction() {
     return new Transaction(this, ...arguments);
+  }
+
+  queryBuilder() {
+    return new QueryBuilder(this);
   }
 
   queryCompiler(builder, formatter) {

--- a/lib/dialects/postgres/query/pg-querybuilder.js
+++ b/lib/dialects/postgres/query/pg-querybuilder.js
@@ -1,0 +1,8 @@
+const QueryBuilder = require('../../../query/querybuilder.js');
+
+module.exports = class QueryBuilder_PostgreSQL extends QueryBuilder {
+  using(tables) {
+    this._single.using = tables;
+    return this;
+  }
+};

--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -105,6 +105,7 @@ class QueryCompiler_PG extends QueryCompiler {
               column: clause.column,
               operator: '=',
               value: clause.value,
+              asColumn: true,
             })
           );
         }
@@ -117,13 +118,10 @@ class QueryCompiler_PG extends QueryCompiler {
       }
     }
 
-    // When using the clause 'using' we delete the "from" table name (like joins)
-    const deleteSelector = using ? tableName + ' ' : '';
+    // With 'using' syntax, no tablename between DELETE and FROM.
     const sql =
       withSQL +
-      `delete ${deleteSelector}from ${
-        this.single.only ? 'only ' : ''
-      }${tableName}` +
+      `delete from ${this.single.only ? 'only ' : ''}${tableName}` +
       (using ? ` ${using}` : '') +
       (wheres ? ` ${wheres}` : '');
     const { returning } = this.single;

--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -57,9 +57,44 @@ class QueryCompiler_PG extends QueryCompiler {
     };
   }
 
-  // Compiles an `update` query, allowing for a return value.
+  using() {
+    const usingTables = this.single.using;
+    if (!usingTables) return;
+    let sql = 'using ';
+    if (Array.isArray(usingTables)) {
+      sql += usingTables
+        .map((table) => {
+          return this.formatter.wrap(table);
+        })
+        .join(',');
+    } else {
+      sql += this.formatter.wrap(usingTables);
+    }
+    return sql;
+  }
+
+  // Compiles an `delete` query, allowing for a return value.
   del() {
-    const sql = super.del(...arguments);
+    // Make sure tableName is processed by the formatter first.
+    const { tableName } = this;
+    const withSQL = this.with();
+    const wheres = this.where();
+    // Joins in PG with delete it's not valid, we throw an error and ask to use 'using'
+    if (this.join().length > 0) {
+      throw new Error(
+        "Joins with delete query isn't valid in PostgreSQL, use 'using' with 'where' functions instead."
+      );
+    }
+    const using = this.using();
+    // When using the clause 'using' we delete the "from" table name (like joins)
+    const deleteSelector = using ? tableName + ' ' : '';
+    const sql =
+      withSQL +
+      `delete ${deleteSelector}from ${
+        this.single.only ? 'only ' : ''
+      }${tableName}` +
+      (using ? ` ${using}` : '') +
+      (wheres ? ` ${wheres}` : '');
     const { returning } = this.single;
     return {
       sql: sql + this._returning(returning),

--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -4,7 +4,10 @@ const identity = require('lodash/identity');
 const reduce = require('lodash/reduce');
 
 const QueryCompiler = require('../../../query/querycompiler');
-const { wrapString } = require('../../../formatter/wrappingFormatter');
+const {
+  wrapString,
+  wrap: wrap_,
+} = require('../../../formatter/wrappingFormatter');
 
 class QueryCompiler_PG extends QueryCompiler {
   constructor(client, builder, formatter) {
@@ -78,14 +81,42 @@ class QueryCompiler_PG extends QueryCompiler {
     // Make sure tableName is processed by the formatter first.
     const { tableName } = this;
     const withSQL = this.with();
-    const wheres = this.where();
-    // Joins in PG with delete it's not valid, we throw an error and ask to use 'using'
-    if (this.join().length > 0) {
-      throw new Error(
-        "Joins with delete query isn't valid in PostgreSQL, use 'using' with 'where' functions instead."
-      );
+    let wheres = this.where() || '';
+    let using = this.using() || '';
+    const joins = this.grouped.join;
+
+    const tableJoins = [];
+    if (Array.isArray(joins)) {
+      for (const join of joins) {
+        tableJoins.push(
+          wrap_(
+            this._joinTable(join),
+            undefined,
+            this.builder,
+            this.client,
+            this.bindingsHolder
+          )
+        );
+
+        const joinWheres = [];
+        for (const clause of join.clauses) {
+          joinWheres.push(
+            this.whereBasic({
+              column: clause.column,
+              operator: '=',
+              value: clause.value,
+            })
+          );
+        }
+        if (joinWheres.length > 0) {
+          wheres += (wheres ? ' and ' : '') + joinWheres.join(' ');
+        }
+      }
+      if (tableJoins.length > 0) {
+        using += (using ? ',' : 'using ') + tableJoins.join(',');
+      }
     }
-    const using = this.using();
+
     // When using the clause 'using' we delete the "from" table name (like joins)
     const deleteSelector = using ? tableName + ' ' : '';
     const sql =

--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -269,6 +269,11 @@ class Builder extends EventEmitter {
     return this;
   }
 
+  using(tables) {
+    this._single.using = tables;
+    return this;
+  }
+
   // JOIN blocks:
   innerJoin(...args) {
     return this._joinType('inner').join(...args);

--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -270,8 +270,9 @@ class Builder extends EventEmitter {
   }
 
   using(tables) {
-    this._single.using = tables;
-    return this;
+    throw new Error(
+      "'using' function is only available in PostgreSQL dialect with Delete statements."
+    );
   }
 
   // JOIN blocks:

--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -333,6 +333,12 @@ class QueryCompiler {
     })`;
   }
 
+  _joinTable(join) {
+    return join.schema && !(join.table instanceof Raw)
+      ? `${join.schema}.${join.table}`
+      : join.table;
+  }
+
   // Compiles all each of the `join` clauses on the query,
   // including any nested join queries.
   join() {
@@ -342,10 +348,7 @@ class QueryCompiler {
     if (!joins) return '';
     while (++i < joins.length) {
       const join = joins[i];
-      const table =
-        join.schema && !(join.table instanceof Raw)
-          ? `${join.schema}.${join.table}`
-          : join.table;
+      const table = this._joinTable(join);
       if (i > 0) sql += ' ';
       if (join.joinType === 'raw') {
         sql += unwrapRaw_(

--- a/test/integration/query/deletes.js
+++ b/test/integration/query/deletes.js
@@ -119,6 +119,9 @@ module.exports = function (knex) {
       });
 
       it('should handle basic delete with join and "using" syntax in PostgreSQL', async function () {
+        if (!isPostgreSQL(knex)) {
+          this.skip();
+        }
         await knex('test_table_two').insert({
           account_id: 4,
           details: '',

--- a/test/integration/query/deletes.js
+++ b/test/integration/query/deletes.js
@@ -2,12 +2,8 @@
 
 const { expect } = require('chai');
 const { TEST_TIMESTAMP } = require('../../util/constants');
-const {
-  isSQLite,
-  isPostgreSQL,
-  isOracle,
-  isCockroachDB,
-} = require('../../util/db-helpers');
+const { isSQLite, isOracle, isCockroachDB } = require('../../util/db-helpers');
+const { isPostgreSQL } = require('../../util/db-helpers.js');
 
 module.exports = function (knex) {
   describe('Deletes', function () {
@@ -96,12 +92,7 @@ module.exports = function (knex) {
           .join('accounts', 'accounts.id', 'test_table_two.account_id')
           .where({ 'accounts.email': 'test3@example.com' })
           .del();
-        if (
-          isSQLite(knex) ||
-          isPostgreSQL(knex) ||
-          isCockroachDB(knex) ||
-          isOracle(knex)
-        ) {
+        if (isSQLite(knex) || isCockroachDB(knex) || isOracle(knex)) {
           await expect(query).to.be.rejected;
           return;
         }
@@ -109,6 +100,12 @@ module.exports = function (knex) {
           tester(
             'mysql',
             'delete `test_table_two` from `test_table_two` inner join `accounts` on `accounts`.`id` = `test_table_two`.`account_id` where `accounts`.`email` = ?',
+            ['test3@example.com'],
+            1
+          );
+          tester(
+            'pg',
+            'delete from "test_table_two" using "accounts" where "accounts"."email" = ? and "accounts"."id" = "test_table_two"."account_id"',
             ['test3@example.com'],
             1
           );
@@ -120,6 +117,32 @@ module.exports = function (knex) {
           );
         });
       });
+
+      it('should handle basic delete with join and "using" syntax in PostgreSQL', async function () {
+        await knex('test_table_two').insert({
+          account_id: 4,
+          details: '',
+          status: 1,
+        });
+        const query = knex('test_table_two')
+          .using('accounts')
+          .where({ 'accounts.email': 'test4@example.com' })
+          .whereRaw('"accounts"."id" = "test_table_two"."account_id"')
+          .del();
+        if (!isPostgreSQL(knex)) {
+          await expect(query).to.be.rejected;
+          return;
+        }
+        return query.testSql(function (tester) {
+          tester(
+            'pg',
+            'delete from "test_table_two" using "accounts" where "accounts"."email" = ? and "accounts"."id" = "test_table_two"."account_id"',
+            ['test4@example.com'],
+            1
+          );
+        });
+      });
+
       it('should handle returning', async function () {
         await knex('test_table_two').insert({
           account_id: 4,
@@ -130,12 +153,7 @@ module.exports = function (knex) {
           .join('accounts', 'accounts.id', 'test_table_two.account_id')
           .where({ 'accounts.email': 'test4@example.com' })
           .del('*');
-        if (
-          isSQLite(knex) ||
-          isPostgreSQL(knex) ||
-          isCockroachDB(knex) ||
-          isOracle(knex)
-        ) {
+        if (isSQLite(knex) || isCockroachDB(knex) || isOracle(knex)) {
           await expect(query).to.be.rejected;
           return;
         }
@@ -145,6 +163,28 @@ module.exports = function (knex) {
             'delete `test_table_two` from `test_table_two` inner join `accounts` on `accounts`.`id` = `test_table_two`.`account_id` where `accounts`.`email` = ?',
             ['test4@example.com'],
             1
+          );
+          tester(
+            'pg',
+            'delete from "test_table_two" using "accounts" where "accounts"."email" = ? and "accounts"."id" = "test_table_two"."account_id" returning *',
+            ['test4@example.com'],
+            [
+              {
+                about: 'Lorem ipsum Dolore labore incididunt enim.',
+                balance: 0,
+                id: '4',
+                account_id: 4,
+                details: '',
+                status: 1,
+                phone: null,
+                logins: 2,
+                email: 'test4@example.com',
+                first_name: 'Test',
+                last_name: 'User',
+                created_at: TEST_TIMESTAMP,
+                updated_at: TEST_TIMESTAMP,
+              },
+            ]
           );
           tester(
             'mssql',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -482,7 +482,7 @@ export declare namespace Knex {
   //
   // QueryInterface
   //
-  type ClearStatements = "with" | "select" | "columns" | "hintComments" | "where" | "union" | "join" | "group" | "order" | "having" | "limit" | "offset" | "counter" | "counters";
+  type ClearStatements = "with" | "select" | "columns" | "hintComments" | "where" | "union" | "using" | "join" | "group" | "order" | "having" | "limit" | "offset" | "counter" | "counters";
 
   interface QueryInterface<TRecord extends {} = any, TResult = any> {
     select: Select<TRecord, TResult>;
@@ -508,6 +508,9 @@ export declare namespace Knex {
     outerJoin: Join<TRecord, TResult>;
     fullOuterJoin: Join<TRecord, TResult>;
     crossJoin: Join<TRecord, TResult>;
+
+    // Using
+    using: Using<TRecord, TResult>;
 
     // Withs
     with: With<TRecord, TResult>;
@@ -1336,6 +1339,10 @@ export declare namespace Knex {
       TRecord,
       TResult
     >;
+  }
+
+  interface Using<TRecord = any, TResult = unknown[]> {
+    (tables: string[]): QueryBuilder<TRecord, TResult>;
   }
 
   interface With<TRecord = any, TResult = unknown[]>


### PR DESCRIPTION
- PostgreSQL dont support Join in Delete (https://www.postgresqltutorial.com/postgresql-delete-join/) so I implements the support of using to do the same thing in two king : implicit and explicit methods.

So implicit method, with usual join methods work: 

```javascript
 qb()
    .del()
    .from('users')
    .join('photos', 'photos.id', 'users.id')
    .where({ 'user.email': 'mock@example.com' })
```
and will generate the query with 'using' and 'where' to work in PostgreSQL.
It will general the same query that explicit form:

```javascript
 qb()
  .del()
  .from('users')
  .using('photos')
  .whereRaw('photos.id = users.id')
  .where({ 'user.email': 'mock@example.com'})
```
- ~~I dont want to go in intrusive and complex implementation (no new kind of joins...) so I just add small using method in querybuilder and make all the specific logic in PG files.~~ Finally I implements both implicit joins conversion and explicit form.
- ~~I choose to make a specific implement of Delete that dont allow joins in Delete and throw an error when user try to make the joins with Delete statement => "Joins with delete query isn't valid in PostgreSQL, use 'using' with 'where' functions instead."~~ Specific implement of Delete for PostgreSQL that convert joins in 'using' + 'wheres'
- Fixes #4591