### PR TITLE
remove default client for migrations

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -210,7 +210,6 @@ function invoke() {
     )
     .action(async (name) => {
       const opts = commander.opts();
-      opts.client = opts.client || 'sqlite3'; // We don't really care about client when creating migrations
       const instance = await initKnex(env, opts, true);
       const ext = getMigrationExtension(env, opts);
       const configOverrides = { extension: ext };


### PR DESCRIPTION
1. the option "client" can not be set in the cli, because the "client" option is missing in the commander call and the resulting `config.client` is always "sqlite3"
2. all the other commands also have no default client