### PR TITLE
Recreate client on `knex.initialize` to use new config

### DIFF
--- a/lib/knex-builder/make-knex.js
+++ b/lib/knex-builder/make-knex.js
@@ -7,6 +7,7 @@ const QueryInterface = require('../query/method-constants');
 const merge = require('lodash/merge');
 const batchInsert = require('../execution/batch-insert');
 const { isObject } = require('../util/is');
+const { resolveConfig } = require('./internal/config-resolver');
 
 // Javascript does not officially support "callable objects".  Instead,
 // you must create a regular Function and inject properties/methods
@@ -164,7 +165,14 @@ function initContext(knexFn) {
 
     // Typically never needed, initializes the pool for a knex client.
     initialize(config) {
-      return this.client.initializePool(config);
+      if (this.client.pool) {
+        this.client.logger.warn('The pool has already been initialized');
+        return;
+      }
+
+      const { resolvedConfig, Dialect } = resolveConfig(config);
+      const client = new Dialect(resolvedConfig);
+      this.client = client;
     },
 
     // Convenience method for tearing down the pool.


### PR DESCRIPTION
This PR is an attempt to close #3828. When calling `knex.destroy` then `knex.initialize([config])`, the current version of knex does not take into account the passed new config. This PR makes `knex.initialize` replace the `knex.client` with a new `Client` based on the `config` using `resolveConfig`, similar to what happens in `makeKnex`

# Notes
- I couldn't use `npm run db:start:postgres` due to the following error that I couldn't fix: 
```
Creating scripts_postgres_1 ... error
ERROR: for scripts_postgres_1  Cannot start service postgres: cgroups: cgroup mountpoint does not exist: unknown
ERROR: for postgres  Cannot start service postgres: cgroups: cgroup mountpoint does not exist: unknown
ERROR: Encountered errors while bringing up the project.   
```
- In my own local test database, I have two roles `postgres` and `postgres2`. I did roughly the following:
```js
const knex = require("knex")({
  client: 'pg',
  connection: {
    user: 'postgres',
    password: 'postgres',
    host: 'localhost',
    database: 'test',
  }
})

await knex.raw('SELECT "current_user"()') // returns "postgres"
await knex.destroy()

knex.initialize({
  client: 'pg',
  connection: {
    user: 'postgres2',
    password: 'postgres2',
    host: 'localhost',
    database: 'test',
  }
})
await knex.raw('SELECT "current_user"()') // returns "postgres2"
```
this proves that knex effectively used the second config.
- This is the first time I contribute to open source so please be kind :) 

