### PR TITLE
Fixed primary keys being created separately on MySQL

### DIFF
--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -2,6 +2,7 @@
 
 // MySQL Table Builder & Compiler
 // -------
+const filter = require('lodash/filter');
 const TableCompiler = require('../../../schema/tablecompiler');
 const { isObject, isString } = require('../../../util/is');
 
@@ -19,7 +20,12 @@ class TableCompiler_MySQL extends TableCompiler {
       : 'create table ';
     const { client } = this;
     let conn = {};
-    const columnsSql = ' (' + columns.sql.join(', ') + this._addChecks() + ')';
+    let columnsSql = ' (' + columns.sql.join(', ');
+
+    columnsSql += this.primaryKeys() || '';
+    columnsSql += this._addChecks();
+    columnsSql += ')';
+
     let sql =
       createStatement +
       this.tableName() +
@@ -135,6 +141,20 @@ class TableCompiler_MySQL extends TableCompiler {
     });
   }
 
+  primaryKeys() {
+    const pks = filter(this.grouped.alterTable || [], { method: 'primary' });
+    if (pks.length > 0 && pks[0].args.length > 0) {
+      const columns = pks[0].args[0];
+      let constraintName = pks[0].args[1] || '';
+      if (constraintName) {
+        constraintName = ' constraint ' + this.formatter.wrap(constraintName);
+      }
+      return `,${constraintName} primary key (${this.formatter.columnize(
+        columns
+      )})`;
+    }
+  }
+
   getFKRefs(runner) {
     const bindingsHolder = {
       bindings: [],
@@ -244,6 +264,10 @@ class TableCompiler_MySQL extends TableCompiler {
   }
 
   primary(columns, constraintName) {
+    if (this.method === 'create' || this.method === 'createIfNot') {
+      return;
+    }
+
     let deferrable;
     if (isObject(constraintName)) {
       ({ constraintName, deferrable } = constraintName);

--- a/test/unit/schema-builder/mysql.js
+++ b/test/unit/schema-builder/mysql.js
@@ -79,6 +79,20 @@ module.exports = function (dialect) {
       );
     });
 
+    it('test basic create table with inline primary key creation', function () {
+      tableSql = client
+        .schemaBuilder()
+        .createTable('users', function (table) {
+          table.string('id', 24).primary();
+        })
+        .toSQL();
+
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'create table `users` (`id` varchar(24), primary key (`id`))'
+      );
+    });
+
     it('test basic create table with charset and collate', function () {
       tableSql = client.schemaBuilder().createTable('users', function (table) {
         table.increments('id');
@@ -1356,17 +1370,6 @@ module.exports = function (dialect) {
         .toSQL();
       expect(tableSql[0].sql).to.equal(
         'alter table `users` add primary key `testconstraintname`(`test1`, `test2`)'
-      );
-
-      tableSql = client
-        .schemaBuilder()
-        .createTable('users', function (t) {
-          t.string('test').primary('testconstraintname');
-        })
-        .toSQL();
-
-      expect(tableSql[1].sql).to.equal(
-        'alter table `users` add primary key `testconstraintname`(`test`)'
       );
     });
 


### PR DESCRIPTION
refs https://github.com/knex/knex/issues/4141

- for the MySQL dialect within `knex`, creating a table with a primary
  key will produce 2 queries - one to create the table and another to
  alter the table with a primary key on the column specified
- this is causing problems when trying to create tables on MySQL
  instances that have `sql_require_primary_key` enabled (the default on
  some managed DB providers)
- this commit adds a `primaryKeys` function to the table compiler that
  is called upon table creation, and inserts the primary keys into the
  `create` statement
- it also prevents the original `alter table ...` being called if we're
  creating a table
- the tests have been updated to reflect the fact we no longer have a
  separate query upon creation, and I've added a test to check the
  inline primary key is added
- the approach was mostly ripped from the same section in the SQLite
  driver - https://github.com/knex/knex/blob/47b96344c21beb3f8a2beb7aee6c99798a1ad318/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js#L257-L274

---

Note: I originally looked into this to fix the problem for Ghost, which is pinned to knex 0.21 because we use Bookshelf. If we manage to get this merged, I'd request the patch also be backported to the 0.21 branch (happy to do so). 🙂 