### PR TITLE
Added support for MSSQL unique constraint

### DIFF
--- a/lib/dialects/mssql/schema/mssql-tablecompiler.js
+++ b/lib/dialects/mssql/schema/mssql-tablecompiler.js
@@ -279,14 +279,14 @@ class TableCompiler_MSSQL extends TableCompiler {
    * Create a unique index.
    *
    * @param {string | string[]} columns
-   * @param {string | {indexName: undefined | string, deferrable?: 'not deferrable'|'deferred'|'immediate', constraint?: true|false }} indexName
+   * @param {string | {indexName: undefined | string, deferrable?: 'not deferrable'|'deferred'|'immediate', useConstraint?: true|false }} indexName
    */
   unique(columns, indexName) {
     /** @type {string | undefined} */
     let deferrable;
-    let constraint = false;
+    let useConstraint = false;
     if (isObject(indexName)) {
-      ({ indexName, deferrable, constraint } = indexName);
+      ({ indexName, deferrable, useConstraint } = indexName);
     }
     if (deferrable && deferrable !== 'not deferrable') {
       this.client.logger.warn(
@@ -305,7 +305,7 @@ class TableCompiler_MSSQL extends TableCompiler {
       .map((column) => this.formatter.columnize(column) + ' IS NOT NULL')
       .join(' AND ');
 
-    if (constraint) {
+    if (useConstraint) {
       // mssql supports unique indexes and unique constraints.
       // unique indexes cannot be used with foreign key relationships hence unique constraints are used instead.
       this.pushQuery(

--- a/lib/dialects/mssql/schema/mssql-tablecompiler.js
+++ b/lib/dialects/mssql/schema/mssql-tablecompiler.js
@@ -279,13 +279,14 @@ class TableCompiler_MSSQL extends TableCompiler {
    * Create a unique index.
    *
    * @param {string | string[]} columns
-   * @param {string | {indexName: undefined | string, deferrable?: 'not deferrable'|'deferred'|'immediate' }} indexName
+   * @param {string | {indexName: undefined | string, deferrable?: 'not deferrable'|'deferred'|'immediate', constraint?: true|false }} indexName
    */
   unique(columns, indexName) {
     /** @type {string | undefined} */
     let deferrable;
+    let constraint = false;
     if (isObject(indexName)) {
-      ({ indexName, deferrable } = indexName);
+      ({ indexName, deferrable, constraint } = indexName);
     }
     if (deferrable && deferrable !== 'not deferrable') {
       this.client.logger.warn(
@@ -304,13 +305,23 @@ class TableCompiler_MSSQL extends TableCompiler {
       .map((column) => this.formatter.columnize(column) + ' IS NOT NULL')
       .join(' AND ');
 
-    // make unique constraint that allows null https://stackoverflow.com/a/767702/360060
-    // to be more or less compatible with other DBs (if any of the columns is NULL then "duplicates" are allowed)
-    this.pushQuery(
-      `CREATE UNIQUE INDEX ${indexName} ON ${this.tableName()} (${this.formatter.columnize(
-        columns
-      )}) WHERE ${whereAllTheColumnsAreNotNull}`
-    );
+    if (constraint) {
+      // mssql supports unique indexes and unique constraints.
+      // unique indexes cannot be used with foreign key relationships hence unique constraints are used instead.
+      this.pushQuery(
+        `ALTER TABLE ${this.tableName()} ADD CONSTRAINT ${indexName} UNIQUE (${this.formatter.columnize(
+          columns
+        )})`
+      );
+    } else {
+      // make unique constraint that allows null https://stackoverflow.com/a/767702/360060
+      // to be more or less compatible with other DBs (if any of the columns is NULL then "duplicates" are allowed)
+      this.pushQuery(
+        `CREATE UNIQUE INDEX ${indexName} ON ${this.tableName()} (${this.formatter.columnize(
+          columns
+        )}) WHERE ${whereAllTheColumnsAreNotNull}`
+      );
+    }
   }
 
   // Compile a drop index command.

--- a/test/integration2/dialects/mssql.spec.js
+++ b/test/integration2/dialects/mssql.spec.js
@@ -170,7 +170,7 @@ describe('MSSQL dialect', () => {
           });
         });
 
-        describe('unique table constraint with options object', () => {
+        describe('unique table index with options object', () => {
           const tableName = 'test_unique_index_options';
           before(async () => {
             await knex.schema.createTable(tableName, function () {
@@ -187,6 +187,38 @@ describe('MSSQL dialect', () => {
             const indexName = `AK_${tableName}_x_y`;
             await knex.schema.alterTable(tableName, function () {
               this.unique(['x', 'y'], { indexName });
+            });
+            expect(
+              knex
+                .insert([
+                  { x: 1, y: 1 },
+                  { x: 1, y: 1 },
+                ])
+                .into(tableName)
+            ).to.eventually.be.rejectedWith(new RegExp(indexName));
+          });
+        });
+
+        describe('unique table constraint with options object', () => {
+          const tableName = 'test_unique_constraint_options';
+          before(async () => {
+            await knex.schema.createTable(tableName, function () {
+              this.integer('x').notNull();
+              this.integer('y').notNull();
+            });
+          });
+
+          after(async () => {
+            await knex.schema.dropTable(tableName);
+          });
+
+          it('accepts indexName and constraint in options object', async () => {
+            const indexName = `UK_${tableName}_x_y`;
+            await knex.schema.alterTable(tableName, function () {
+              this.unique(['x', 'y'], {
+                indexName: indexName,
+                constraint: true,
+              });
             });
             expect(
               knex

--- a/test/integration2/dialects/mssql.spec.js
+++ b/test/integration2/dialects/mssql.spec.js
@@ -217,7 +217,7 @@ describe('MSSQL dialect', () => {
             await knex.schema.alterTable(tableName, function () {
               this.unique(['x', 'y'], {
                 indexName: indexName,
-                constraint: true,
+                useConstraint: true,
               });
             });
             await expect(

--- a/test/integration2/dialects/mssql.spec.js
+++ b/test/integration2/dialects/mssql.spec.js
@@ -188,7 +188,7 @@ describe('MSSQL dialect', () => {
             await knex.schema.alterTable(tableName, function () {
               this.unique(['x', 'y'], { indexName });
             });
-            expect(
+            await expect(
               knex
                 .insert([
                   { x: 1, y: 1 },
@@ -220,7 +220,7 @@ describe('MSSQL dialect', () => {
                 constraint: true,
               });
             });
-            expect(
+            await expect(
               knex
                 .insert([
                   { x: 1, y: 1 },

--- a/test/unit/schema-builder/mssql.js
+++ b/test/unit/schema-builder/mssql.js
@@ -570,6 +570,20 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
+  it('test adding unique constraint', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function () {
+        this.unique('foo', { indexName: 'bar', constraint: true });
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'ALTER TABLE [users] ADD CONSTRAINT [bar] UNIQUE ([foo])'
+    );
+  });
+
   it('test adding index', function () {
     tableSql = client
       .schemaBuilder()

--- a/test/unit/schema-builder/mssql.js
+++ b/test/unit/schema-builder/mssql.js
@@ -574,7 +574,7 @@ describe('MSSQL SchemaBuilder', function () {
     tableSql = client
       .schemaBuilder()
       .table('users', function () {
-        this.unique('foo', { indexName: 'bar', constraint: true });
+        this.unique('foo', { indexName: 'bar', useConstraint: true });
       })
       .toSQL();
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2075,7 +2075,7 @@ export declare namespace Knex {
     ): TableBuilder;
     setNullable(column: string): TableBuilder;
     dropNullable(column: string): TableBuilder;
-    unique(columnNames: readonly (string | Raw)[], options?: Readonly<{indexName?: string, storageEngineIndexType?: string, deferrable?: deferrableType}>): TableBuilder;
+    unique(columnNames: readonly (string | Raw)[], options?: Readonly<{indexName?: string, storageEngineIndexType?: string, deferrable?: deferrableType, constraint?: boolean}>): TableBuilder;
     /** @deprecated */
     unique(columnNames: readonly (string | Raw)[], indexName?: string): TableBuilder;
     foreign(column: string, foreignKeyName?: string): ForeignConstraintBuilder;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2075,7 +2075,7 @@ export declare namespace Knex {
     ): TableBuilder;
     setNullable(column: string): TableBuilder;
     dropNullable(column: string): TableBuilder;
-    unique(columnNames: readonly (string | Raw)[], options?: Readonly<{indexName?: string, storageEngineIndexType?: string, deferrable?: deferrableType, constraint?: boolean}>): TableBuilder;
+    unique(columnNames: readonly (string | Raw)[], options?: Readonly<{indexName?: string, storageEngineIndexType?: string, deferrable?: deferrableType, useConstraint?: boolean}>): TableBuilder;
     /** @deprecated */
     unique(columnNames: readonly (string | Raw)[], indexName?: string): TableBuilder;
     foreign(column: string, foreignKeyName?: string): ForeignConstraintBuilder;


### PR DESCRIPTION
MSSQL supports both unique indexes and unique constraints. One of the issues we found was unique index (current implementation) cannot be used with foreign key relationships. We must use unique constraints instead.

This is all based on issue #4825

I thought I'd give it a go and update the way MSSQL handles `table.unique`. This is my first PR here so please let me know if there's anything missing, which I'm sure there is.

I created a new test which seems to work fine 🤞 