### PR TITLE
Added cjs file extension to filetypes. Linked to #4819

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -64,7 +64,7 @@ async function initKnex(env, opts) {
 }
 
 function invoke() {
-  const filetypes = ['js', 'coffee', 'ts', 'eg', 'ls'];
+  const filetypes = ['js', 'coffee', 'ts', 'eg', 'ls', 'cjs'];
 
   const cwd = argv.knexfile
     ? path.dirname(path.resolve(argv.knexfile))


### PR DESCRIPTION
This PR should solve the problem which I encountered in project, that haves `"type": "module"` on the `package.json`. Details in [#4819](https://github.com/knex/knex/issues/4819). In short, knexfile.cjs didn't worked, so I added cjs to filetypes and then I able to use knexfile with cjs extension. I run test locally before and after change and got same test passed percent.