### PR TITLE
Added getDialectByNameOrAlias and converted repo to use it.

### DIFF
--- a/lib/dialects/index.js
+++ b/lib/dialects/index.js
@@ -1,0 +1,35 @@
+const { resolveClientNameWithAliases } = require('../util/helpers');
+
+const dbNameToDialectLoader = Object.freeze({
+  'better-sqlite3': () => require('./better-sqlite3'),
+  cockroachdb: () => require('./cockroachdb'),
+  mssql: () => require('./mssql'),
+  mysql: () => require('./mysql'),
+  mysql2: () => require('./mysql2'),
+  oracle: () => require('./oracle'),
+  oracledb: () => require('./oracledb'),
+  pgnative: () => require('./pgnative'),
+  postgres: () => require('./postgres'),
+  redshift: () => require('./redshift'),
+  sqlite3: () => require('./sqlite3'),
+});
+
+/**
+ * Gets the Dialect object with the given client name or throw an
+ * error if not found.
+ * 
+ * NOTE: This is a replacement for prior practice of doing dynamic
+ * string construction for imports of Dialect objects.
+ */
+function getDialectByNameOrAlias(clientName) {
+  const resolvedClientName = resolveClientNameWithAliases(clientName);
+  const dialectLoader = dbNameToDialectLoader[resolvedClientName];
+  if (!dialectLoader) {
+    throw new Error(`Invalid clientName given: ${clientName}`);
+  }
+  return dialectLoader();
+}
+
+module.exports = {
+  getDialectByNameOrAlias,
+};

--- a/lib/knex-builder/internal/config-resolver.js
+++ b/lib/knex-builder/internal/config-resolver.js
@@ -2,7 +2,7 @@ const Client = require('../../client');
 const { SUPPORTED_CLIENTS } = require('../../constants');
 
 const parseConnection = require('./parse-connection');
-const { resolveClientNameWithAliases } = require('../../util/helpers');
+const { getDialectByNameOrAlias } = require('../../dialects');
 
 function resolveConfig(config) {
   let Dialect;
@@ -34,8 +34,7 @@ function resolveConfig(config) {
       );
     }
 
-    const resolvedClientName = resolveClientNameWithAliases(clientName);
-    Dialect = require(`../../dialects/${resolvedClientName}/index.js`);
+    Dialect = getDialectByNameOrAlias(clientName);
   }
 
   // If config connection parameter is passed as string, try to parse it


### PR DESCRIPTION
Previous this repo has imported Dialect objects via dynamically generating a string to require. This does not work well with compilers like ncc. To solve this and make for a better development experience we add the function `getDialectByNameOrAlias` to safely import Dialects while making requirement paths static for better compiler and bundler experiences.