### PR TITLE
materialized CTE support for Postgres

### DIFF
--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -124,6 +124,20 @@ class Builder extends EventEmitter {
     return this.withWrapped(alias, statementOrColumnList, nothingOrStatement);
   }
 
+  withMaterialized(alias, statementOrColumnList, nothingOrStatement) {
+    validateWithArgs(alias, statementOrColumnList, nothingOrStatement, 'with');
+    this.withWrapped(alias, statementOrColumnList, nothingOrStatement);
+    this._statements[this._statements.length - 1].materialized = true;
+    return this;
+  }
+
+  withNotMaterialized(alias, statementOrColumnList, nothingOrStatement) {
+    validateWithArgs(alias, statementOrColumnList, nothingOrStatement, 'with');
+    this.withWrapped(alias, statementOrColumnList, nothingOrStatement);
+    this._statements[this._statements.length - 1].materialized = false;
+    return this;
+  }
+
   // Helper for compiling any advanced `with` queries.
   withWrapped(alias, statementOrColumnList, nothingOrStatement) {
     const [query, columnList] =

--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -1160,6 +1160,16 @@ class QueryCompiler {
       this.client,
       this.bindingsHolder
     );
+
+    let sqlMaterialized = '';
+    const canMaterialized = this.client.config.client === 'pg';
+
+    if (canMaterialized && typeof statement.materialized !== 'undefined') {
+      sqlMaterialized = statement.materialized
+        ? 'materialized '
+        : 'not materialized ';
+    }
+
     const columnList = statement.columnList
       ? '(' +
         columnize_(
@@ -1179,7 +1189,9 @@ class QueryCompiler {
           this.bindingsHolder
         ) +
           columnList +
-          ' as (' +
+          ' as ' +
+          sqlMaterialized +
+          '(' +
           val +
           ')') ||
       ''

--- a/test/integration2/query/select/selects.spec.js
+++ b/test/integration2/query/select/selects.spec.js
@@ -1093,6 +1093,29 @@ describe('Selects', function () {
           });
       });
 
+      it('MATERIALIZED CTE', async function () {
+        if (!isPostgreSQL(knex)) {
+          return this.skip();
+        }
+
+        await knex('test_default_table').truncate();
+        await knex('test_default_table').insert([
+          { string: 'something', tinyint: 1 },
+        ]);
+
+        const materialized = await knex
+          .withMaterialized('t', knex('test_default_table'))
+          .from('t')
+          .first();
+        expect(materialized.tinyint).to.equal(1);
+
+        const notMaterialized = await knex
+          .withNotMaterialized('t', knex('test_default_table'))
+          .from('t')
+          .first();
+        expect(notMaterialized.tinyint).to.equal(1);
+      });
+
       it('forUpdate().skipLocked() with order by should return the first non-locked row', async function () {
         // Note: this test doesn't work properly on MySQL - see https://bugs.mysql.com/bug.php?id=67745
         if (!isPostgreSQL(knex)) {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -9391,6 +9391,47 @@ describe('QueryBuilder', () => {
     });
   });
 
+  it("wrapped 'with' materialized clause select", () => {
+    testsql(
+      qb()
+        .withMaterialized('withClause', function () {
+          this.select('foo').from('users');
+        })
+        .select('*')
+        .from('withClause'),
+      {
+        mssql:
+          'with [withClause] as (select [foo] from [users]) select * from [withClause]',
+        pg: 'with "withClause" as materialized (select "foo" from "users") select * from "withClause"',
+        sqlite3:
+          'with `withClause` as (select `foo` from `users`) select * from `withClause`',
+        'pg-redshift':
+          'with "withClause" as (select "foo" from "users") select * from "withClause"',
+        oracledb:
+          'with "withClause" as (select "foo" from "users") select * from "withClause"',
+      }
+    );
+    testsql(
+      qb()
+        .withNotMaterialized('withClause', function () {
+          this.select('foo').from('users');
+        })
+        .select('*')
+        .from('withClause'),
+      {
+        mssql:
+          'with [withClause] as (select [foo] from [users]) select * from [withClause]',
+        pg: 'with "withClause" as not materialized (select "foo" from "users") select * from "withClause"',
+        sqlite3:
+          'with `withClause` as (select `foo` from `users`) select * from `withClause`',
+        'pg-redshift':
+          'with "withClause" as (select "foo" from "users") select * from "withClause"',
+        oracledb:
+          'with "withClause" as (select "foo" from "users") select * from "withClause"',
+      }
+    );
+  });
+
   it("wrapped 'with' clause select", () => {
     testsql(
       qb()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -520,6 +520,8 @@ export declare namespace Knex {
 
     // Withs
     with: With<TRecord, TResult>;
+    withMaterialized: With<TRecord, TResult>;
+    withNotMaterialized: With<TRecord, TResult>;
     withRecursive: With<TRecord, TResult>;
     withRaw: WithRaw<TRecord, TResult>;
     withSchema: WithSchema<TRecord, TResult>;


### PR DESCRIPTION
`knex.withMaterialized('t',knex('users')).from('t')` for `with 't' as materialized (select * from users) select * from t`

and 

`knex.withNotMaterialized('t',knex('users')).from('t')` -> `with 't' as not materialized (select * from users) select * from t`

https://www.postgresql.org/docs/current/queries-with.html#id-1.5.6.12.7

I will add documentation changes if this is approved