### PR TITLE
Fix #4228 Improved columnInfo type

### DIFF
--- a/test-tsd/tables.test-d.ts
+++ b/test-tsd/tables.test-d.ts
@@ -66,6 +66,29 @@ const main = async () => {
     await knexInstance.first('id').from('users_composite')
   );
 
+  expectType<Record<keyof User, Knex.ColumnInfo>>(
+    await knexInstance<User>('users').columnInfo()
+  );
+  expectType<Record<string | number | symbol, Knex.ColumnInfo>>(
+    await knexInstance('users').columnInfo()
+  );
+  expectType<Record<keyof User, Knex.ColumnInfo>>(
+    await knexInstance('users_inferred').columnInfo()
+  );
+  expectType<Record<keyof User, Knex.ColumnInfo>>(
+    await knexInstance('users_composite').columnInfo()
+  );
+  expectType<Knex.ColumnInfo>(
+    await knexInstance('users_inferred').columnInfo('id')
+  );
+  expectType<Knex.ColumnInfo>(
+    await knexInstance('users_composite').columnInfo('id')
+  );
+  expectType<Knex.ColumnInfo>(await knexInstance('users').columnInfo('id'));
+  expectType<Knex.ColumnInfo>(
+    await knexInstance<User>('users').columnInfo('id')
+  );
+
   //These tests simply check if type work by showing that it does not throw syntax error
 
   knexInstance.schema.createTable('testTable',(table) => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1812,7 +1812,8 @@ export declare namespace Knex {
     and: QueryBuilder<TRecord, TResult>;
 
     // TODO: Promise?
-    columnInfo(column?: keyof TRecord): Promise<ColumnInfo>;
+    columnInfo(column: keyof DeferredKeySelection.Resolve<TRecord>): Promise<ColumnInfo>;
+    columnInfo(): Promise<Record<keyof DeferredKeySelection.Resolve<TRecord>, ColumnInfo>>;
 
     forUpdate(...tableNames: string[]): QueryBuilder<TRecord, TResult>;
     forUpdate(tableNames: readonly string[]): QueryBuilder<TRecord, TResult>;

--- a/types/test.ts
+++ b/types/test.ts
@@ -2691,16 +2691,16 @@ const main = async () => {
   // # Column Info:
 
   // $ExpectType ColumnInfo
-  await knexInstance('users').columnInfo();
+  await knexInstance('users').columnInfo('id');
 
   // $ExpectType ColumnInfo
-  await knexInstance<User>('users').columnInfo();
+  await knexInstance<User>('users').columnInfo('id');
 
   // $ExpectType ColumnInfo
-  await knexInstance('users_inferred').columnInfo();
+  await knexInstance('users_inferred').columnInfo('id');
 
   // $ExpectType ColumnInfo
-  await knexInstance('users_composite').columnInfo();
+  await knexInstance('users_composite').columnInfo('id');
 
   // # Modify:
 


### PR DESCRIPTION
This fixes the typing of `.columnInfo` as mentioned in #4228 
According to [docs](https://knexjs.org/#Builder-columnInfo) It should return either an object with `ColumnInfo` for all properties or  a single `ColumnInfo` if a `column` is provided

## What has be done?
* Added function overload typing with and without `column`
* Use `keyof Resolve<TRecord>` to resolve available keys if there are typings within the `Tables`
* Fixed `dtslint` type test and added new tests in `test-tsd`