### PR TITLE
FIX 5114: Allow `null` as a valid value for `.enu`/`.enum`

### DIFF
--- a/test-tsd/tables.test-d.ts
+++ b/test-tsd/tables.test-d.ts
@@ -101,6 +101,12 @@ const main = async () => {
     table.integer('num').references('id').withKeyName('non_for7').deferrable('deferred').inTable('non_exist').onDelete('CASCADE');
     table.integer('num').references('id').inTable('non_exist').onDelete('CASCADE').withKeyName('non_for6').deferrable('deferred');
     table.integer('num').references('id').withKeyName('non_for7').onDelete('CASCADE').deferrable('deferred').inTable('non_exist');
+    
+    table.enu("myenum", null, {
+      enumName:"MyEnum",
+      useNative: true,
+      existingType: true,
+    });
 
     expectType<Knex.ReferencingColumnBuilder>(
       table.integer('num').references('id').withKeyName('non_for7').onDelete('CASCADE')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2097,12 +2097,12 @@ export declare namespace Knex {
     binary(columnName: string, length?: number): ColumnBuilder;
     enum(
       columnName: string,
-      values: readonly Value[],
+      values: (readonly Value[]) | null,
       options?: EnumOptions
     ): ColumnBuilder;
     enu(
       columnName: string,
-      values: readonly Value[],
+      values: (readonly Value[]) | null,
       options?: EnumOptions
     ): ColumnBuilder;
     json(columnName: string): ColumnBuilder;


### PR DESCRIPTION
When using the `useNative` and `existingType` options, the value isn't utilized.
The documentation uses `null` as an example, this commit allows said example
to pass in typescript


close #5114