### PR TITLE
Refresh materialized view concurrently for PostgreSQL

### DIFF
--- a/lib/dialects/postgres/schema/pg-compiler.js
+++ b/lib/dialects/postgres/schema/pg-compiler.js
@@ -118,9 +118,9 @@ class SchemaCompiler_PG extends SchemaCompiler {
     );
   }
 
-  refreshMaterializedView(viewName) {
+  refreshMaterializedView(viewName, concurrently = false) {
     this.pushQuery({
-      sql: `refresh materialized view ${this.formatter.wrap(viewName)}`,
+      sql: `refresh materialized view${concurrently ? " concurrently" : ""} ${this.formatter.wrap(viewName)}`,
     });
   }
 

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -445,6 +445,18 @@ describe('PostgreSQL SchemaBuilder', function () {
         'refresh materialized view "view_to_refresh"'
       );
     });
+
+
+    it('refresh view concurrently', function () {
+      tableSql = client
+        .schemaBuilder()
+        .refreshMaterializedView('view_to_refresh', true)
+        .toSQL();
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'refresh materialized view concurrently "view_to_refresh"'
+      );
+    });
   });
 
   it('drop table with schema', function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1983,7 +1983,7 @@ export declare namespace Knex {
       viewName: string,
       callback: (viewBuilder: ViewBuilder) => any
     ): SchemaBuilder;
-    refreshMaterializedView(viewName: string): SchemaBuilder;
+    refreshMaterializedView(viewName: string, concurrently?: boolean): SchemaBuilder;
     dropView(viewName: string): SchemaBuilder;
     dropViewIfExists(viewName: string): SchemaBuilder;
     dropMaterializedView(viewName: string): SchemaBuilder;


### PR DESCRIPTION
PostgreSQL has a support to refresh the materialized view concurrently: [Documentation](https://www.postgresql.org/docs/current/sql-refreshmaterializedview.html)

This PR adds an optional boolean argument to the `refreshMaterializedView` method to refresh the view concurrently for PostgreSQL