### PR TITLE
Fix @vscode-sqlite3 error message

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -189,10 +189,9 @@ class Client extends EventEmitter {
     try {
       this.driver = this._driver();
     } catch (e) {
-      let driverName = this.driverName;
-      if (driverName === 'sqlite3') {
-        driverName = '@vscode/' + driverName;
-      }
+      const driverName = this.aliasDriverName
+        ? this.aliasDriverName
+        : this.driverName;
       const message = `Knex: run\n$ npm install ${driverName} --save`;
       this.logger.error(`${message}\n${e.message}\n${e.stack}`);
       throw new Error(`${message}\n${e.message}`);

--- a/lib/client.js
+++ b/lib/client.js
@@ -189,7 +189,11 @@ class Client extends EventEmitter {
     try {
       this.driver = this._driver();
     } catch (e) {
-      const message = `Knex: run\n$ npm install ${this.driverName} --save`;
+      let driverName = this.driverName;
+      if (driverName === 'sqlite3') {
+        driverName = '@vscode/' + driverName;
+      }
+      const message = `Knex: run\n$ npm install ${driverName} --save`;
       this.logger.error(`${message}\n${e.message}\n${e.stack}`);
       throw new Error(`${message}\n${e.message}`);
     }

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -232,6 +232,8 @@ Object.assign(Client_SQLite3.prototype, {
   dialect: 'sqlite3',
 
   driverName: 'sqlite3',
+  // SqlLite3 driver package name is different from driver name.
+  aliasDriverName: '@vscode/sqlite3',
 });
 
 module.exports = Client_SQLite3;

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -357,7 +357,8 @@ describe('knex', () => {
     ClientFoobar.prototype._driver = () => {
       throw new Error('Cannot require...');
     };
-    ClientFoobar.prototype.driverName = 'foo-bar';
+    ClientFoobar.prototype.driverName = ClientFoobar.prototype.aliasDriverName =
+      'foo-bar';
 
     expect(() => {
       Knex({ client: ClientFoobar, connection: {} });


### PR DESCRIPTION
- Fix the error message when sqlite3 driver don't exist.
- Relates #5002
- If I remove my vscode/sqlite3 install, I have the error. If I reinstall it via "npm install @vscode/sqlite3 --save" it's ok for me. I miss something ?