### PR TITLE
Fix #4869, oracledb correctly INSERTS Buffer

### DIFF
--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -111,7 +111,8 @@ class Client_Oracledb extends Client_Oracle {
         this
       );
     } else if (value instanceof BlobHelper) {
-      return 'EMPTY_BLOB()';
+      formatter.bindings.push(value.value);
+      return '?';
     }
     return unwrapRaw(value, true, builder, this, formatter) || '?';
   }

--- a/test/integration2/dialects/oracledb.spec.js
+++ b/test/integration2/dialects/oracledb.spec.js
@@ -1,0 +1,46 @@
+const { expect } = require('chai');
+const { getAllDbs, getKnexForDb } = require('../util/knex-instance-provider');
+
+describe('Oracledb dialect', () => {
+  describe('Connection configuration', () => {
+    const dbs = getAllDbs().filter((db) => db === 'oracledb');
+
+    dbs.forEach((db) => {
+      describe(db, () => {
+        let knex;
+        before(() => {
+          knex = getKnexForDb(db, {
+            connection: {
+              user: 'user',
+              password: 'password',
+              connectString: 'connect-string',
+              externalAuth: true,
+              host: 'host',
+              database: 'database',
+            },
+          });
+        });
+
+        after(() => {
+          return knex.destroy();
+        });
+
+        describe('#4869 inserting Buffer', async () => {
+          it('.toSQL().toNative() generates correct sql and bindings for INSERT of Buffer', async () => {
+            const b = Buffer.from('hello', 'utf-8')
+            const query = knex('table1').insert({ value: b })
+            const queryObj = query.toSQL().toNative()
+            // Ensure we have two bindings, before fix for #4869 there would only have been one due
+            // to silent dropping of the Buffer.
+            expect(queryObj.bindings.length).to.eql(2)
+            expect(queryObj).to.eql({
+              sql: 'insert into "table1" ("value") values (:1) returning "value" into :2',
+              bindings: [b, { type: 2019, dir: 3003 }],
+            });
+          });
+        });
+
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Related Issues and PRs
1. #4869

## Change(s)
1. Fixes `parameter` function for Oracledb dialect to properly handle Blobs instead of replacing them with `EMPTY_BLOB()` in `lib/dialects/oracledb/index.js`.
2. Created new test file to verify new behavior in `test/integration2/dialects/oracledb.spec.js`.