### PR TITLE
Fix types for "returning" methods

### DIFF
--- a/test-tsd/types.test-d.ts
+++ b/test-tsd/types.test-d.ts
@@ -94,12 +94,7 @@ expectAssignable<QueryBuilder>(
     .debug(true)
 );
 
-expectType<
-  QueryBuilder<
-    User,
-    DeferredKeySelection<User, 'id', true, {}, true, {}, never>[]
-  >
->(
+expectAssignable<QueryBuilder>(
   knexInstance
     .table<User>('users')
     .insert({ id: 10, active: true })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -284,27 +284,6 @@ type AggregationQueryResult<TResult, TIntersectProps2> = ArrayIfAlready<
   : TIntersectProps2
 >;
 
-// Convenience alias and associated companion namespace for working
-// with DeferredSelection having TSingle=true.
-//
-// When TSingle=true in DeferredSelection, then we are effectively
-// deferring an index access operation (TBase[TKey]) over a potentially
-// unknown initial type of TBase and potentially never initial type of TKey
-
-type DeferredIndex<TBase, TKey extends string> = DeferredKeySelection<TBase, TKey, false, {}, true>;
-
-declare namespace DeferredIndex {
-  type Augment<
-    T,
-    TBase,
-    TKey extends string,
-    TAliasMapping = {}
-    > = DeferredKeySelection.SetSingle<
-      DeferredKeySelection.AddKey<DeferredKeySelection.SetBase<T, TBase>, TKey>,
-      true
-    >;
-}
-
 // If we have more categories of deferred selection in future,
 // this will combine all of them
 type ResolveResult<S> = DeferredKeySelection.Resolve<S>;
@@ -694,7 +673,7 @@ export declare namespace Knex {
     ): QueryBuilder<TRecord, DeferredKeySelection<TRecord, never>[]>;
     insert<
       TKey extends StrKey<ResolveTableType<TRecord>>,
-      TResult2 = DeferredIndex.Augment<
+      TResult2 = DeferredKeySelection.Augment<
         UnwrapArrayMember<TResult>,
         ResolveTableType<TRecord>,
         TKey
@@ -722,7 +701,7 @@ export declare namespace Knex {
     ): QueryBuilder<TRecord, TResult2>;
     insert<
       TKey extends string,
-      TResult2 = DeferredIndex.Augment<
+      TResult2 = DeferredKeySelection.Augment<
         UnwrapArrayMember<TResult>,
         TRecord,
         TKey
@@ -736,7 +715,7 @@ export declare namespace Knex {
     ): QueryBuilder<TRecord, TResult2>;
     insert<
       TKey extends string,
-      TResult2 = DeferredIndex.Augment<
+      TResult2 = DeferredKeySelection.Augment<
         UnwrapArrayMember<TResult>,
         TRecord,
         TKey
@@ -763,7 +742,7 @@ export declare namespace Knex {
     ): QueryBuilder<TRecord, DeferredKeySelection<TRecord, never>[]>;
     upsert<
       TKey extends StrKey<ResolveTableType<TRecord>>,
-      TResult2 = DeferredIndex.Augment<
+      TResult2 = DeferredKeySelection.Augment<
         UnwrapArrayMember<TResult>,
         ResolveTableType<TRecord>,
         TKey
@@ -791,7 +770,7 @@ export declare namespace Knex {
     ): QueryBuilder<TRecord, TResult2>;
     upsert<
       TKey extends string,
-      TResult2 = DeferredIndex.Augment<
+      TResult2 = DeferredKeySelection.Augment<
         UnwrapArrayMember<TResult>,
         TRecord,
         TKey
@@ -805,7 +784,7 @@ export declare namespace Knex {
     ): QueryBuilder<TRecord, TResult2>;
     upsert<
       TKey extends string,
-      TResult2 = DeferredIndex.Augment<
+      TResult2 = DeferredKeySelection.Augment<
         UnwrapArrayMember<TResult>,
         TRecord,
         TKey
@@ -830,7 +809,7 @@ export declare namespace Knex {
     update<
       K1 extends StrKey<ResolveTableType<TRecord, 'update'>>,
       K2 extends StrKey<ResolveTableType<TRecord>>,
-      TResult2 = DeferredIndex.Augment<
+      TResult2 = DeferredKeySelection.Augment<
         UnwrapArrayMember<TResult>,
         ResolveTableType<TRecord>,
         K2
@@ -872,7 +851,7 @@ export declare namespace Knex {
     ): QueryBuilder<TRecord, DeferredKeySelection<TRecord, never>[]>;
     update<
       TKey extends StrKey<ResolveTableType<TRecord>>,
-      TResult2 = DeferredIndex.Augment<
+      TResult2 = DeferredKeySelection.Augment<
         UnwrapArrayMember<TResult>,
         ResolveTableType<TRecord>,
         TKey
@@ -927,7 +906,7 @@ export declare namespace Knex {
     returning(column: '*', options?: DMLOptions): QueryBuilder<TRecord, DeferredKeySelection<TRecord, never>[]>;
     returning<
       TKey extends StrKey<ResolveTableType<TRecord>>,
-      TResult2 = DeferredIndex.Augment<
+      TResult2 = DeferredKeySelection.Augment<
         UnwrapArrayMember<TResult>,
         ResolveTableType<TRecord>,
         TKey
@@ -952,24 +931,15 @@ export declare namespace Knex {
     ): QueryBuilder<TRecord, TResult2>;
 
     onConflict<
-      TKey extends StrKey<ResolveTableType<TRecord>>,
-      TResult2 = DeferredIndex.Augment<
-        UnwrapArrayMember<TResult>,
-        TRecord,
-        TKey
-      >[]
+      TKey extends StrKey<ResolveTableType<TRecord>>
     >(
       column: TKey
-    ): OnConflictQueryBuilder<TRecord, TResult2>;
+    ): OnConflictQueryBuilder<TRecord, TResult>;
     onConflict<
-      TKey extends StrKey<ResolveTableType<TRecord>>,
-      TResult2 = DeferredKeySelection.SetSingle<
-        DeferredKeySelection.Augment<UnwrapArrayMember<TResult>, TRecord, TKey>,
-        false
-      >[]
+      TKey extends StrKey<ResolveTableType<TRecord>>
     >(
       columns: readonly TKey[]
-    ): OnConflictQueryBuilder<TRecord, TResult2>;
+    ): OnConflictQueryBuilder<TRecord, TResult>;
 
     onConflict(
       columns: string
@@ -991,7 +961,7 @@ export declare namespace Knex {
     ): QueryBuilder<TRecord, DeferredKeySelection<TRecord, never>[]>;
     del<
       TKey extends StrKey<TRecord>,
-      TResult2 = DeferredIndex.Augment<
+      TResult2 = DeferredKeySelection.Augment<
         UnwrapArrayMember<TResult>,
         TRecord,
         TKey
@@ -1023,7 +993,7 @@ export declare namespace Knex {
     ): QueryBuilder<TRecord, DeferredKeySelection<TRecord, never>[]>;
     delete<
       TKey extends StrKey<ResolveTableType<TRecord>>,
-      TResult2 = DeferredIndex.Augment<
+      TResult2 = DeferredKeySelection.Augment<
         UnwrapArrayMember<TResult>,
         ResolveTableType<TRecord>,
         TKey
@@ -1833,7 +1803,7 @@ export declare namespace Knex {
     returning(column: '*'): BatchInsertBuilder<TRecord, DeferredKeySelection<TRecord, never>[]>;
     returning<
       TKey extends StrKey<ResolveTableType<TRecord>>,
-      TResult2 = DeferredIndex.Augment<
+      TResult2 = DeferredKeySelection.Augment<
         UnwrapArrayMember<TResult>,
         ResolveTableType<TRecord>,
         TKey

--- a/types/test.ts
+++ b/types/test.ts
@@ -1958,17 +1958,17 @@ const main = async () => {
     .insert({ id: 10 })
     .returning<string[]>('id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance<User>('users')
     .insert({ id: 10 })
     .returning('id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance('users_inferred')
     .insert({ id: 10 })
     .returning('id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance('users_composite')
     .insert({ insert: 'insert' })
     .returning('id');
@@ -1999,17 +1999,17 @@ const main = async () => {
     .insert([{ id: 10 }])
     .returning<string[]>('id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance<User>('users')
     .insert([{ id: 10 }])
     .returning('id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance('users_inferred')
     .insert([{ id: 10 }])
     .returning('id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance('users_composite')
     .insert([{ insert: 'insert' }])
     .returning('id');
@@ -2030,7 +2030,7 @@ const main = async () => {
     .insert({ id: 10 })
     .returning(['id', 'age']);
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance<User>('users').insert({ id: 10 }, 'id');
 
   // $ExpectType User[]
@@ -2063,13 +2063,13 @@ const main = async () => {
   // $ExpectType User[]
   await knexInstance('users_composite').insert([{ insert: 'insert' }], '*');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance.insert({ id: 10 }, 'id').into<User>('users');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance.insert({ id: 10 }, 'id').into('users_inferred');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance.insert({ insert: 'insert' }, 'id').into('users_composite');
 
   // $ExpectType Pick<User, "id" | "age">[]
@@ -2380,17 +2380,17 @@ const main = async () => {
     .update({})
     .returning(['id', 'age']);
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance<User>('users')
     .where('id', 10)
     .update({ active: true }, 'id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance('users_inferred')
     .where('id', 10)
     .update({ active: true }, 'id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance('users_composite')
     .where('id', 10)
     .update({ update: 'update' }, 'id');
@@ -2405,17 +2405,17 @@ const main = async () => {
     // $ExpectError
     .update({}, 'id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance<User>('users')
     .where('id', 10)
     .update('active', true, 'id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance('users_inferred')
     .where('id', 10)
     .update('active', true, 'id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance('users_composite')
     .where('id', 10)
     .update('update', 'update', 'id');
@@ -2553,17 +2553,17 @@ const main = async () => {
     .where('id', 10)
     .del();
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance<User>('users')
     .where('id', 10)
     .delete('id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance('users_inferred')
     .where('id', 10)
     .delete('id');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance('users_composite')
     .where('id', 10)
     .delete('id');
@@ -2658,19 +2658,19 @@ const main = async () => {
     .returning('*')
     .from('users_composite');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance
     .where('id', 10)
     .delete('id')
     .from<User>('users');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance
     .where('id', 10)
     .delete('id')
     .from('users_inferred');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance
     .where('id', 10)
     .delete('id')
@@ -2889,13 +2889,13 @@ const main = async () => {
       id: knexInstance.raw<number>('a')
     }], '*');
 
-  // $ExpectType number[]
+  // $ExpectType Pick<User, "id">[]
   await knexInstance<User>('users')
     .update({
       id: knexInstance.raw<number>('a')
     }, 'id');
 
-  // $ExpectType string[]
+  // $ExpectType Pick<User, "name">[]
   await knexInstance<User>('users')
     .update<'active', 'name'>('active', knexInstance.raw<boolean>('true'), 'name');
 


### PR DESCRIPTION
Closes #4942
With the release of v1, the methods for `returning` changed a bit. However, the type definitions were not updated.

Reviewing the rest of the types I found that the `onConflict` clause was setting the Result type with the passed conflicting columns. This looked very strange and at least when using postgres as the backend, this is not the case.

Also, (this is another issue) when not using the "returning", the types specify that the result is `number[]`. However (at least using pg) a Result object is returned instead.

```ts
  const users = await knex
    .from<Contact>("contact").insert([{
      email: "xxxx@gmail.com",
      first_name: "jeff"
    }])
  // users is suposed to be a number[];
  console.log(users)
  // Result {
  //   command: 'INSERT',
  //   rowCount: 2,
  //   oid: 0,
  //   rows: [],
  //   fields: [],
  //   ...
  // }
```