### PR TITLE
Support string json in json values

### DIFF
--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -1076,10 +1076,14 @@ class QueryCompiler {
   }
 
   _jsonWrapValue(jsonValue) {
-    if (this.builder._isJsonObject(jsonValue)) {
-      return JSON.stringify(jsonValue);
+    if (!this.builder._isJsonObject(jsonValue)) {
+      try {
+        return JSON.stringify(JSON.parse(jsonValue.replace(/\n|\t/g, '')));
+      } catch (e) {
+        return jsonValue;
+      }
     }
-    return jsonValue;
+    return JSON.stringify(jsonValue);
   }
 
   _jsonValueClause(statement) {

--- a/test/integration2/query/select/where.spec.js
+++ b/test/integration2/query/select/where.spec.js
@@ -637,6 +637,22 @@ describe('Where', function () {
           });
         });
 
+        it('where json object with string object', async () => {
+          const result = await knex('cities')
+            .select('name')
+            .whereJsonObject(
+              'descriptions',
+              `{
+              "type": "bigcity",
+              "short": "beautiful city",
+              "long": "beautiful and dirty city"
+            }`
+            );
+          expect(result[0]).to.eql({
+            name: 'Paris',
+          });
+        });
+
         it('where not json object', async () => {
           const result = await knex('cities')
             .select('name')
@@ -697,6 +713,24 @@ describe('Where', function () {
             .whereJsonSupersetOf('descriptions', {
               type: 'bigcity',
             });
+          expect(result.length).to.equal(2);
+          assertJsonEquals(result, [
+            {
+              name: 'Paris',
+            },
+            {
+              name: 'Milan',
+            },
+          ]);
+        });
+
+        it('where json superset of with string', async function () {
+          if (!(isPostgreSQL(knex) || isMysql(knex))) {
+            this.skip();
+          }
+          const result = await knex('cities')
+            .select('name')
+            .whereJsonSupersetOf('descriptions', '{"type": "bigcity"}');
           expect(result.length).to.equal(2);
           assertJsonEquals(result, [
             {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -10923,6 +10923,26 @@ describe('QueryBuilder', () => {
         );
       });
 
+      it('where a json column is a superset of value', async function () {
+        testsql(
+          qb().select().from('users').whereJsonSupersetOf('address', 'test'),
+          {
+            pg: {
+              sql: 'select * from "users" where "address" @> ?',
+              bindings: ['test'],
+            },
+            mysql: {
+              sql: 'select * from `users` where json_contains(`address`,?)',
+              bindings: ['test'],
+            },
+            cockroachdb: {
+              sql: 'select * from "users" where "address" @> ?',
+              bindings: ['test'],
+            },
+          }
+        );
+      });
+
       it('where a json column is not a superset of value', async function () {
         testsql(
           qb()


### PR DESCRIPTION
- Json values for Json functions now support Json in string format (not only json object).
- `await knex('table_name').whereJsonSupersetOf('path', "hello")` is always not supported (regarding @> Postgres documentation, this notation doesn't make sense, `whereJsonSupersetOf` checks two valid json objects).
- Closes https://github.com/knex/knex/issues/4979