### PR TITLE
Add 'validate' pool options. Resolves #5119.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -269,6 +269,10 @@ class Client extends EventEmitter {
           return false;
         }
 
+        if (poolConfig.validate && !poolConfig.validate(connection)) {
+          return false;
+        }
+
         return this.validateConnection(connection);
       },
     });

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -43,6 +43,7 @@ const POOL_CONFIG_OPTIONS = Object.freeze([
   'numTestsPerRun',
   'softIdleTimeoutMillis',
   'Promise',
+  'validate',
 ]);
 
 /**


### PR DESCRIPTION
In #5119, I described an issue where knex & the underlying tarn.js pool of connections does not roll off old connections, and so new database instances added behind a load-balancer end up going unused.

This PR proposes the simplest possible solution to #5119, which is to allow consumers to also define a `pool.validate` function.