### PR TITLE
Fix type definition for getMigration in MigrationSource

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2662,7 +2662,7 @@ export declare namespace Knex {
   interface MigrationSource<TMigrationSpec> {
     getMigrations(loadExtensions: readonly string[]): Promise<TMigrationSpec[]>;
     getMigrationName(migration: TMigrationSpec): string;
-    getMigration(migration: TMigrationSpec): Migration;
+    getMigration(migration: TMigrationSpec): Promise<Migration>;
   }
 
   interface MigratorConfig {


### PR DESCRIPTION
FsMigrations returns a promise, and all calling code expects a promise, so this updates the type definition to match that.