### PR TITLE
Use correct paths in package.json browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,9 +201,9 @@
     }
   ],
   "browser": {
-    "./lib/migrate/Migrator.js": "./lib/util/noop.js",
+    "./lib/migrations/migrate/Migrator.js": "./lib/util/noop.js",
     "./lib/bin/cli.js": "./lib/util/noop.js",
-    "./lib/seed/Seeder.js": "./lib/util/noop.js",
+    "./lib/migrations/seed/Seeder.js": "./lib/util/noop.js",
     "tedious": false,
     "mysql": false,
     "mysql2": false,


### PR DESCRIPTION
The seeder entry is the only one really required to easily build knex for
the browser without shimming `fs`, but I updated the migrations path to
match.

However, there's also `lib/migrations/seed/seed-stub.js`, which actually
seems to provide errors when attempting to use the seed functionality in
a browser, but isn't actually used anywhere

I'm not exactly sure which way is intended.

If the seed stub is intended, then I'll change it to use that, otherwise it should probably be removed.