### PR TITLE
Fix sqlite returning

### DIFF
--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -116,6 +116,12 @@ class Client_SQLite3 extends Client {
     let callMethod;
     switch (method) {
       case 'insert':
+        // if there is any returning column
+        // query should return data
+        if(obj.returning){
+          callMethod = 'all';
+          break;
+        }
       case 'update':
       case 'counter':
       case 'del':


### PR DESCRIPTION
**Issue**
Client sqlite3 does not return results. It only returns last inserted id as number array. It always return last inserted 

**Cause**
when method is insert, sqlite3 client sends query with 'run' call method. The call method does not allow to return any value.

**Fix**
When method is insert and returning exists, call method is set to 'all' instead of 'run'