### PR TITLE
let user can use customized String format function like push "N" in t…

### DIFF
--- a/lib/execution/internal/query-executioner.js
+++ b/lib/execution/internal/query-executioner.js
@@ -14,7 +14,14 @@ function formatQuery(sql, bindings, timeZone, client) {
       return match;
     }
     const value = bindings[index++];
-    return client._escapeBinding(value, { timeZone });
+    let tmp = client._escapeBinding(value, { timeZone });
+    if (client.config.stringFormatter) {
+      const stringFormatter = client.config.stringFormatter;
+      if (typeof tmp == 'string') {
+        tmp = stringFormatter(tmp);
+      }
+    }
+    return tmp;
   });
 }
 


### PR DESCRIPTION
this is related to the issue
https://github.com/knex/knex/issues/4582

first time, user can config like below:
```
const knex = require('./knex')({
  client: 'mssql', stringFormatter: (str) => {
    if (escape(str).indexOf("%u") > -1)
      return `N${str}`;
    return `${str}`;
  }});
```