### PR TITLE
Fix whereJsonPath queries for postgres and cockroachdb

### DIFF
--- a/lib/dialects/cockroachdb/crdb-querycompiler.js
+++ b/lib/dialects/cockroachdb/crdb-querycompiler.js
@@ -35,9 +35,9 @@ class QueryCompiler_CRDB extends QueryCompiler_PG {
 
   whereJsonPath(statement) {
     let castValue = '';
-    if (parseInt(statement.value)) {
+    if (!isNaN(statement.value) && parseInt(statement.value)) {
       castValue = '::int';
-    } else if (parseFloat(statement.value)) {
+    } else if (!isNaN(statement.value) && parseFloat(statement.value)) {
       castValue = '::float';
     } else {
       castValue = " #>> '{}'";

--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -341,9 +341,9 @@ class QueryCompiler_PG extends QueryCompiler {
 
   whereJsonPath(statement) {
     let castValue = '';
-    if (parseInt(statement.value)) {
+    if (!isNaN(statement.value) && parseInt(statement.value)) {
       castValue = '::int';
-    } else if (parseFloat(statement.value)) {
+    } else if (!isNaN(statement.value) && parseFloat(statement.value)) {
       castValue = '::float';
     } else {
       castValue = " #>> '{}'";

--- a/test/integration2/query/select/where.spec.js
+++ b/test/integration2/query/select/where.spec.js
@@ -690,6 +690,20 @@ describe('Where', function () {
           });
         });
 
+        it('where json path equal string starting with number', async () => {
+          const result = await knex('cities')
+            .select('name')
+            .whereJsonPath(
+              'statistics',
+              '$.statisticId',
+              '=',
+              '6qITEHRUNJ4bdAmA0lk82'
+            );
+          expect(result[0]).to.eql({
+            name: 'Paris',
+          });
+        });
+
         it('where multiple json path', async () => {
           const result = await knex('cities')
             .select('name')

--- a/test/util/dataInsertHelper.js
+++ b/test/util/dataInsertHelper.js
@@ -143,6 +143,7 @@ async function insertCities(knex) {
         min: 1234,
         max: 1333,
       },
+      statisticId: '6qITEHRUNJ4bdAmA0lk82',
     },
     temperature: {
       desc: 'cold',
@@ -172,6 +173,7 @@ async function insertCities(knex) {
         max: 1655,
       },
       hotYears: [2012, 2015, 2021],
+      statisticId: '-4mZkPL-ZzRyEed00RQTQ',
     },
     temperature: {
       desc: 'warm',
@@ -201,6 +203,7 @@ async function insertCities(knex) {
         max: 156,
       },
       hotYears: [2016],
+      statisticId: '6bBGzpyL3sTRrxWs5gXTa',
     },
     temperature: {
       desc: 'verycold',


### PR DESCRIPTION
This PR fixes 2 bugs I've found working with where clauses build with 'whereJsonPath' for postgres database:

1.  If a passed value is a number, it is casted to integer or float on postgres side. However, is casted also if value only starts with a number but contains also letters or other characters. This is because **parseInt** and **parseFloat** are used for value check and they just ignore all non-numeric characters.
2. Queries using 'orWhereJsonPath' don't have proper binding for value. 

For 1st I've added additional check if value is not a NaN and for 2nd I've fixed arguments passed in query builder method.