### PR TITLE
No client override during migrate:make

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -69,11 +69,7 @@ async function initKnex(env, opts, noClientOverride) {
   }
 
   // Migrations directory gets defaulted if it is undefined.
-  if (
-    !env.configPath &&
-    resolvedConfig.migrations &&
-    !resolvedConfig.migrations.directory
-  ) {
+  if (!env.configPath && !resolvedConfig.migrations.directory) {
     resolvedConfig.migrations.directory = null;
   }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -69,7 +69,11 @@ async function initKnex(env, opts, noClientOverride) {
   }
 
   // Migrations directory gets defaulted if it is undefined.
-  if (!env.configPath && !resolvedConfig.migrations.directory) {
+  if (
+    !env.configPath &&
+    resolvedConfig.migrations &&
+    !resolvedConfig.migrations.directory
+  ) {
     resolvedConfig.migrations.directory = null;
   }
 

--- a/bin/utils/cli-config-utils.js
+++ b/bin/utils/cli-config-utils.js
@@ -7,7 +7,7 @@ const color = require('colorette');
 const argv = require('getopts')(process.argv.slice(2));
 
 function parseConfigObj(opts, noClientOverride) {
-  const config = {};
+  const config = { migrations: {} };
 
   if (opts.client && (!noClientOverride || !config.client)) {
     config.client = opts.client;
@@ -17,15 +17,12 @@ function parseConfigObj(opts, noClientOverride) {
     config.connection = opts.connection;
   }
 
-  if (opts.migrationsDirectory || opts.migrationsTableName) {
-    config.migrations = {};
-    if (opts.migrationsDirectory) {
-      config.migrations.directory = opts.migrationsDirectory;
-    }
+  if (opts.migrationsDirectory) {
+    config.migrations.directory = opts.migrationsDirectory;
+  }
 
-    if (opts.migrationsTableName) {
-      config.migrations.tableName = opts.migrationsTableName;
-    }
+  if (opts.migrationsTableName) {
+    config.migrations.tableName = opts.migrationsTableName;
   }
 
   return config;

--- a/bin/utils/cli-config-utils.js
+++ b/bin/utils/cli-config-utils.js
@@ -6,16 +6,10 @@ const tildify = require('tildify');
 const color = require('colorette');
 const argv = require('getopts')(process.argv.slice(2));
 
-function findCaseInsensitiveProperty(propertyName, object) {
-  return Object.keys(object).find(
-    (key) => key.toLowerCase() === propertyName.toLowerCase()
-  );
-}
+function parseConfigObj(opts, noClientOverride) {
+  const config = {};
 
-function parseConfigObj(opts) {
-  const config = { migrations: {} };
-
-  if (opts.client) {
+  if (opts.client && (!noClientOverride || !config.client)) {
     config.client = opts.client;
   }
 
@@ -23,18 +17,21 @@ function parseConfigObj(opts) {
     config.connection = opts.connection;
   }
 
-  if (opts.migrationsDirectory) {
-    config.migrations.directory = opts.migrationsDirectory;
-  }
+  if (opts.migrationsDirectory || opts.migrationsTableName) {
+    config.migrations = {};
+    if (opts.migrationsDirectory) {
+      config.migrations.directory = opts.migrationsDirectory;
+    }
 
-  if (opts.migrationsTableName) {
-    config.migrations.tableName = opts.migrationsTableName;
+    if (opts.migrationsTableName) {
+      config.migrations.tableName = opts.migrationsTableName;
+    }
   }
 
   return config;
 }
 
-function mkConfigObj(opts) {
+function mkConfigObj(opts, noClientOverride) {
   if (!opts.client) {
     throw new Error(
       `No configuration file found and no commandline connection parameters passed`
@@ -44,7 +41,7 @@ function mkConfigObj(opts) {
   const envName = opts.env || process.env.NODE_ENV || 'development';
   const resolvedClientName = resolveClientNameWithAliases(opts.client);
   const useNullAsDefault = resolvedClientName === 'sqlite3';
-  const parsedConfig = parseConfigObj(opts);
+  const parsedConfig = parseConfigObj(opts, noClientOverride);
 
   return {
     ext: DEFAULT_EXT,

--- a/test/cli/migrate-make.spec.js
+++ b/test/cli/migrate-make.spec.js
@@ -136,6 +136,33 @@ module.exports = {
       );
     });
 
+    it('Create new migration with default knexfile with pg client', () => {
+      fileHelper.registerGlobForCleanup(
+        'test/jake-util/knexfile_migrations/*_somename.js'
+      );
+      fileHelper.createFile(
+        process.cwd() + '/knexfile.js',
+        `
+module.exports = {
+  client: 'pg',
+  connection: {
+    filename: __dirname + '/test/jake-util/test.sqlite3',
+  },
+  migrations: {
+    directory: __dirname + '/test/jake-util/knexfile_migrations',
+  },
+};
+    `,
+        { isPathAbsolute: true }
+      );
+      return execCommand(
+        `node ${KNEX} migrate:make somename --knexpath=../knex.js`,
+        {
+          expectedOutput: 'Created Migration',
+        }
+      );
+    });
+
     it('Create new migration with default ts knexfile', async () => {
       fileHelper.registerGlobForCleanup(
         'test/jake-util/knexfile_migrations/*_somename1.ts'


### PR DESCRIPTION
- During migrate:make client is set to 'sqlite3' only if client
is not setted in options and configuration.
- Closes #5102 