### PR TITLE
WhereILike - Fix typo in types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -546,7 +546,7 @@ export declare namespace Knex {
     whereNotIn: WhereIn<TRecord, TResult>;
     orWhereNotIn: WhereIn<TRecord, TResult>;
     whereLike: Where<TRecord, TResult>;
-    whereIlike: Where<TRecord, TResult>;
+    whereILike: Where<TRecord, TResult>;
     whereNull: WhereNull<TRecord, TResult>;
     orWhereNull: WhereNull<TRecord, TResult>;
     whereNotNull: WhereNull<TRecord, TResult>;


### PR DESCRIPTION
Fixing typo:  `whereIlike` to `whereILike` in types.
Changes introduced in https://github.com/knex/knex/pull/4779