### PR TITLE
Set comment size warning limit to 1024 in MySQL

### DIFF
--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -42,9 +42,10 @@ class TableCompiler_MySQL extends TableCompiler {
 
     if (this.single.comment) {
       const comment = this.single.comment || '';
-      if (comment.length > 60)
+      const MAX_COMMENT_LENGTH = 1024;
+      if (comment.length > MAX_COMMENT_LENGTH)
         this.client.logger.warn(
-          'The max length for a table comment is 60 characters'
+          `The max length for a table comment is ${MAX_COMMENT_LENGTH} characters`
         );
       sql += ` comment = '${comment}'`;
     }

--- a/test/unit/schema-builder/mysql.js
+++ b/test/unit/schema-builder/mysql.js
@@ -1195,6 +1195,42 @@ module.exports = function (dialect) {
       }).to.throw(TypeError);
     });
 
+    it('set comment to old comment limit (size 60+) #4863', function () {
+      const warnMessages = [];
+      client.logger = {
+        warn: (msg) => {
+          warnMessages.push(msg);
+        },
+      };
+      client
+        .schemaBuilder()
+        .createTable('user', function (t) {
+          t.comment(
+            "A big comment. If we write more than 60 characters here it shouldn't trigger any warning since mysql and mariaDB maximum length is 1024 characters. Please fix this warning, it's annoying when a migration is taking place with multiple long comments."
+          );
+        })
+        .toSQL();
+      expect(warnMessages.length).to.equal(0);
+    });
+
+    it('set comment to current comment limit (size 1024+) #4863', function () {
+      const warnMessages = [];
+      client.logger = {
+        warn: (msg) => {
+          warnMessages.push(msg);
+        },
+      };
+      client
+        .schemaBuilder()
+        .createTable('users', function (t) {
+          t.comment('big comment'.repeat(100));
+        })
+        .toSQL();
+      expect(warnMessages[0]).to.equal(
+        'The max length for a table comment is 1024 characters'
+      );
+    });
+
     it('should alter columns with the alter flag', function () {
       tableSql = client
         .schemaBuilder()


### PR DESCRIPTION
- Set comment limit size from 60 to 1024.
- Closes #4863