### PR TITLE
Fix cli migrate:make sqlite dependency

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,6 +16,7 @@ const {
   exit,
   success,
   checkLocalModule,
+  checkConfigurationOptions,
   getMigrationExtension,
   getSeedExtension,
   getStubPath,
@@ -42,7 +43,7 @@ async function openKnexfile(configPath) {
   return config;
 }
 
-async function initKnex(env, opts, noClientOverride) {
+async function initKnex(env, opts, useDefaultClientIfNotSpecified) {
   checkLocalModule(env);
   if (process.cwd() !== env.cwd) {
     process.chdir(env.cwd);
@@ -52,29 +53,35 @@ async function initKnex(env, opts, noClientOverride) {
     );
   }
 
+  if (!useDefaultClientIfNotSpecified) {
+    checkConfigurationOptions(env, opts);
+  }
+
   env.configuration = env.configPath
     ? await openKnexfile(env.configPath)
-    : mkConfigObj(opts, noClientOverride);
+    : mkConfigObj(opts);
 
-  let resolvedConfig = resolveEnvironmentConfig(
+  const resolvedConfig = resolveEnvironmentConfig(
     opts,
     env.configuration,
     env.configPath
   );
 
-  // In the other case, config is already override in mkConfigObj.
-  if (env.configPath) {
-    const optionsConfig = parseConfigObj(opts, noClientOverride);
-    resolvedConfig = merge(resolvedConfig, optionsConfig);
-  }
+  const optionsConfig = parseConfigObj(opts);
+  const config = merge(resolvedConfig, optionsConfig);
 
   // Migrations directory gets defaulted if it is undefined.
-  if (!env.configPath && !resolvedConfig.migrations.directory) {
-    resolvedConfig.migrations.directory = null;
+  if (!env.configPath && !config.migrations.directory) {
+    config.migrations.directory = null;
+  }
+
+  // Client gets defaulted if undefined and it's allowed
+  if (useDefaultClientIfNotSpecified && config.client === undefined) {
+    config.client = 'sqlite3';
   }
 
   const knex = require(env.modulePath);
-  return knex(resolvedConfig);
+  return knex(config);
 }
 
 function invoke() {
@@ -210,8 +217,7 @@ function invoke() {
     )
     .action(async (name) => {
       const opts = commander.opts();
-      opts.client = opts.client || 'sqlite3'; // We don't really care about client when creating migrations
-      const instance = await initKnex(env, opts, true);
+      const instance = await initKnex(env, opts, true);  // Skip config check, we don't really care about client when creating migrations
       const ext = getMigrationExtension(env, opts);
       const configOverrides = { extension: ext };
 
@@ -377,8 +383,7 @@ function invoke() {
     )
     .action(async (name) => {
       const opts = commander.opts();
-      opts.client = opts.client || 'sqlite3'; // We don't really care about client when creating seeds
-      const instance = await initKnex(env, opts);
+      const instance = await initKnex(env, opts, true); // Skip config check, we don't really care about client when creating seeds
       const ext = getSeedExtension(env, opts);
       const configOverrides = { extension: ext };
       const stub = getStubPath('seeds', env, opts);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -216,22 +216,26 @@ function invoke() {
       'Specify the migration stub to use. If using <name> the file must be located in config.migrations.directory'
     )
     .action(async (name) => {
-      const opts = commander.opts();
-      const instance = await initKnex(env, opts, true);  // Skip config check, we don't really care about client when creating migrations
-      const ext = getMigrationExtension(env, opts);
-      const configOverrides = { extension: ext };
+      try {
+        const opts = commander.opts();
+        const instance = await initKnex(env, opts, true);  // Skip config check, we don't really care about client when creating migrations
+        const ext = getMigrationExtension(env, opts);
+        const configOverrides = { extension: ext };
 
-      const stub = getStubPath('migrations', env, opts);
-      if (stub) {
-        configOverrides.stub = stub;
+        const stub = getStubPath('migrations', env, opts);
+        if (stub) {
+          configOverrides.stub = stub;
+        }
+
+        instance.migrate
+          .make(name, configOverrides)
+          .then((name) => {
+            success(color.green(`Created Migration: ${name}`));
+          })
+          .catch(exit);
+      } catch(err) {
+        exit(err);
       }
-
-      instance.migrate
-        .make(name, configOverrides)
-        .then((name) => {
-          success(color.green(`Created Migration: ${name}`));
-        })
-        .catch(exit);
     });
 
   commander
@@ -382,25 +386,29 @@ function invoke() {
       false
     )
     .action(async (name) => {
-      const opts = commander.opts();
-      const instance = await initKnex(env, opts, true); // Skip config check, we don't really care about client when creating seeds
-      const ext = getSeedExtension(env, opts);
-      const configOverrides = { extension: ext };
-      const stub = getStubPath('seeds', env, opts);
-      if (stub) {
-        configOverrides.stub = stub;
-      }
+      try {
+        const opts = commander.opts();
+        const instance = await initKnex(env, opts, true); // Skip config check, we don't really care about client when creating seeds
+        const ext = getSeedExtension(env, opts);
+        const configOverrides = { extension: ext };
+        const stub = getStubPath('seeds', env, opts);
+        if (stub) {
+          configOverrides.stub = stub;
+        }
 
-      if (opts.timestampFilenamePrefix) {
-        configOverrides.timestampFilenamePrefix = opts.timestampFilenamePrefix;
-      }
+        if (opts.timestampFilenamePrefix) {
+          configOverrides.timestampFilenamePrefix = opts.timestampFilenamePrefix;
+        }
 
-      instance.seed
-        .make(name, configOverrides)
-        .then((name) => {
-          success(color.green(`Created seed file: ${name}`));
-        })
-        .catch(exit);
+        instance.seed
+          .make(name, configOverrides)
+          .then((name) => {
+            success(color.green(`Created seed file: ${name}`));
+          })
+          .catch(exit);
+      } catch(err) {
+        exit(err);
+      }   
     });
 
   commander

--- a/bin/utils/cli-config-utils.js
+++ b/bin/utils/cli-config-utils.js
@@ -6,10 +6,10 @@ const tildify = require('tildify');
 const color = require('colorette');
 const argv = require('getopts')(process.argv.slice(2));
 
-function parseConfigObj(opts, noClientOverride) {
+function parseConfigObj(opts) {
   const config = { migrations: {} };
 
-  if (opts.client && (!noClientOverride || !config.client)) {
+  if (opts.client) {
     config.client = opts.client;
   }
 
@@ -28,17 +28,11 @@ function parseConfigObj(opts, noClientOverride) {
   return config;
 }
 
-function mkConfigObj(opts, noClientOverride) {
-  if (!opts.client) {
-    throw new Error(
-      `No configuration file found and no commandline connection parameters passed`
-    );
-  }
-
+function mkConfigObj(opts) {
   const envName = opts.env || process.env.NODE_ENV || 'development';
   const resolvedClientName = resolveClientNameWithAliases(opts.client);
   const useNullAsDefault = resolvedClientName === 'sqlite3';
-  const parsedConfig = parseConfigObj(opts, noClientOverride);
+  const parsedConfig = parseConfigObj(opts);
 
   return {
     ext: DEFAULT_EXT,
@@ -102,6 +96,14 @@ function checkLocalModule(env) {
       color.magenta(tildify(env.cwd))
     );
     exit('Try running: npm install knex');
+  }
+}
+
+function checkConfigurationOptions(env, opts) {
+  if (!env.configPath && !opts.client) {
+    throw new Error(
+      `No configuration file found and no commandline connection parameters passed`
+    );
   }
 }
 
@@ -199,6 +201,7 @@ module.exports = {
   exit,
   success,
   checkLocalModule,
+  checkConfigurationOptions,
   getSeedExtension,
   getMigrationExtension,
   getStubPath,

--- a/test/cli/migrate-make.spec.js
+++ b/test/cli/migrate-make.spec.js
@@ -163,6 +163,30 @@ module.exports = {
       );
     });
 
+    it('Does not create new migration with default knexfile with invalid client', () => {
+      fileHelper.registerGlobForCleanup(
+        'test/jake-util/knexfile_migrations/*_somename.js'
+      );
+      fileHelper.createFile(
+        process.cwd() + '/knexfile.js',
+        `
+module.exports = {
+  client: 'invalidclient',
+  migrations: {
+    directory: __dirname + '/test/jake-util/knexfile_migrations',
+  },
+};
+    `,
+        { isPathAbsolute: true }
+      );
+      return execCommand(
+        `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
+        {
+          expectedErrorMessage: `Unknown configuration option 'client' value invalidclient.`,
+        }
+      );
+    });
+
     it('Create new migration with default ts knexfile', async () => {
       fileHelper.registerGlobForCleanup(
         'test/jake-util/knexfile_migrations/*_somename1.ts'

--- a/test/cli/seed-make.spec.js
+++ b/test/cli/seed-make.spec.js
@@ -133,6 +133,30 @@ module.exports = {
       expect(fileCount).to.equal(1);
     });
 
+    it('Does not create new seed with default knexfile with invalid client', () => {
+      fileHelper.registerGlobForCleanup(
+        'test/jake-util/knexfile_seeds/somename.js'
+      );
+      fileHelper.createFile(
+        process.cwd() + '/knexfile.js',
+        `
+module.exports = {
+  client: 'invalidclient',
+  migrations: {
+    directory: __dirname + '/test/jake-util/knexfile_seeds',
+  },
+};
+    `,
+        { isPathAbsolute: true }
+      );
+      return execCommand(
+        `node ${KNEX} seed:make somename --knexpath=../knex.js`,
+        {
+          expectedErrorMessage: `Unknown configuration option 'client' value invalidclient.`,
+        }
+      );
+    });
+
     it('Creates new seed with default ts knexfile', async () => {
       fileHelper.registerGlobForCleanup(
         'test/jake-util/knexfile_seeds/somename.ts'


### PR DESCRIPTION
This is a proposed fix for #5102 .

Recent changes to how command line options are prioritized relative to configured options in the CLI exposed a bug in `migrate:make`. If a command line `client` option was not supplied, the CLI would use `sqlite3` instead of whatever is configured in the configuration file. This causes an error in environments where the optional sqlite3 peer dependency is not installed.

This PR alters the CLI initialization for commands that don't care about the client (`migrate:make` and `seed:make`) to skip an early check for the presence of a `client` option, and supply a default value of `sqlite3` later in the initialization process where it won't override a configured value.