### PR TITLE
migration without file extension

### DIFF
--- a/lib/migrations/migrate/Migrator.js
+++ b/lib/migrations/migrate/Migrator.js
@@ -52,7 +52,7 @@ class Migrator {
       this.knex.client.logger
     );
     this._activeMigration = {
-      fileName: null,
+      name: null,
     };
   }
 
@@ -121,7 +121,13 @@ class Migrator {
     );
 
     let migrationToRun;
-    const name = this.config.name;
+    const name =
+      this.config.name != null
+        ? this.config.migrationSource.getMigrationName({
+            file: this.config.name,
+            directory: this.config.directory,
+          })
+        : null;
     if (name) {
       if (!completed.includes(name)) {
         migrationToRun = newMigrations.find((migration) => {
@@ -400,9 +406,9 @@ class Migrator {
             "lock manually by running 'knex migrate:unlock'"
         );
       } else {
-        if (this._activeMigration.fileName) {
+        if (this._activeMigration.name) {
           this.knex.client.logger.warn(
-            `migration file "${this._activeMigration.fileName}" failed`
+            `migration name "${this._activeMigration.name}" failed`
           );
         }
         this.knex.client.logger.warn(
@@ -492,7 +498,7 @@ class Migrator {
     const log = [];
     migrations.forEach((migration) => {
       const name = this.config.migrationSource.getMigrationName(migration);
-      this._activeMigration.fileName = name;
+      this._activeMigration.name = name;
       const migrationContent =
         this.config.migrationSource.getMigration(migration);
 
@@ -500,7 +506,7 @@ class Migrator {
       current = current
         .then(async () => await migrationContent) //maybe promise
         .then((migrationContent) => {
-          this._activeMigration.fileName = name;
+          this._activeMigration.name = name;
           if (
             !trx &&
             this._useTransaction(migrationContent, disableTransactions)
@@ -564,7 +570,7 @@ function validateMigrationList(migrationSource, migrations) {
   const diff = getMissingMigrations(migrationSource, completed, all);
   if (!isEmpty(diff)) {
     throw new Error(
-      `The migration directory is corrupt, the following files are missing: ${diff.join(
+      `The migration directory is corrupt, the following migrations are missing: ${diff.join(
         ', '
       )}`
     );

--- a/lib/migrations/migrate/sources/fs-migrations.js
+++ b/lib/migrations/migrate/sources/fs-migrations.js
@@ -72,7 +72,7 @@ class FsMigrations {
   }
 
   getMigrationName(migration) {
-    return migration.file;
+    return path.parse(migration.file).name;
   }
 
   getMigration(migration) {

--- a/lib/migrations/migrate/sources/fs-migrations.js
+++ b/lib/migrations/migrate/sources/fs-migrations.js
@@ -59,14 +59,12 @@ class FsMigrations {
       // return the migrations fully qualified
       if (this.sortDirsSeparately) {
         return filterMigrations(
-          this,
           migrations,
           loadExtensions || this.loadExtensions
         );
       }
 
       return filterMigrations(
-        this,
         sortBy(migrations, 'file'),
         loadExtensions || this.loadExtensions
       );
@@ -85,10 +83,9 @@ class FsMigrations {
   }
 }
 
-function filterMigrations(migrationSource, migrations, loadExtensions) {
+function filterMigrations(migrations, loadExtensions) {
   return migrations.filter((migration) => {
-    const migrationName = migrationSource.getMigrationName(migration);
-    const extension = path.extname(migrationName);
+    const extension = path.extname(migration.file);
     return loadExtensions.includes(extension);
   });
 }

--- a/test/cli/migrate.spec.js
+++ b/test/cli/migrate.spec.js
@@ -53,7 +53,7 @@ describe('migrate:latest', () => {
       });
     });
     const row = await getPromise;
-    expect(row.name).to.equal('000_create_rule_table.js');
+    expect(row.name).to.equal('000_create_rule_table');
     db.close();
   });
 });

--- a/test/unit/migrations/migrate/sources/fs-migrations.js
+++ b/test/unit/migrations/migrate/sources/fs-migrations.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const { expect } = require('chai');
+const {
+  FsMigrations,
+} = require('../../../../../lib/migrations/migrate/sources/fs-migrations');
+const mockFs = require('mock-fs');
+
+describe('fs-migrations', () => {
+  describe('getMigrationName', () => {
+    let migrationSource;
+    let fileNames;
+    before(() => {
+      migrationSource = new FsMigrations('test/integration/migrate/migration');
+      fileNames = [
+        'cjs-migration.cjs',
+        'co-migration.co',
+        'coffee-migration.coffee',
+        'eg-migration.eg',
+        'iced-migration.iced',
+        'js-migration.js',
+        'litcoffee-migration.litcoffee',
+        'ls-migration.ls',
+        'ts-migration.ts',
+      ];
+    });
+
+    it('should return the file name without extension', () => {
+      let migrationName = [];
+      fileNames.forEach((filename) =>
+        migrationName.push(
+          migrationSource.getMigrationName({
+            directory: 'test/integration/migrate/migration',
+            file: filename,
+          })
+        )
+      );
+      return expect(migrationName).to.eql([
+        'cjs-migration',
+        'co-migration',
+        'coffee-migration',
+        'eg-migration',
+        'iced-migration',
+        'js-migration',
+        'litcoffee-migration',
+        'ls-migration',
+        'ts-migration',
+      ]);
+    });
+  });
+
+  describe('getMigrations', () => {
+    let migrationSource;
+    before(() => {
+      migrationSource = new FsMigrations('test/integration/migrate/migration');
+      mockFs({
+        'test/integration/migrate/migration': {
+          'cjs-migration.cjs': 'cjs migration content',
+          'co-migration.co': 'co migation content',
+          'coffee-migration.coffee': 'coffee migation content',
+          'eg-migration.eg': 'eg migation content',
+          'iced-migration.iced': 'iced migation content',
+          'js-migration.js': 'js migation content',
+          'litcoffee-migration.litcoffee': 'litcoffee migation content',
+          'ls-migration.ls': 'ls migation content',
+          'ts-migration.ts': 'ts migation content',
+          'useless.txt': 'i am not a migration',
+        },
+      });
+    });
+
+    after(() => {
+      mockFs.restore();
+    });
+
+    it('should include all supported extensions by default', () => {
+      return migrationSource.getMigrations().then((list) => {
+        expect(list).to.eql([
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'cjs-migration.cjs',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'co-migration.co',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'coffee-migration.coffee',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'eg-migration.eg',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'iced-migration.iced',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'js-migration.js',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'litcoffee-migration.litcoffee',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'ls-migration.ls',
+          },
+          {
+            directory: 'test/integration/migrate/migration',
+            file: 'ts-migration.ts',
+          },
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This fixes #4028.

This is a breaking change as it currently expects all migrations to not have a file extension. It may be possible to have it instead check if the migration ends with one of the supported extensions and remove it before comparing.

There is still a failing test at [test\integration2\migrate\migration-integration.spec.js:827](https://github.com/Fydon/knex/blob/feature/migrationWithoutFileExtension/test/integration2/migrate/migration-integration.spec.js#L827). I'm not sure what the cause of the change is.

I've created test\unit\migrations\migrate\sources\fs-migrations.js to specifically test the output of the two, although this is being test with test\integration2\migrate\migration-integration.spec.js. I could add more tests.