### PR TITLE
feature  - Support for JSON parameter in MSSQL connection string

### DIFF
--- a/lib/knex-builder/internal/parse-connection.js
+++ b/lib/knex-builder/internal/parse-connection.js
@@ -69,8 +69,10 @@ function connectionObject(parsed) {
   }
   if (parsed.searchParams) {
     for (const [key, value] of parsed.searchParams.entries()) {
-      const isMySQLLike = ['mysql:', 'mariadb:'].includes(parsed.protocol);
-      if (isMySQLLike) {
+      const isNestedConfigSupported = ['mysql:', 'mariadb:', 'mssql:'].includes(
+        parsed.protocol
+      );
+      if (isNestedConfigSupported) {
         try {
           connection[key] = JSON.parse(value);
         } catch (err) {

--- a/test/tape/parse-connection.js
+++ b/test/tape/parse-connection.js
@@ -311,3 +311,27 @@ test('#4628, supports mysql / mariadb client JSON parameters', function (t) {
     }
   );
 });
+
+test('support MSSQL JSON parameters for config object', function (t) {
+  t.plan(1);
+  t.deepLooseEqual(
+    parseConnection(
+      'mssql://user:password@host/database?domain=testDomain&options={"instanceName": "TestInstance001", "readOnlyIntent": true}'
+    ),
+
+    {
+      client: 'mssql',
+      connection: {
+        server: 'host',
+        user: 'user',
+        password: 'password',
+        database: 'database',
+        domain: 'testDomain',
+        options: {
+          instanceName: 'TestInstance001',
+          readOnlyIntent: true,
+        },
+      },
+    }
+  );
+});


### PR DESCRIPTION
### Issue: 
The existing parser implementation does not parse the nested properties from the connection string for MSSQL ([Tedious](https://tediousjs.github.io/tedious/api-connection.html) supports properties like `InstanceName`, `TDS Packet size`, `readOnlyIntent` under `options` key, which can not be passed to knex over connection string at the moment). 

**Example Connection string :** 

`mssql://user:password@host/database?domain=testDomain&options={"instanceName": "TestInstance001", "readOnlyIntent": true}'`

**Actual Config**

```
{
  user: 'user',
  password: 'password',
  database: 'database',
  server: 'host',
  domain: 'testDomain',
  options:'{"instanceName": "TestInstance001", "readOnlyIntent": true}'
}

```
**Expected Config**

```
{
  user: 'user',
  password: 'password',
  database: 'database',
  server: 'host',
  domain: 'testDomain',
  options: {
    instanceName: 'TestInstance001'
    trustServerCertificate: true
  }
}
```

