### PR TITLE
Enable wrapIdentifier for SQLite .hasTable

### DIFF
--- a/lib/dialects/sqlite3/schema/sqlite-compiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-compiler.js
@@ -17,7 +17,7 @@ class SchemaCompiler_SQLite3 extends SchemaCompiler {
     const sql =
       `select * from sqlite_master ` +
       `where type = 'table' and name = ${this.client.parameter(
-        tableName,
+        this.formatter.wrap(tableName).replace(/`/g, ''),
         this.builder,
         this.bindingsHolder
       )}`;

--- a/lib/execution/internal/query-executioner.js
+++ b/lib/execution/internal/query-executioner.js
@@ -14,9 +14,6 @@ function formatQuery(sql, bindings, timeZone, client) {
       return match;
     }
     const value = bindings[index++];
-    if (client.config.wrapIdentifier) {
-      return client.wrapIdentifier(value);
-    }
     return client._escapeBinding(value, { timeZone });
   });
 }

--- a/lib/execution/internal/query-executioner.js
+++ b/lib/execution/internal/query-executioner.js
@@ -14,6 +14,9 @@ function formatQuery(sql, bindings, timeZone, client) {
       return match;
     }
     const value = bindings[index++];
+    if (client.config.wrapIdentifier) {
+      return client.wrapIdentifier(value);
+    }
     return client._escapeBinding(value, { timeZone });
   });
 }

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -1577,6 +1577,12 @@ describe('Schema (misc)', () => {
             expect(resp).to.equal(false);
           }));
 
+        it('should not parse table name if wrapIdentifier is not specified', () => {
+          knex.schema.hasTable('testTableTwo').then((resp) => {
+            expect(resp).to.equal(false);
+          });
+        });
+
         it('should parse table name if wrapIdentifier is specified', () => {
           knex.client.config.wrapIdentifier = (value, origImpl, queryContext) =>
             origImpl(_.snakeCase(value));

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -1578,18 +1578,22 @@ describe('Schema (misc)', () => {
           }));
 
         describe('sqlite only', () => {
-          if (!isSQLite(knex)) {
-            return Promise.resolve();
-          }
+          it('should not parse table name if wrapIdentifier is not specified', async function () {
+            if (!isSQLite(knex)) {
+              return this.skip();
+            }
 
-          it('should not parse table name if wrapIdentifier is not specified', async () => {
             knex.client.config.wrapIdentifier = null;
 
             const resp = await knex.schema.hasTable('testTableTwo');
-            expect(resp).to.equal(false);
+            expect(resp).to.equal(true);
           });
 
-          it('should parse table name if wrapIdentifier is specified', async () => {
+          it('should parse table name if wrapIdentifier is specified', async function () {
+            if (!isSQLite(knex)) {
+              return this.skip();
+            }
+
             knex.client.config.wrapIdentifier = (
               value,
               origImpl,
@@ -1597,7 +1601,7 @@ describe('Schema (misc)', () => {
             ) => origImpl(_.snakeCase(value));
 
             const resp = await knex.schema.hasTable('testTableTwo');
-            expect(resp).to.equal(true);
+            expect(resp).to.equal(false);
           });
         });
       });

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -1586,7 +1586,7 @@ describe('Schema (misc)', () => {
             knex.client.config.wrapIdentifier = null;
 
             const resp = await knex.schema.hasTable('testTableTwo');
-            expect(resp).to.equal(true);
+            expect(resp).to.be.false;
           });
 
           it('should parse table name if wrapIdentifier is specified', async function () {
@@ -1601,7 +1601,7 @@ describe('Schema (misc)', () => {
             ) => origImpl(_.snakeCase(value));
 
             const resp = await knex.schema.hasTable('testTableTwo');
-            expect(resp).to.equal(false);
+            expect(resp).to.be.true;
           });
         });
       });

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -1576,6 +1576,15 @@ describe('Schema (misc)', () => {
           knex.schema.hasTable('').then((resp) => {
             expect(resp).to.equal(false);
           }));
+
+        it('should parse table name if wrapIdentifier is specified', () => {
+          knex.client.config.wrapIdentifier = (value, origImpl, queryContext) =>
+            origImpl(_.snakeCase(value));
+
+          knex.schema.hasTable('testTableTwo').then((resp) => {
+            expect(resp).to.equal(true);
+          });
+        });
       });
 
       describe('renameTable', () => {

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -1578,6 +1578,8 @@ describe('Schema (misc)', () => {
           }));
 
         it('should not parse table name if wrapIdentifier is not specified', () => {
+          knex.client.config.wrapIdentifier = null;
+
           knex.schema.hasTable('testTableTwo').then((resp) => {
             expect(resp).to.equal(false);
           });

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -1577,19 +1577,28 @@ describe('Schema (misc)', () => {
             expect(resp).to.equal(false);
           }));
 
-        it('should not parse table name if wrapIdentifier is not specified', async () => {
-          knex.client.config.wrapIdentifier = null;
+        describe('sqlite only', () => {
+          if (!isSQLite(knex)) {
+            return Promise.resolve();
+          }
 
-          const resp = await knex.schema.hasTable('testTableTwo');
-          expect(resp).to.equal(false);
-        });
+          it('should not parse table name if wrapIdentifier is not specified', async () => {
+            knex.client.config.wrapIdentifier = null;
 
-        it('should parse table name if wrapIdentifier is specified', async () => {
-          knex.client.config.wrapIdentifier = (value, origImpl, queryContext) =>
-            origImpl(_.snakeCase(value));
+            const resp = await knex.schema.hasTable('testTableTwo');
+            expect(resp).to.equal(false);
+          });
 
-          const resp = await knex.schema.hasTable('testTableTwo');
-          expect(resp).to.equal(true);
+          it('should parse table name if wrapIdentifier is specified', async () => {
+            knex.client.config.wrapIdentifier = (
+              value,
+              origImpl,
+              queryContext
+            ) => origImpl(_.snakeCase(value));
+
+            const resp = await knex.schema.hasTable('testTableTwo');
+            expect(resp).to.equal(true);
+          });
         });
       });
 

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -1577,21 +1577,19 @@ describe('Schema (misc)', () => {
             expect(resp).to.equal(false);
           }));
 
-        it('should not parse table name if wrapIdentifier is not specified', () => {
+        it('should not parse table name if wrapIdentifier is not specified', async () => {
           knex.client.config.wrapIdentifier = null;
 
-          knex.schema.hasTable('testTableTwo').then((resp) => {
-            expect(resp).to.equal(false);
-          });
+          const resp = await knex.schema.hasTable('testTableTwo');
+          expect(resp).to.equal(false);
         });
 
-        it('should parse table name if wrapIdentifier is specified', () => {
+        it('should parse table name if wrapIdentifier is specified', async () => {
           knex.client.config.wrapIdentifier = (value, origImpl, queryContext) =>
             origImpl(_.snakeCase(value));
 
-          knex.schema.hasTable('testTableTwo').then((resp) => {
-            expect(resp).to.equal(true);
-          });
+          const resp = await knex.schema.hasTable('testTableTwo');
+          expect(resp).to.equal(true);
         });
       });
 


### PR DESCRIPTION
Currently, the `wrapIdentifier` option does not apply for SQLite `db.schema.hasTable`.

For example, even if we set `wrapIdentifier` to parse identifiers to snake case, we'd get the following:

```js
db.schema.hasTable('infoBoxes').toString()
> select * from sqlite_master where type = 'table' and name = 'infoBoxes'
```

This PR fixes this by enabling the wrap for SQLite Compiler:

```js
db.schema.hasTable('infoBoxes').toString()
> select * from sqlite_master where type = 'table' and name = 'info_boxes'
```

Fix #4898 