### PR TITLE
Fix error message for missing migration files

### DIFF
--- a/lib/migrations/migrate/Migrator.js
+++ b/lib/migrations/migrate/Migrator.js
@@ -562,8 +562,9 @@ function validateMigrationList(migrationSource, migrations) {
   const [all, completed] = migrations;
   const diff = getMissingMigrations(migrationSource, completed, all);
   if (!isEmpty(diff)) {
+    const names = diff.map((d) => d.name);
     throw new Error(
-      `The migration directory is corrupt, the following files are missing: ${diff.join(
+      `The migration directory is corrupt, the following files are missing: ${names.join(
         ', '
       )}`
     );


### PR DESCRIPTION
This was caused by this change 1.0

> Changed Migrator to return list of migrations as objects consistently.

I'm not sure how / if I should add tests for this. Let me know if you'd like them :)

This fixes the following error:

```
$ (createdb luma-test &> /dev/null || true) && knex migrate:latest --env test && node -r esbuild-register ./node_modules/knex/bin/cli.js seed:run --env test --specific=seed_db.ts && NODE_ENV=test jest --runInBand
Using environment: test
The migration directory is corrupt, the following files are missing: [object Object]
Error: The migration directory is corrupt, the following files are missing: [object Object]
    at validateMigrationList (/Users/victor/Code/luma/node_modules/.pnpm/knex@1.0.1_pg@8.7.1/node_modules/knex/lib/migrations/migrate/Migrator.js:566:11)
    at Migrator.latest (/Users/victor/Code/luma/node_modules/.pnpm/knex@1.0.1_pg@8.7.1/node_modules/knex/lib/migrations/migrate/Migrator.js:69:7)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Command.<anonymous> (/Users/victor/Code/luma/node_modules/.pnpm/knex@1.0.1_pg@8.7.1/node_modules/knex/bin/cli.js:232:32)
```