### PR TITLE
CI: Add Node 18, drop Node 17

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [17.x]
+        node-version: [18.x]
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [17.x, 16.x, 14.x, 12.x]
+        node-version: [18.x, 16.x, 14.x, 12.x]
         database-type: [postgres, pgnative, mysql, mssql, sqlite3, cockroachdb, better-sqlite3, oracledb]
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [17.x, 16.x, 14.x, 12.x]
+        node-version: [18.x, 16.x, 14.x, 12.x]
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Replace Node 17 in CI with Node 18, which was released today.