### PR TITLE
Fix executing sqlite ddl comands when the table name is a substring of "CREATE TABLE"

### DIFF
--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -7,7 +7,6 @@
 const identity = require('lodash/identity');
 const { nanonum } = require('../../../util/nanoid');
 const {
-  createNewTable,
   copyData,
   dropOriginal,
   renameTable,
@@ -88,14 +87,11 @@ class SQLite3_DDL {
     return trx.raw(copyData(this.tableName(), this.alteredName, columns));
   }
 
-  createNewTable(trx, sql) {
-    return trx.raw(createNewTable(sql, this.tableName(), this.alteredName));
-  }
-
   async alterColumn(columns) {
     const { createTable, createIndices } = await this.getTableSql();
 
     const parsedTable = parseCreateTable(createTable);
+    parsedTable.table = this.alteredName;
 
     parsedTable.columns = parsedTable.columns.map((column) => {
       const newColumnInfo = columns.find((c) => isEqualId(c.name, column.name));
@@ -133,6 +129,7 @@ class SQLite3_DDL {
     const { createTable, createIndices } = await this.getTableSql();
 
     const parsedTable = parseCreateTable(createTable);
+    parsedTable.table = this.alteredName;
 
     parsedTable.columns = parsedTable.columns.filter(
       (parsedColumn) =>
@@ -190,6 +187,7 @@ class SQLite3_DDL {
     const { createTable, createIndices } = await this.getTableSql();
 
     const parsedTable = parseCreateTable(createTable);
+    parsedTable.table = this.alteredName;
 
     if (!foreignKeyName) {
       parsedTable.columns = parsedTable.columns.map((column) => ({
@@ -223,6 +221,7 @@ class SQLite3_DDL {
     const { createTable, createIndices } = await this.getTableSql();
 
     const parsedTable = parseCreateTable(createTable);
+    parsedTable.table = this.alteredName;
 
     parsedTable.columns = parsedTable.columns.map((column) => ({
       ...column,
@@ -252,6 +251,7 @@ class SQLite3_DDL {
     const { createTable, createIndices } = await this.getTableSql();
 
     const parsedTable = parseCreateTable(createTable);
+    parsedTable.table = this.alteredName;
 
     parsedTable.columns = parsedTable.columns.map((column) => ({
       ...column,
@@ -283,6 +283,7 @@ class SQLite3_DDL {
     const { createTable, createIndices } = await this.getTableSql();
 
     const parsedTable = parseCreateTable(createTable);
+    parsedTable.table = this.alteredName;
 
     parsedTable.constraints.push({
       type: 'FOREIGN KEY',
@@ -307,6 +308,8 @@ class SQLite3_DDL {
     const { createTable, createIndices } = await this.getTableSql();
 
     const parsedTable = parseCreateTable(createTable);
+    parsedTable.table = this.alteredName;
+
     const parsedColumn = parsedTable.columns.find((c) =>
       isEqualId(column, c.name)
     );
@@ -340,7 +343,7 @@ class SQLite3_DDL {
     try {
       await this.client.transaction(
         async (trx) => {
-          await this.createNewTable(trx, newSql);
+          await trx.raw(newSql);
           await this.copyData(trx, columns);
           await this.dropOriginal(trx);
           await this.renameTable(trx);
@@ -372,7 +375,7 @@ class SQLite3_DDL {
     const post = [];
     let check = null;
 
-    sql.push(createNewTable(newSql, this.tableName(), this.alteredName));
+    sql.push(newSql);
     sql.push(copyData(this.tableName(), this.alteredName, columns));
     sql.push(dropOriginal(this.tableName()));
     sql.push(renameTable(this.alteredName, this.tableName()));

--- a/lib/dialects/sqlite3/schema/internal/sqlite-ddl-operations.js
+++ b/lib/dialects/sqlite3/schema/internal/sqlite-ddl-operations.js
@@ -1,21 +1,17 @@
-function createNewTable(sql, tablename, alteredName) {
-  return sql.replace(tablename, alteredName);
-}
-
 function copyData(sourceTable, targetTable, columns) {
-  return `INSERT INTO ${targetTable} SELECT ${
+  return `INSERT INTO "${targetTable}" SELECT ${
     columns === undefined
       ? '*'
       : columns.map((column) => `"${column}"`).join(', ')
-  } FROM ${sourceTable};`;
+  } FROM "${sourceTable}";`;
 }
 
 function dropOriginal(tableName) {
-  return `DROP TABLE '${tableName}'`;
+  return `DROP TABLE "${tableName}"`;
 }
 
 function renameTable(tableName, alteredName) {
-  return `ALTER TABLE '${tableName}' RENAME TO '${alteredName}'`;
+  return `ALTER TABLE "${tableName}" RENAME TO "${alteredName}"`;
 }
 
 function getTableSql(tableName) {
@@ -35,7 +31,6 @@ function executeForeignCheck() {
 }
 
 module.exports = {
-  createNewTable,
   copyData,
   dropOriginal,
   renameTable,

--- a/test/integration2/schema/alter.spec.js
+++ b/test/integration2/schema/alter.spec.js
@@ -179,9 +179,9 @@ describe('Schema', () => {
 
               expect(queries.sql).to.deep.equal([
                 "CREATE TABLE `_knex_temp_alter111` (`column_integer` varchar(255), `column_string` varchar(255), `column_datetime` datetime, `column_defaultTo` integer DEFAULT '0', `column_notNullable` varchar(255) NOT NULL, `column_defaultToAndNotNullable` datetime NOT NULL DEFAULT '0', `column_nullable` boolean NULL)",
-                'INSERT INTO _knex_temp_alter111 SELECT * FROM alter_table;',
-                "DROP TABLE 'alter_table'",
-                "ALTER TABLE '_knex_temp_alter111' RENAME TO 'alter_table'",
+                'INSERT INTO "_knex_temp_alter111" SELECT * FROM "alter_table";',
+                'DROP TABLE "alter_table"',
+                'ALTER TABLE "_knex_temp_alter111" RENAME TO "alter_table"',
               ]);
             });
           });

--- a/test/integration2/schema/foreign-keys.spec.js
+++ b/test/integration2/schema/foreign-keys.spec.js
@@ -76,9 +76,9 @@ describe('Schema', () => {
             if (isSQLite(knex)) {
               expect(queries.sql).to.eql([
                 'CREATE TABLE `_knex_temp_alter111` (`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `fkey_two` integer NOT NULL, `fkey_three` integer NOT NULL, CONSTRAINT `fk_fkey_threeee` FOREIGN KEY (`fkey_three`) REFERENCES `foreign_keys_table_three` (`id`))',
-                'INSERT INTO _knex_temp_alter111 SELECT * FROM foreign_keys_table_one;',
-                "DROP TABLE 'foreign_keys_table_one'",
-                "ALTER TABLE '_knex_temp_alter111' RENAME TO 'foreign_keys_table_one'",
+                'INSERT INTO "_knex_temp_alter111" SELECT * FROM "foreign_keys_table_one";',
+                'DROP TABLE "foreign_keys_table_one"',
+                'ALTER TABLE "_knex_temp_alter111" RENAME TO "foreign_keys_table_one"',
               ]);
             }
 
@@ -112,9 +112,9 @@ describe('Schema', () => {
 
             expect(queries.sql).to.eql([
               'CREATE TABLE `_knex_temp_alter111` (`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `fkey_two` integer NOT NULL, `fkey_three` integer NOT NULL, CONSTRAINT `fk_fkey_threeee` FOREIGN KEY (`fkey_three`) REFERENCES `foreign_keys_table_three` (`id`) ON DELETE CASCADE)',
-              'INSERT INTO _knex_temp_alter111 SELECT * FROM foreign_keys_table_one;',
-              "DROP TABLE 'foreign_keys_table_one'",
-              "ALTER TABLE '_knex_temp_alter111' RENAME TO 'foreign_keys_table_one'",
+              'INSERT INTO "_knex_temp_alter111" SELECT * FROM "foreign_keys_table_one";',
+              'DROP TABLE "foreign_keys_table_one"',
+              'ALTER TABLE "_knex_temp_alter111" RENAME TO "foreign_keys_table_one"',
             ]);
           });
 
@@ -138,9 +138,9 @@ describe('Schema', () => {
 
             expect(queries.sql).to.eql([
               'CREATE TABLE `_knex_temp_alter111` (`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `fkey_two` integer NOT NULL, `fkey_three` integer NOT NULL, CONSTRAINT `fk_fkey_threeee` FOREIGN KEY (`fkey_three`) REFERENCES `foreign_keys_table_three` (`id`) ON UPDATE CASCADE)',
-              'INSERT INTO _knex_temp_alter111 SELECT * FROM foreign_keys_table_one;',
-              "DROP TABLE 'foreign_keys_table_one'",
-              "ALTER TABLE '_knex_temp_alter111' RENAME TO 'foreign_keys_table_one'",
+              'INSERT INTO "_knex_temp_alter111" SELECT * FROM "foreign_keys_table_one";',
+              'DROP TABLE "foreign_keys_table_one"',
+              'ALTER TABLE "_knex_temp_alter111" RENAME TO "foreign_keys_table_one"',
             ]);
           });
 

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -2183,6 +2183,42 @@ describe('Schema (misc)', () => {
               }));
         });
       });
+
+      describe('sqlite ddl', () => {
+        before(async () => {
+          if (!isSQLite(knex)) {
+            return;
+          }
+
+          await knex.schema.createTable('CREATE TABLE', (table) => {
+            table.primary();
+            table.integer('alter_column');
+          });
+
+          await knex('CREATE TABLE').insert({ alter_column: 1 });
+        });
+
+        after(async () => {
+          if (!isSQLite(knex)) {
+            return;
+          }
+
+          await knex.schema.dropTable('CREATE TABLE');
+        });
+
+        it('properly executes any ddl command when the table name is a substring of "CREATE TABLE"', async () => {
+          if (!isSQLite(knex)) {
+            return;
+          }
+
+          await expect(
+            knex.schema.alterTable('CREATE TABLE', (table) => {
+              table.string('alter_column').alter();
+            })
+          ).to.not.be.eventually.rejected;
+        });
+      });
+
       it('supports named primary keys', async () => {
         const constraintName = 'pk-test';
         const tableName = 'namedpk';

--- a/test/integration2/schema/set-nullable.spec.js
+++ b/test/integration2/schema/set-nullable.spec.js
@@ -48,9 +48,9 @@ describe('Schema', () => {
             if (isSQLite(knex)) {
               expect(queries.sql).to.eql([
                 'CREATE TABLE `_knex_temp_alter111` (`id_nullable` integer NULL, `id_not_nullable` integer)',
-                'INSERT INTO _knex_temp_alter111 SELECT * FROM primary_table;',
-                "DROP TABLE 'primary_table'",
-                "ALTER TABLE '_knex_temp_alter111' RENAME TO 'primary_table'",
+                'INSERT INTO "_knex_temp_alter111" SELECT * FROM "primary_table";',
+                'DROP TABLE "primary_table"',
+                'ALTER TABLE "_knex_temp_alter111" RENAME TO "primary_table"',
               ]);
             }
 


### PR DESCRIPTION
This bug was reported at directus/directus#10878.