### PR TITLE
move deferrable to after on update/on delete

### DIFF
--- a/lib/schema/tablecompiler.js
+++ b/lib/schema/tablecompiler.js
@@ -127,9 +127,9 @@ class TableCompiler {
             ' (' +
             references +
             ')' +
-            deferrable +
             onUpdate +
-            onDelete
+            onDelete +
+            deferrable
         );
       } else {
         this.pushQuery(
@@ -144,9 +144,9 @@ class TableCompiler {
             ' (' +
             references +
             ')' +
-            deferrable +
             onUpdate +
-            onDelete
+            onDelete +
+            deferrable
         );
       }
     }

--- a/test/integration2/query/insert/on-conflict-deferred.spec.js
+++ b/test/integration2/query/insert/on-conflict-deferred.spec.js
@@ -9,7 +9,7 @@ describe('Insert', () => {
     getAllDbs().forEach((db) => {
       describe(db, () => {
         let knex;
-        before(() => {
+        before(function () {
           knex = getKnexForDb(db);
           if (!isPostgreSQL(knex)) {
             this.skip('This test is PostgreSQL only');

--- a/test/integration2/query/insert/on-conflict-deferred.spec.js
+++ b/test/integration2/query/insert/on-conflict-deferred.spec.js
@@ -1,0 +1,76 @@
+const {
+  getAllDbs,
+  getKnexForDb,
+} = require('../../util/knex-instance-provider');
+const { isPostgreSQL } = require('../../../util/db-helpers');
+
+describe('Insert', () => {
+  describe('onConflict deferred', () => {
+    getAllDbs().forEach((db) => {
+      describe(db, () => {
+        let knex;
+        before(() => {
+          knex = getKnexForDb(db);
+          if (!isPostgreSQL(knex)) {
+            this.skip('This test is PostgreSQL only');
+          }
+        });
+
+        after(() => {
+          return knex.destroy();
+        });
+
+        beforeEach(async () => {
+          await knex.schema.createTable('table_a', (table) => {
+            table.integer('id').primary().notNull();
+            table.integer('b_id').notNull();
+            table.integer('value').notNull();
+          });
+          await knex.schema.createTable('table_b', (table) => {
+            table.integer('id').primary().notNull();
+            table.integer('a_id').notNull();
+            table.integer('value').notNull();
+          });
+          await knex.schema.table('table_a', (table) => {
+            table
+              .foreign('b_id')
+              .references('table_b.id')
+              .onDelete('cascade')
+              .onUpdate('cascade')
+              .deferrable('deferred');
+          });
+          await knex.schema.table('table_b', (table) => {
+            table
+              .foreign('a_id')
+              .references('table_a.id')
+              .onDelete('cascade')
+              .onUpdate('cascade')
+              .deferrable('deferred');
+          });
+        });
+
+        afterEach(async () => {
+          await knex.schema.raw('drop table table_a cascade');
+          await knex.schema.raw('drop table table_b cascade');
+        });
+
+        it('inserts entries with delayed checks correctly', async function () {
+          for (let i = 0; i < 10; i++) {
+            await knex.transaction(async function (txn) {
+              await txn
+                .table('table_a')
+                .insert({ id: i, b_id: i, value: i })
+                .onConflict('id')
+                .merge();
+              await txn
+                .table('table_b')
+                .insert({ id: i, a_id: i, value: i })
+                .onConflict('id')
+                .merge();
+            });
+          }
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Postgresql requires that deferrable appear after on update/on delete, the current order fails with:

```
error: alter table "smtp_servers" add constraint "smtp_servers_email_channel_foreign" foreign key ("email_channel") references "email_channels" ("id") deferrable initially deferred  on update cascade on delete cascade - syntax error at or near "on"
```

Moving the deferred clause to the end works as intended.