### PR TITLE
Resolves #4583 Add JSDoc (TS flavor) to stub files

### DIFF
--- a/lib/migrations/migrate/stub/js.stub
+++ b/lib/migrations/migrate/stub/js.stub
@@ -1,4 +1,7 @@
-
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
 exports.up = function(knex) {
   <% if (d.tableName) { %>
   return knex.schema.createTable("<%= d.tableName %>", function(t) {
@@ -8,6 +11,10 @@ exports.up = function(knex) {
   <% } %>
 };
 
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
 exports.down = function(knex) {
   <% if (d.tableName) { %>
   return knex.schema.dropTable("<%= d.tableName %>");

--- a/lib/migrations/migrate/stub/knexfile-js.stub
+++ b/lib/migrations/migrate/stub/knexfile-js.stub
@@ -1,5 +1,8 @@
 // Update with your config settings.
 
+/**
+ * @type { Object.<string, import("knex").Knex.Config> }
+ */
 module.exports = {
 
   development: {

--- a/lib/migrations/seed/stub/js.stub
+++ b/lib/migrations/seed/stub/js.stub
@@ -1,4 +1,7 @@
-
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> } 
+ */
 exports.seed = function(knex) {
   // Deletes ALL existing entries
   return knex('table_name').del()


### PR DESCRIPTION
Documents the types of the cli-generated files for init, migrate:make and seed:make. Uses the TS-specific flavor of JSDoc described in the [TypeScript](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) Handbook. This enables code hinting. Typescript users can use the [checkJs](https://www.typescriptlang.org/tsconfig/#checkJs) in their project to raise a compilation error e.g. if they forget to return a Promise from the migration function. So this provides an alternative to making the cli generate TS directly with the `-x ts` option. Being JSDoc, it does not assume any specific module system on the user's machine to import the Knex.

Some screenshots with IntelliSense in Visual Studio Code

Seed, current
![seed-before](https://user-images.githubusercontent.com/44092779/140579311-c23905d1-81f5-4350-aedb-14c81f7e9db5.png)

Seed, PR
![seed-after](https://user-images.githubusercontent.com/44092779/140579313-53c94ab4-599d-4ef0-bcf7-56cba85bd26f.png)

Knexfile, current
![knexfile-before](https://user-images.githubusercontent.com/44092779/140579314-87867725-a7c4-4cdc-a363-34c828beb9b3.png)

Knexfile, PR
![knexfile-after](https://user-images.githubusercontent.com/44092779/140579315-6e7bed85-54c7-4d84-b96b-f43d65c14fe3.png)

Migrations, current
![migrations-before](https://user-images.githubusercontent.com/44092779/140579316-616662da-c288-437a-b094-cfcb24769aad.png)

Migrations , PR
![migrations-after](https://user-images.githubusercontent.com/44092779/140579318-b77a69d4-10f5-4205-a3b8-c95dce06cc25.png)


