### PR TITLE
Insert lock row fix during migration

### DIFF
--- a/lib/migrations/migrate/Migrator.js
+++ b/lib/migrations/migrate/Migrator.js
@@ -328,7 +328,7 @@ class Migrator {
       .where('is_locked', '=', 0)
       .update({ is_locked: 1 })
       .then((rowCount) => {
-        if (rowCount != 1) {
+        if (rowCount !== 1) {
           throw new Error('Migration table is already locked');
         }
       });

--- a/lib/migrations/migrate/migration-list-resolver.js
+++ b/lib/migrations/migrate/migration-list-resolver.js
@@ -11,12 +11,10 @@ function listAll(migrationSource, loadExtensions) {
 async function listCompleted(tableName, schemaName, trxOrKnex) {
   await ensureTable(tableName, schemaName, trxOrKnex);
 
-  const completedMigrations = await trxOrKnex
+  return await trxOrKnex
     .from(getTableName(tableName, schemaName))
     .orderBy('id')
     .select('name');
-
-  return completedMigrations;
 }
 
 // Gets the migration list from the migration directory specified in config, as well as

--- a/lib/migrations/migrate/table-creator.js
+++ b/lib/migrations/migrate/table-creator.js
@@ -55,11 +55,12 @@ function _createMigrationLockTable(tableName, schemaName, trxOrKnex) {
 function _insertLockRowIfNeeded(tableName, schemaName, trxOrKnex) {
   const lockTableWithSchema = getLockTableNameWithSchema(tableName, schemaName);
   return trxOrKnex
-    .from(trxOrKnex.raw('?? (??)', [lockTableWithSchema, 'is_locked']))
-    .insert(function () {
-      return this.select(trxOrKnex.raw('?', [0])).whereNotExists(function () {
-        return this.select('*').from(lockTableWithSchema);
-      });
+    .select('*')
+    .from(lockTableWithSchema)
+    .then((data) => {
+      return !data.length
+        ? trxOrKnex.from(lockTableWithSchema).insert({ is_locked: 0 })
+        : null;
     });
 }
 

--- a/test/integration2/migrate/migration-integration.spec.js
+++ b/test/integration2/migrate/migration-integration.spec.js
@@ -25,6 +25,9 @@ const {
 } = require('../../util/db-helpers');
 const { assertNumber } = require('../../util/assertHelper');
 const { getAllDbs, getKnexForDb } = require('../util/knex-instance-provider');
+const {
+  ensureTable,
+} = require('../../../lib/migrations/migrate/table-creator');
 
 describe('Migrations', function () {
   getAllDbs().forEach((db) => {
@@ -1318,6 +1321,35 @@ describe('Migrations', function () {
               directory: 'test/integration2/migrate/test',
             });
           }
+        });
+      });
+
+      describe('Test lock row', async () => {
+        beforeEach(async () => {
+          await knex.schema.dropTableIfExists('test_lock');
+        });
+
+        it('should insert is_locked value to 1 if lock table not exists', async () => {
+          const result = await ensureTable('test', undefined, knex);
+
+          expect(result.rowCount).is.equal(1);
+          const data = await knex('test_lock').select('*');
+          expect(data[0]).to.have.property('is_locked');
+          expect(Number.parseInt(data[0].is_locked)).to.not.be.ok;
+        });
+
+        it('should is_locked value still be 1 if row already exists', async () => {
+          await knex.schema.createTable('test_lock', (t) => {
+            t.increments('index').primary();
+            t.integer('is_locked');
+          });
+          await knex('test_lock').insert({ is_locked: 1 });
+
+          const result = await ensureTable('test', undefined, knex);
+          expect(result).to.false;
+          const data = await knex('test_lock').select('*');
+          expect(data[0]).to.have.property('is_locked');
+          expect(Number.parseInt(data[0].is_locked)).to.be.ok;
         });
       });
     });

--- a/test/integration2/migrate/migration-integration.spec.js
+++ b/test/integration2/migrate/migration-integration.spec.js
@@ -1332,7 +1332,7 @@ describe('Migrations', function () {
         it('should insert is_locked value to 1 if lock table not exists', async () => {
           const result = await ensureTable('test', undefined, knex);
 
-          expect(result.rowCount).is.equal(1);
+          expect(!!(result || result.length)).is.true;
           const data = await knex('test_lock').select('*');
           expect(data[0]).to.have.property('is_locked');
           expect(Number.parseInt(data[0].is_locked)).to.not.be.ok;


### PR DESCRIPTION
- Problem : During migration, the _insertLockRowIfNeeded function try to make select statement without FROM clause. That works in some db but no in Oracle and MariaDB (you need to use DUAL).
- I rewrite the _insertLockRowIfNeeded  to make it works in any db (no database specific logic)
- Closes #4864 #4844 #4835