### PR TITLE
Ensure consistent `integer` vs `bigInteger` use in CRDB

### DIFF
--- a/lib/dialects/cockroachdb/crdb-columncompiler.js
+++ b/lib/dialects/cockroachdb/crdb-columncompiler.js
@@ -1,0 +1,11 @@
+/* eslint max-len: 0 */
+
+const ColumnCompiler = require('../postgres/schema/pg-columncompiler');
+
+class ColumnCompiler_CRDB extends ColumnCompiler {
+  integer() {
+    return 'int4';
+  }
+}
+
+module.exports = ColumnCompiler_CRDB;

--- a/lib/dialects/cockroachdb/index.js
+++ b/lib/dialects/cockroachdb/index.js
@@ -6,6 +6,7 @@ const QueryCompiler = require('./crdb-querycompiler');
 const TableCompiler = require('./crdb-tablecompiler');
 const ViewCompiler = require('./crdb-viewcompiler');
 const QueryBuilder = require('./crdb-querybuilder');
+const ColumnCompiler = require('./crdb-columncompiler');
 
 // Always initialize with the "QueryBuilder" and "QueryCompiler"
 // objects, which extend the base 'lib/query/builder' and
@@ -21,6 +22,10 @@ class Client_CockroachDB extends Client_PostgreSQL {
 
   tableCompiler() {
     return new TableCompiler(this, ...arguments);
+  }
+
+  columnCompiler() {
+    return new ColumnCompiler(this, ...arguments);
   }
 
   viewCompiler() {

--- a/test/integration2/schema/type-consistency.spec.js
+++ b/test/integration2/schema/type-consistency.spec.js
@@ -40,7 +40,7 @@ describe('Schema', () => {
 
           it('Retrieves DB bigIntegers as JS strings', async () => {
             const record = await knex.select('*').from(tblName).first();
-            expect(record[colNameInt]).to.be.a('string').that.equals('15');
+            expect(record[colNameBigInt]).to.be.a('string').that.equals('15');
           });
         });
       });

--- a/test/integration2/schema/type-consistency.spec.js
+++ b/test/integration2/schema/type-consistency.spec.js
@@ -23,8 +23,8 @@ describe('Schema', () => {
               table.bigInteger(colNameBigInt);
             });
             await knex(tblName).insert({
-              integer: 15,
-              bigInteger: 15,
+              [colNameInt]: 15,
+              [colNameBigInt]: 15,
             });
           });
 

--- a/test/integration2/schema/type-consistency.spec.js
+++ b/test/integration2/schema/type-consistency.spec.js
@@ -1,0 +1,49 @@
+const { expect } = require('chai');
+const {
+  Db,
+  getAllDbs,
+  getKnexForDb,
+} = require('../util/knex-instance-provider');
+
+describe('Schema', () => {
+  describe('Type Consistency', () => {
+    describe('Integers', () => {
+      getAllDbs().forEach((db) => {
+        describe(db, () => {
+          let knex;
+          const tblName = 'table_with_integers';
+          const colNameInt = 'integer_test';
+          const colNameBigInt = 'big_integer_test';
+
+          before(async () => {
+            knex = getKnexForDb(db);
+            await knex.schema.dropTableIfExists(tblName);
+            await knex.schema.createTable(tblName, (table) => {
+              table.integer(colNameInt);
+              table.bigInteger(colNameBigInt);
+            });
+            await knex(tblName).insert({
+              integer: 15,
+              bigInteger: 15,
+            });
+          });
+
+          after(async () => {
+            await knex.schema.dropTable(tblName);
+            return knex.destroy();
+          });
+
+          it('Retrieves DB integers as JS numbers', async () => {
+            const record = await knex.select('*').from(tblName).first();
+            expect(record[colNameInt]).to.be.a('number').that.equals(15);
+          });
+
+          it('Retrieves DB bigIntegers as JS strings', async () => {
+            const record = await knex.select('*').from(tblName).first();
+            expect(record[colNameInt]).to.be.a('string').that.equals('15');
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Forces the CockroachDB dialect to use `int4` for `.integer()` use to align with Postgres and differentiate from `.bigInteger()`.

Fixes #4953