### PR TITLE
Fixes Maria issue with 'NULL' returned instead of NULL on MariaDB 10.2.6+

### DIFF
--- a/lib/dialects/mysql/query/mysql-querycompiler.js
+++ b/lib/dialects/mysql/query/mysql-querycompiler.js
@@ -131,7 +131,7 @@ class QueryCompiler_MySQL extends QueryCompiler {
       output(resp) {
         const out = resp.reduce(function (columns, val) {
           columns[val.COLUMN_NAME] = {
-            defaultValue: val.COLUMN_DEFAULT,
+            defaultValue: val.COLUMN_DEFAULT === 'NULL' ? null : val.COLUMN_DEFAULT,
             type: val.DATA_TYPE,
             maxLength: val.CHARACTER_MAXIMUM_LENGTH,
             nullable: val.IS_NULLABLE === 'YES',

--- a/test/integration2/query/misc/additional.spec.js
+++ b/test/integration2/query/misc/additional.spec.js
@@ -423,6 +423,27 @@ describe('Additional', function () {
           expect(expectedUuid).to.equal(originalUuid);
         });
 
+        it ('#5154 - should properly mark COLUMN_DEFAULT as null', async function () {
+          if (!isMysql(knex)) {
+            return this.skip();
+          }
+
+          await knex.schema.dropTableIfExists('null_col');
+          await knex.schema.createTable('null_col', function (table) {
+            table.date('foo').defaultTo(null).nullable();
+          })
+          const columnInfo = await knex('null_col').columnInfo();
+
+          expect(columnInfo).to.deep.equal({
+            foo: {
+              type: 'date',
+              maxLength: null,
+              nullable: true,
+              defaultValue: null,
+            },
+          });
+        });
+
         it('#2184 - should properly escape table name for SQLite columnInfo', async function () {
           if (!isSQLite(knex)) {
             return this.skip();


### PR DESCRIPTION
Fixes: #5154

---

If we look at https://jira.mariadb.org/browse/MDEV-13132, a bug was fixed to properly quote default value to be able to determine expressions vs null. This meant due to the strict typing that `'NULL'` was not detected as null and thus attempted to be included as a default value even against a not-nullable table here - https://github.com/knex/knex/blob/master/lib/schema/tablecompiler.js#L333

I've never worked with this project, but my Ghost blog stopped working and while Ghost is dropping Maria and I'm sad about that. I cannot complain seeing how I paid $0, so I'm attempting to fix to resolve this issue.

I added a test which I believe resolves issue, but to truly replicate you need Maria 10.2.6+ and I don't even see that in the integration suite (the docker). So while I pointed my test to my own Maria and confirmed this works as well as "monkey patching" this fix into my live environment as well. So I am setting this to draft to figure out how you recommend I solve this in terms of "proving" it was solved.

* Should I bring in Maria into integration suite, which might expose a few more issues?
* How should I handle this?

---
(proof of Ghost working after patch)

```
Message: Ghost was able to start, but errored during boot with: alter table `newsletters` modify  `created_at` datetime null default 'NULL' - Invalid default value for 'created_at'

Debug Information:
    OS: Ubuntu, v20.04.4 LTS
    Node Version: v14.19.2
    Ghost Version: 4.47.3
    Ghost-CLI Version: 1.18.1
    Environment: production
    Command: 'ghost restart'

Additional log info available in: xxx

connor@dune:/var/www/connor/blog$ ghost start
+ sudo systemctl start ghost_connortumbleson-com
✔ Starting Ghost
```