### PR TITLE
Create multiple PKs with increments

### DIFF
--- a/lib/dialects/mssql/schema/mssql-columncompiler.js
+++ b/lib/dialects/mssql/schema/mssql-columncompiler.js
@@ -126,12 +126,22 @@ class ColumnCompiler_MSSQL extends ColumnCompiler {
     });
     return '';
   }
+
+  increments(options = { primaryKey: true }) {
+    return (
+      'int identity(1,1) not null' +
+      (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '')
+    );
+  }
+
+  bigincrements(options = { primaryKey: true }) {
+    return (
+      'bigint identity(1,1) not null' +
+      (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '')
+    );
+  }
 }
 
-ColumnCompiler_MSSQL.prototype.increments = ({ primaryKey = true } = {}) =>
-  'int identity(1,1) not null' + (primaryKey ? ' primary key' : '');
-ColumnCompiler_MSSQL.prototype.bigincrements = ({ primaryKey = true } = {}) =>
-  'bigint identity(1,1) not null' + (primaryKey ? ' primary key' : '');
 ColumnCompiler_MSSQL.prototype.bigint = 'bigint';
 ColumnCompiler_MSSQL.prototype.mediumint = 'int';
 ColumnCompiler_MSSQL.prototype.smallint = 'smallint';

--- a/lib/dialects/mysql/schema/mysql-columncompiler.js
+++ b/lib/dialects/mysql/schema/mysql-columncompiler.js
@@ -155,15 +155,23 @@ class ColumnCompiler_MySQL extends ColumnCompiler {
 
   increments(options = { primaryKey: true }) {
     return (
-      'int unsigned not null auto_increment' +
-      (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '')
+      'int unsigned not null' +
+      // In MySQL autoincrement are always a primary key. If you already have a primary key, we
+      // initialize this column as classic int column then modify it later in table compiler
+      (this.tableCompiler._canBeAddPrimaryKey(options)
+        ? ' auto_increment primary key'
+        : '')
     );
   }
 
   bigincrements(options = { primaryKey: true }) {
     return (
-      'bigint unsigned not null auto_increment' +
-      (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '')
+      'bigint unsigned not null' +
+      // In MySQL autoincrement are always a primary key. If you already have a primary key, we
+      // initialize this column as classic int column then modify it later in table compiler
+      (this.tableCompiler._canBeAddPrimaryKey(options)
+        ? ' auto_increment primary key'
+        : '')
     );
   }
 }

--- a/lib/dialects/mysql/schema/mysql-columncompiler.js
+++ b/lib/dialects/mysql/schema/mysql-columncompiler.js
@@ -152,13 +152,26 @@ class ColumnCompiler_MySQL extends ColumnCompiler {
   collate(collation) {
     return collation && `collate '${collation}'`;
   }
+
+  increments(options = { primaryKey: true }) {
+    return (
+      'int unsigned not null' +
+      (this.tableCompiler._canBeAddPrimaryKey(options)
+        ? 'auto_increment primary key'
+        : '')
+    );
+  }
+
+  bigincrements(options = { primaryKey: true }) {
+    return (
+      'bigint unsigned not null' +
+      (this.tableCompiler._canBeAddPrimaryKey(options)
+        ? 'auto_increment primary key'
+        : '')
+    );
+  }
 }
 
-ColumnCompiler_MySQL.prototype.increments = ({ primaryKey = true } = {}) =>
-  'int unsigned not null auto_increment' + (primaryKey ? ' primary key' : '');
-ColumnCompiler_MySQL.prototype.bigincrements = ({ primaryKey = true } = {}) =>
-  'bigint unsigned not null auto_increment' +
-  (primaryKey ? ' primary key' : '');
 ColumnCompiler_MySQL.prototype.bigint = 'bigint';
 ColumnCompiler_MySQL.prototype.mediumint = 'mediumint';
 ColumnCompiler_MySQL.prototype.smallint = 'smallint';

--- a/lib/dialects/mysql/schema/mysql-columncompiler.js
+++ b/lib/dialects/mysql/schema/mysql-columncompiler.js
@@ -155,19 +155,15 @@ class ColumnCompiler_MySQL extends ColumnCompiler {
 
   increments(options = { primaryKey: true }) {
     return (
-      'int unsigned not null' +
-      (this.tableCompiler._canBeAddPrimaryKey(options)
-        ? ' auto_increment primary key'
-        : '')
+      'int unsigned not null auto_increment' +
+      (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '')
     );
   }
 
   bigincrements(options = { primaryKey: true }) {
     return (
-      'bigint unsigned not null' +
-      (this.tableCompiler._canBeAddPrimaryKey(options)
-        ? ' auto_increment primary key'
-        : '')
+      'bigint unsigned not null auto_increment' +
+      (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '')
     );
   }
 }

--- a/lib/dialects/mysql/schema/mysql-columncompiler.js
+++ b/lib/dialects/mysql/schema/mysql-columncompiler.js
@@ -157,7 +157,7 @@ class ColumnCompiler_MySQL extends ColumnCompiler {
     return (
       'int unsigned not null' +
       (this.tableCompiler._canBeAddPrimaryKey(options)
-        ? 'auto_increment primary key'
+        ? ' auto_increment primary key'
         : '')
     );
   }
@@ -166,7 +166,7 @@ class ColumnCompiler_MySQL extends ColumnCompiler {
     return (
       'bigint unsigned not null' +
       (this.tableCompiler._canBeAddPrimaryKey(options)
-        ? 'auto_increment primary key'
+        ? ' auto_increment primary key'
         : '')
     );
   }

--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -253,11 +253,31 @@ class TableCompiler_MySQL extends TableCompiler {
     constraintName = constraintName
       ? this.formatter.wrap(constraintName)
       : this.formatter.wrap(`${this.tableNameRaw}_pkey`);
+
+    const primaryCols = columns;
+    let incrementsCols = [];
+    if (this.grouped.columns) {
+      incrementsCols = this._getIncrementsColumnNames();
+      if (incrementsCols) {
+        incrementsCols.forEach((c) => {
+          if (!primaryCols.includes(c)) {
+            primaryCols.unshift(c);
+          }
+        });
+      }
+    }
     this.pushQuery(
       `alter table ${this.tableName()} add primary key ${constraintName}(${this.formatter.columnize(
-        columns
+        primaryCols
       )})`
     );
+    if (incrementsCols.length) {
+      this.pushQuery(
+        `alter table ${this.tableName()} modify column ${this.formatter.columnize(
+          incrementsCols
+        )} int unsigned not null auto_increment`
+      );
+    }
   }
 
   unique(columns, indexName) {

--- a/lib/dialects/oracle/schema/internal/trigger.js
+++ b/lib/dialects/oracle/schema/internal/trigger.js
@@ -64,7 +64,7 @@ const trigger = {
       `PK_NAME VARCHAR(200); ` +
       `BEGIN` +
       `  EXECUTE IMMEDIATE ('CREATE SEQUENCE ${schemaQuoted}${sequenceNameQuoted}');` +
-      `  SELECT cols.column_name INTO PK_NAME` +
+      `  SELECT cols.column_name INTO PK_NAME` + // TODO : support autoincrement on table with multiple primary keys
       `  FROM all_constraints cons, all_cons_columns cols` +
       `  WHERE cons.constraint_type = 'P'` +
       `  AND cons.constraint_name = cols.constraint_name` +
@@ -83,7 +83,7 @@ const trigger = {
       `        where "' || PK_NAME || '" = :new."' || PK_NAME || '";` +
       `      end loop;` +
       `    end if;` +
-      `  end;'); ` +
+      `  end;');` +
       `END;`
     );
   },

--- a/lib/dialects/oracle/schema/internal/trigger.js
+++ b/lib/dialects/oracle/schema/internal/trigger.js
@@ -83,7 +83,7 @@ const trigger = {
       `        where "' || PK_NAME || '" = :new."' || PK_NAME || '";` +
       `      end loop;` +
       `    end if;` +
-      `  end;');` +
+      `  end;'); ` +
       `END;`
     );
   },

--- a/lib/dialects/oracle/schema/oracle-columncompiler.js
+++ b/lib/dialects/oracle/schema/oracle-columncompiler.js
@@ -15,14 +15,20 @@ class ColumnCompiler_Oracle extends ColumnCompiler {
     this.modifiers = ['defaultTo', 'checkIn', 'nullable', 'comment'];
   }
 
-  increments({ primaryKey = true } = {}) {
-    createAutoIncrementTriggerAndSequence(this);
-    return 'integer not null' + (primaryKey ? ' primary key' : '');
+  increments(options = { primaryKey: true }) {
+    const addPrimaryKey = this.tableCompiler._canBeAddPrimaryKey(options);
+    if (addPrimaryKey) {
+      createAutoIncrementTriggerAndSequence(this);
+    }
+    return 'integer not null' + (addPrimaryKey ? ' primary key' : '');
   }
 
-  bigincrements({ primaryKey = true } = {}) {
-    createAutoIncrementTriggerAndSequence(this);
-    return 'number(20, 0) not null' + (primaryKey ? ' primary key' : '');
+  bigincrements(options = { primaryKey: true }) {
+    const addPrimaryKey = this.tableCompiler._canBeAddPrimaryKey(options);
+    if (addPrimaryKey) {
+      createAutoIncrementTriggerAndSequence(this);
+    }
+    return 'number(20, 0) not null' + (addPrimaryKey ? ' primary key' : '');
   }
 
   floating(precision) {

--- a/lib/dialects/oracle/schema/oracle-columncompiler.js
+++ b/lib/dialects/oracle/schema/oracle-columncompiler.js
@@ -16,19 +16,19 @@ class ColumnCompiler_Oracle extends ColumnCompiler {
   }
 
   increments(options = { primaryKey: true }) {
-    const addPrimaryKey = this.tableCompiler._canBeAddPrimaryKey(options);
-    if (addPrimaryKey) {
-      createAutoIncrementTriggerAndSequence(this);
-    }
-    return 'integer not null' + (addPrimaryKey ? ' primary key' : '');
+    createAutoIncrementTriggerAndSequence(this);
+    return (
+      'integer not null' +
+      (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '')
+    );
   }
 
   bigincrements(options = { primaryKey: true }) {
-    const addPrimaryKey = this.tableCompiler._canBeAddPrimaryKey(options);
-    if (addPrimaryKey) {
-      createAutoIncrementTriggerAndSequence(this);
-    }
-    return 'number(20, 0) not null' + (addPrimaryKey ? ' primary key' : '');
+    createAutoIncrementTriggerAndSequence(this);
+    return (
+      'number(20, 0) not null' +
+      (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '')
+    );
   }
 
   floating(precision) {

--- a/lib/dialects/oracle/schema/oracle-tablecompiler.js
+++ b/lib/dialects/oracle/schema/oracle-tablecompiler.js
@@ -85,10 +85,6 @@ class TableCompiler_Oracle extends TableCompiler {
     );
   }
 
-  changeType() {
-    // alter table + table + ' modify ' + wrapped + '// type';
-  }
-
   _indexCommand(type, tableName, columns) {
     return this.formatter.wrap(
       utils.generateCombinedName(this.client.logger, type, tableName, columns)
@@ -104,11 +100,33 @@ class TableCompiler_Oracle extends TableCompiler {
     constraintName = constraintName
       ? this.formatter.wrap(constraintName)
       : this.formatter.wrap(`${this.tableNameRaw}_pkey`);
+    const primaryCols = columns;
+    let incrementsCols = [];
+    if (this.grouped.columns) {
+      incrementsCols = this._getIncrementsColumnNames();
+      if (incrementsCols) {
+        incrementsCols.forEach((c) => {
+          if (!primaryCols.includes(c)) {
+            primaryCols.unshift(c);
+          }
+        });
+      }
+    }
     this.pushQuery(
       `alter table ${this.tableName()} add constraint ${constraintName} primary key (${this.formatter.columnize(
-        columns
+        primaryCols
       )})${deferrable}`
     );
+    if (incrementsCols.length) {
+      const tableName = this.tableNameRaw;
+      const schemaName = this.schemaNameRaw;
+      const createTriggerSQL = Trigger.createAutoIncrementTrigger(
+        this.client.logger,
+        tableName,
+        schemaName
+      );
+      this.pushQuery(createTriggerSQL);
+    }
   }
 
   dropPrimary(constraintName) {

--- a/lib/dialects/oracle/schema/oracle-tablecompiler.js
+++ b/lib/dialects/oracle/schema/oracle-tablecompiler.js
@@ -117,16 +117,6 @@ class TableCompiler_Oracle extends TableCompiler {
         primaryCols
       )})${deferrable}`
     );
-    if (incrementsCols.length) {
-      const tableName = this.tableNameRaw;
-      const schemaName = this.schemaNameRaw;
-      const createTriggerSQL = Trigger.createAutoIncrementTrigger(
-        this.client.logger,
-        tableName,
-        schemaName
-      );
-      this.pushQuery(createTriggerSQL);
-    }
   }
 
   dropPrimary(constraintName) {

--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -100,12 +100,22 @@ class ColumnCompiler_PG extends ColumnCompiler {
       );
     }, comment);
   }
+
+  increments(options = { primaryKey: true }) {
+    return (
+      'serial' +
+      (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '')
+    );
+  }
+
+  bigincrements(options = { primaryKey: true }) {
+    return (
+      'bigserial' +
+      (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '')
+    );
+  }
 }
 
-ColumnCompiler_PG.prototype.bigincrements = ({ primaryKey = true } = {}) =>
-  'bigserial' + (primaryKey ? ' primary key' : '');
-ColumnCompiler_PG.prototype.increments = ({ primaryKey = true } = {}) =>
-  'serial' + (primaryKey ? ' primary key' : '');
 ColumnCompiler_PG.prototype.bigint = 'bigint';
 ColumnCompiler_PG.prototype.binary = 'bytea';
 ColumnCompiler_PG.prototype.bool = 'boolean';

--- a/lib/dialects/sqlite3/schema/sqlite-columncompiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-columncompiler.js
@@ -26,5 +26,9 @@ ColumnCompiler_SQLite3.prototype.double =
   ColumnCompiler_SQLite3.prototype.floating =
     'float';
 ColumnCompiler_SQLite3.prototype.timestamp = 'datetime';
+// autoincrement without primary key is a syntax error in SQLite, so it's necessary
+ColumnCompiler_SQLite3.prototype.increments =
+  ColumnCompiler_SQLite3.prototype.bigincrements =
+    'integer not null primary key autoincrement';
 
 module.exports = ColumnCompiler_SQLite3;

--- a/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
@@ -261,9 +261,14 @@ class TableCompiler_SQLite3 extends TableCompiler {
       if (constraintName) {
         constraintName = ' constraint ' + this.formatter.wrap(constraintName);
       }
-      return `,${constraintName} primary key (${this.formatter.columnize(
-        columns
-      )})`;
+      const needUniqueCols =
+        this.grouped.columns.filter((t) => t.builder._type === 'increments')
+          .length > 0;
+      // SQLite dont support autoincrement columns and composite primary keys (autoincrement is always primary key).
+      // You need to add unique index instead when you have autoincrement columns (https://stackoverflow.com/a/6154876/1535159)
+      return `,${constraintName} ${
+        needUniqueCols ? 'unique' : 'primary key'
+      } (${this.formatter.columnize(columns)})`;
     }
   }
 

--- a/lib/schema/columncompiler.js
+++ b/lib/schema/columncompiler.js
@@ -134,6 +134,18 @@ class ColumnCompiler {
   defaultTo(value) {
     return `default ${formatDefault(value, this.type, this.client)}`;
   }
+
+  increments(options = { primaryKey: true }) {
+    return (
+      'integer not null' +
+      (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '') +
+      ' autoincrement'
+    );
+  }
+
+  bigincrements(options = { primaryKey: true }) {
+    return this.increments(options);
+  }
 }
 
 ColumnCompiler.prototype.binary = 'blob';
@@ -149,10 +161,6 @@ ColumnCompiler.prototype.enu = 'varchar';
 ColumnCompiler.prototype.bit = ColumnCompiler.prototype.json = 'text';
 ColumnCompiler.prototype.uuid = ({ useBinaryUuid = false } = {}) =>
   useBinaryUuid ? 'binary(16)' : 'char(36)';
-ColumnCompiler.prototype.increments = ({ primaryKey = true } = {}) =>
-  'integer not null' + (primaryKey ? ' primary key' : '') + ' autoincrement';
-ColumnCompiler.prototype.bigincrements = ({ primaryKey = true } = {}) =>
-  'integer not null' + (primaryKey ? ' primary key' : '') + ' autoincrement';
 ColumnCompiler.prototype.integer =
   ColumnCompiler.prototype.smallint =
   ColumnCompiler.prototype.mediumint =

--- a/lib/schema/tablecompiler.js
+++ b/lib/schema/tablecompiler.js
@@ -363,7 +363,7 @@ class TableCompiler {
   }
 
   _getPrimaryKeys() {
-    return this.grouped.alterTable
+    return (this.grouped.alterTable || [])
       .filter((a) => a.method === 'primary')
       .flatMap((a) => a.args)
       .flat();

--- a/lib/schema/tablecompiler.js
+++ b/lib/schema/tablecompiler.js
@@ -361,6 +361,23 @@ class TableCompiler {
     ).toLowerCase();
     return this.formatter.wrap(indexName);
   }
+
+  _getPrimaryKeys() {
+    return this.grouped.alterTable
+      .filter((a) => a.method === 'primary')
+      .flatMap((a) => a.args)
+      .flat();
+  }
+
+  _canBeAddPrimaryKey(options) {
+    return options.primaryKey && this._getPrimaryKeys().length === 0;
+  }
+
+  _getIncrementsColumnNames() {
+    return this.grouped.columns
+      .filter((c) => c.builder._type === 'increments')
+      .map((c) => c.builder._args[0]);
+  }
 }
 
 TableCompiler.prototype.pushQuery = pushQuery;

--- a/test/integration2/schema/primary-keys.spec.js
+++ b/test/integration2/schema/primary-keys.spec.js
@@ -7,7 +7,6 @@ const {
   isBetterSQLite3,
 } = require('../../util/db-helpers');
 const { getAllDbs, getKnexForDb } = require('../util/knex-instance-provider');
-const { assertNumber } = require('../../util/assertHelper');
 
 describe('Schema', () => {
   describe('Primary keys', () => {

--- a/test/unit/schema-builder/mysql.js
+++ b/test/unit/schema-builder/mysql.js
@@ -68,13 +68,14 @@ module.exports = function (dialect) {
         .schemaBuilder()
         .createTable('users', function (table) {
           table.increments('id');
+          // In MySQL a autoincrement column is always a primary key
           table.increments('other_id', { primaryKey: false });
         })
         .toSQL();
 
       equal(1, tableSql.length);
       expect(tableSql[0].sql).to.equal(
-        'create table `users` (`id` int unsigned not null auto_increment primary key, `other_id` int unsigned not null auto_increment)'
+        'create table `users` (`id` int unsigned not null auto_increment primary key, `other_id` int unsigned not null)'
       );
     });
 
@@ -665,13 +666,14 @@ module.exports = function (dialect) {
       tableSql = client
         .schemaBuilder()
         .table('users', function () {
+          // In MySQL a autoincrement column is always a primary key
           this.bigIncrements('id', { primaryKey: false });
         })
         .toSQL();
 
       equal(1, tableSql.length);
       expect(tableSql[0].sql).to.equal(
-        'alter table `users` add `id` bigint unsigned not null auto_increment'
+        'alter table `users` add `id` bigint unsigned not null'
       );
     });
 

--- a/test/unit/schema-builder/oracle.js
+++ b/test/unit/schema-builder/oracle.js
@@ -76,7 +76,7 @@ describe('Oracle SchemaBuilder', function () {
         table.increments('id', { primaryKey: false });
       });
 
-    equal(2, tableSql.toSQL().length);
+    expect(tableSql.toSQL().length).to.equal(2);
     expect(tableSql.toSQL()[0].sql).to.equal(
       'begin execute immediate \'create table "users" ("id" integer not null)\'; exception when others then if sqlcode != -955 then raise; end if; end;'
     );

--- a/test/unit/schema-builder/sqlite3.js
+++ b/test/unit/schema-builder/sqlite3.js
@@ -19,7 +19,6 @@ const {
 const _ = require('lodash');
 const { equal, deepEqual } = require('assert');
 const knex = require('../../../knex');
-const { isSQLite } = require('../../util/db-helpers');
 
 describe('SQLite SchemaBuilder', function () {
   it('basic create table', function () {

--- a/test/unit/schema-builder/sqlite3.js
+++ b/test/unit/schema-builder/sqlite3.js
@@ -19,6 +19,7 @@ const {
 const _ = require('lodash');
 const { equal, deepEqual } = require('assert');
 const knex = require('../../../knex');
+const { isSQLite } = require('../../util/db-helpers');
 
 describe('SQLite SchemaBuilder', function () {
   it('basic create table', function () {
@@ -214,15 +215,15 @@ describe('SQLite SchemaBuilder', function () {
     tableSql = client
       .schemaBuilder()
       .createTable('users', function (table) {
-        table.increments('id');
-        table.increments('other_id', { primaryKey: false });
+        // This make nothing in SQLite, autoincrement without primary key is a syntax error.
+        table.increments('id', { primaryKey: false });
       })
       .toSQL();
 
     equal(1, tableSql.length);
     equal(
       tableSql[0].sql,
-      'create table `users` (`id` integer not null primary key autoincrement, `other_id` integer not null autoincrement)'
+      'create table `users` (`id` integer not null primary key autoincrement)'
     );
   });
 
@@ -563,6 +564,7 @@ describe('SQLite SchemaBuilder', function () {
     tableSql = client
       .schemaBuilder()
       .table('users', function (table) {
+        // This make nothing in SQLite, autoincrement without primary key is a syntax error.
         table.bigIncrements('id', { primaryKey: false });
       })
       .toSQL();
@@ -570,7 +572,7 @@ describe('SQLite SchemaBuilder', function () {
     equal(1, tableSql.length);
     equal(
       tableSql[0].sql,
-      'alter table `users` add column `id` integer not null autoincrement'
+      'alter table `users` add column `id` integer not null primary key autoincrement'
     );
   });
 


### PR DESCRIPTION
- Resolve the case when a increments column is created in same time that primary keys. Now you can specify a increments columns with or without primary keys: 
   * If a primary key is specified, the increment column is added to composite key,
   * If a primary key is not specified, the increment column is set to primary key.

This two cases works :

```js
knex.schema.createTable('table_multiple_keys', function (t) {
  t.primary(['id', 'second_id', 'other_col']);
  t.increments('id');

  t.string('second_id', 16).notNullable();
  t.integer('other_col').notNullable();
});
```

```js
knex.schema.createTable('table_multiple_keys', function (t) {
  t.primary(['second_id', 'other_col']);
  t.increments('id');

  t.string('second_id', 16).notNullable();
  t.integer('other_col').notNullable();
});
```
- Solve tricky cases : 
     * SQLite : it's not possible to specify autoincrement with composite key, autoincrement need to be primary key. I solve it by transform primary keys in unique index if autoincrement with primary keys is specified.
     * MYSQL don't support autoincrement without primary keys so it's not possible to add autoincrement column without primary key and alter table to add primary key in second query. I solve it by add classic int column, add composite primary key and transform the column to autoincrement.

- Closes https://github.com/knex/knex/issues/385