### PR TITLE
Wait for search path to be set before returning connection

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -107,8 +107,8 @@ class Client_PG extends Client {
 
         return connection;
       })
-      .then(function setSearchPath(connection) {
-        client.setSchemaSearchPath(connection);
+      .then(async function setSearchPath(connection) {
+        await client.setSchemaSearchPath(connection);
         return connection;
       });
   }


### PR DESCRIPTION
In my test suite the connection was sometimes returned too fast and before the search path was actually set.

Since `setSchemaSearchPath` is running the query in a `Promise` we should wait for this promise to finish before continuing.