### PR TITLE
Same boolean handling in better-sqlite3 as in sqlite3

### DIFF
--- a/lib/dialects/better-sqlite3/index.js
+++ b/lib/dialects/better-sqlite3/index.js
@@ -56,7 +56,7 @@ class Client_BetterSQLite3 extends Client_SQLite3 {
       }
 
       if (typeof binding === 'boolean') {
-        return String(binding);
+        return Number(binding);
       }
 
       return binding;

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -1412,6 +1412,22 @@ describe('Schema (misc)', () => {
                 'create index "10_test_table_logins_index" on "10_test_table" ("logins")',
               ]);
             }));
+
+        it('test boolean type with sqlite3 and better sqlite3 #4955', async function () {
+          if (!isSQLite(knex)) {
+            this.skip();
+          }
+          await knex.schema
+            .dropTableIfExists('test')
+            .createTable('test', (table) => {
+              table.boolean('value').notNullable();
+            });
+
+          await knex('test').insert([{ value: true }, { value: false }]);
+          const data = await knex('test').select();
+          expect(data[0].value).to.eq(1);
+          expect(data[1].value).to.eq(0);
+        });
       });
 
       describe('table', () => {


### PR DESCRIPTION
This is an extremely small pull request in accordance with issue #4955; if there is a design reason that that issue is misguided, feel free to squash it. The existing tests for better-sqlite3 still pass; maintainers should feel free to let me know if I should add anything to the tests to check this thing (presumably to test\unit\schema-builder\better-sqlite3.js?)