### PR TITLE
Experiment: Unwind dialects/resolvedClientName require

### DIFF
--- a/lib/knex-builder/internal/config-resolver.js
+++ b/lib/knex-builder/internal/config-resolver.js
@@ -35,7 +35,11 @@ function resolveConfig(config) {
     }
 
     const resolvedClientName = resolveClientNameWithAliases(clientName);
-    Dialect = require(`../../dialects/${resolvedClientName}/index.js`);
+    if (resolvedClientName === 'mysql') {
+      Dialect = require(`../../dialects/mysql/index.js`);
+    } else {
+      Dialect = require(`../../dialects/${resolvedClientName}/index.js`);
+    }
   }
 
   // If config connection parameter is passed as string, try to parse it


### PR DESCRIPTION
This is to help bundlers like [esbuild](https://esbuild.github.io) to inline the code.

prepare:
```
$ esbuild bin/console.ts --bundle --outfile=bin/console.js --platform=node --target=node16 --loader:.graphql=text

  bin/console.js  4.6mb ⚠️
```

before:

```
➜ ./bin/console.js --help
Error: Cannot find module '../../dialects/mysql/index.js'
```

after
```
➜ ./bin/console.js --help
Usage: console [options] [command]

Options:
  -h, --help                         display help for command
```