### PR TITLE
createTableLike callback should be optional

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2005,7 +2005,7 @@ export declare namespace Knex {
     createTableLike(
       tableName: string,
       tableNameLike: string,
-      callback: (tableBuilder: CreateTableBuilder) => any
+      callback?: (tableBuilder: CreateTableBuilder) => any
     ): SchemaBuilder;
     alterTable(
       tableName: string,


### PR DESCRIPTION
As per the documentation the callback is supposed to be optional. Leaving the callback as undefined works fine functionally but TypeScript marks it as invalid.

This update is to correct the types file.