### PR TITLE
fix: mysql hasColumn Error.(hasColumn `a_id` but hasColumn('a_Id') is false)

### DIFF
--- a/lib/dialects/mysql/schema/mysql-compiler.js
+++ b/lib/dialects/mysql/schema/mysql-compiler.js
@@ -48,8 +48,8 @@ class SchemaCompiler_MySQL extends SchemaCompiler {
       output(resp) {
         return resp.some((row) => {
           return (
-            this.client.wrapIdentifier(row.Field) ===
-            this.client.wrapIdentifier(column)
+            this.client.wrapIdentifier(row.Field.toLowerCase()) ===
+            this.client.wrapIdentifier(column.toLowerCase())
           );
         });
       },

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -1661,9 +1661,9 @@ describe('Schema (misc)', () => {
               expect(exists).to.equal(true);
             }));
 
-          describe('sqlite only', () => {
+          describe('sqlite and mysql only', () => {
             it('checks whether a column exists without being case sensitive, resolving with a boolean', async function () {
-              if (!isSQLite(knex)) {
+              if (!isSQLite(knex)&& !isMysql(knex)) {
                 return this.skip();
               }
 


### PR DESCRIPTION
I find this problem when i use strapi who will try to create column `a_id` although i already have a column `a_Id` on mysql.
This is my first pull request, if there are any error, please  give me a change to correct it. 