### PR TITLE
bugfix: use logger.warn for redshift transaction dialect

### DIFF
--- a/lib/dialects/redshift/transaction.js
+++ b/lib/dialects/redshift/transaction.js
@@ -9,17 +9,17 @@ module.exports = class Redshift_Transaction extends Transaction {
   }
 
   savepoint(conn) {
-    this.trxClient.logger('Redshift does not support savepoints.');
+    this.trxClient.logger.warn('Redshift does not support savepoints.');
     return Promise.resolve();
   }
 
   release(conn, value) {
-    this.trxClient.logger('Redshift does not support savepoints.');
+    this.trxClient.logger.warn('Redshift does not support savepoints.');
     return Promise.resolve();
   }
 
   rollbackTo(conn, error) {
-    this.trxClient.logger('Redshift does not support savepoints.');
+    this.trxClient.logger.warn('Redshift does not support savepoints.');
     return Promise.resolve();
   }
 };


### PR DESCRIPTION
The redshift transaction dialect previously assumed that the logger
was a function that could be used directly instead of using a specific
logger method. The logger interface might actually have been a single
function at some point in time, but now you at least need to use a
specific logger function indicating the appropriate log level.