### PR TITLE
remove outdated warning message

### DIFF
--- a/lib/dialects/sqlite3/query/sqlite-querycompiler.js
+++ b/lib/dialects/sqlite3/query/sqlite-querycompiler.js
@@ -22,12 +22,6 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
 
     const { returning } = this.single;
 
-    if (returning) {
-      this.client.logger.warn(
-        '.returning() is not supported by sqlite3 and will not have any effect.'
-      );
-    }
-
     // The locks are not applicable in SQLite3
     this.forShare = emptyStr;
     this.forKeyShare = emptyStr;

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -9985,40 +9985,6 @@ describe('QueryBuilder', () => {
     }).to.throw(Error);
   });
 
-  it('should warn to user when use `.returning()` function in SQLite3', () => {
-    const loggerConfigForTestingWarnings = {
-      log: {
-        warn: (message) => {
-          if (
-            message ===
-            '.returning() is not supported by sqlite3 and will not have any effect.'
-          ) {
-            throw new Error(message);
-          }
-        },
-      },
-    };
-
-    const sqlite3ClientForWarnings = new SQLite3_Client(
-      Object.assign({ client: 'sqlite3' }, loggerConfigForTestingWarnings)
-    );
-
-    expect(() => {
-      testsql(
-        qb().into('users').insert({ email: 'foo' }).returning('id'),
-        {
-          sqlite3: {
-            sql: 'insert into `users` (`email`) values (?)',
-            bindings: ['foo'],
-          },
-        },
-        {
-          sqlite3: sqlite3ClientForWarnings,
-        }
-      );
-    }).to.throw(Error);
-  });
-
   it('join with subquery using .withSchema', () => {
     testsql(
       qb()


### PR DESCRIPTION
Returning is supported by sqlite3 in the current version.

Reference: https://sqlite.org/lang_returning.html
Discussion: https://stackoverflow.com/a/67644622/3156509