### PR TITLE
MSSQL: Fix .hasTable result when using .withSchema

### DIFF
--- a/lib/dialects/mssql/schema/mssql-compiler.js
+++ b/lib/dialects/mssql/schema/mssql-compiler.js
@@ -49,10 +49,17 @@ class SchemaCompiler_MSSQL extends SchemaCompiler {
       this.builder,
       this.bindingsHolder
     );
-    const sql =
+    const bindings = [tableName];
+    let sql =
       `SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES ` +
       `WHERE TABLE_NAME = ${formattedTable}`;
-    this.pushQuery({ sql, output: (resp) => resp.length > 0 });
+
+    if (this.schema) {
+      sql += ' AND TABLE_SCHEMA = ?';
+      bindings.push(this.schema);
+    }
+
+    this.pushQuery({ sql, bindings, output: (resp) => resp.length > 0 });
   }
 
   // Check whether a column exists on the schema.

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -1597,7 +1597,7 @@ describe('Schema (misc)', () => {
       });
 
       describe('hasTable', () => {
-        it('checks whether a table exists', () =>
+        it('should be true if a table exists', () =>
           knex.schema.hasTable('test_table_two').then((resp) => {
             expect(resp).to.equal(true);
           }));
@@ -1663,7 +1663,7 @@ describe('Schema (misc)', () => {
 
           describe('sqlite and mysql only', () => {
             it('checks whether a column exists without being case sensitive, resolving with a boolean', async function () {
-              if (!isSQLite(knex)&& !isMysql(knex)) {
+              if (!isSQLite(knex) && !isMysql(knex)) {
                 return this.skip();
               }
 
@@ -2046,7 +2046,7 @@ describe('Schema (misc)', () => {
 
       describe('withSchema', () => {
         describe('mssql only', () => {
-          if (!knex || !knex.client || !/mssql/i.test(knex.client.dialect)) {
+          if (!isMssql(knex)) {
             return Promise.resolve(true);
           }
 
@@ -2085,15 +2085,23 @@ describe('Schema (misc)', () => {
           }
 
           const defaultSchemaName = 'public';
-          const testSchemaName = 'test';
+          const testSchemaName = 'test_schema';
 
           before(() => createSchema(testSchemaName));
 
+          afterEach(() =>
+            knex.schema.withSchema(testSchemaName).dropTableIfExists('test')
+          );
           after(() => knex.schema.raw('DROP SCHEMA ' + testSchemaName));
 
           it('should not find non-existent tables', () =>
             checkTable(testSchemaName, 'test', false).then(() =>
               checkTable(defaultSchemaName, 'test', false)
+            ));
+
+          it('should find existent tables', () =>
+            createTable(testSchemaName, 'test').then(() =>
+              checkTable(testSchemaName, 'test', true)
             ));
 
           it('should create and drop tables', () =>

--- a/test/unit/schema-builder/mssql.js
+++ b/test/unit/schema-builder/mssql.js
@@ -511,9 +511,9 @@ describe('MSSQL SchemaBuilder', function () {
 
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
-      'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ?'
+      'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ? AND TABLE_SCHEMA = ?'
     );
-    expect(tableSql[0].bindings[0]).to.equal('schema.users');
+    expect(tableSql[0].bindings[0]).to.equal('users');
   });
 
   it('test rename table with schema', function () {


### PR DESCRIPTION
This PR fixes an issue where `hasTable` would return false if used on `withSchema`. This happens only on MSSQL.

I added a new test to ensure the behavior and also cleaned the test file a bit.

Closes #5170 