### PR TITLE
Stringify json value in update

### DIFF
--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -1236,7 +1236,11 @@ class Builder extends EventEmitter {
     const obj = this._single.update || {};
     this._method = 'update';
     if (isString(values)) {
-      obj[values] = returning;
+      if (isPlainObject(returning)) {
+        obj[values] = JSON.stringify(returning);
+      } else {
+        obj[values] = returning;
+      }
       if (arguments.length > 2) {
         ret = arguments[2];
       }


### PR DESCRIPTION
- Stringify a json value in update query to avoid exploit.
- Closes #5059