### PR TITLE
Explicit jsonb support for custom pg clients

### DIFF
--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -139,8 +139,8 @@ function jsonColumn(client, jsonb) {
   if (
     !client.version ||
     client.config.client === 'cockroachdb' ||
-    parseFloat(client.version) >= 9.2 ||
-    client.config.jsonbSupport === true
+    client.config.jsonbSupport === true ||
+    parseFloat(client.version) >= 9.2
   ) {
     return jsonb ? 'jsonb' : 'json';
   }

--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -138,7 +138,6 @@ ColumnCompiler_PG.prototype.uuid = 'uuid';
 function jsonColumn(client, jsonb) {
   if (
     !client.version ||
-    client.config.client === 'cockroachdb' ||
     parseFloat(client.version) >= 9.2 ||
     client.config.jsonbSupport === true
   ) {

--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -139,7 +139,8 @@ function jsonColumn(client, jsonb) {
   if (
     !client.version ||
     client.config.client === 'cockroachdb' ||
-    parseFloat(client.version) >= 9.2
+    parseFloat(client.version) >= 9.2 ||
+    client.config.jsonbSupport === true
   ) {
     return jsonb ? 'jsonb' : 'json';
   }

--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -138,6 +138,7 @@ ColumnCompiler_PG.prototype.uuid = 'uuid';
 function jsonColumn(client, jsonb) {
   if (
     !client.version ||
+    client.config.client === 'cockroachdb' ||
     parseFloat(client.version) >= 9.2 ||
     client.config.jsonbSupport === true
   ) {

--- a/test/integration2/util/knex-instance-provider.js
+++ b/test/integration2/util/knex-instance-provider.js
@@ -132,7 +132,6 @@ const testConfigs = {
     pool,
     migrations,
     seeds,
-    jsonbSupport: true,
   },
 
   pgnative: {

--- a/test/integration2/util/knex-instance-provider.js
+++ b/test/integration2/util/knex-instance-provider.js
@@ -132,6 +132,7 @@ const testConfigs = {
     pool,
     migrations,
     seeds,
+    jsonbSupport: true,
   },
 
   pgnative: {

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -93,6 +93,41 @@ describe('PostgreSQL Config', function () {
         );
       });
     });
+
+    describe('check custom pg client', function () {
+      it('jsonb as text', function () {
+        knexInstance = knex({
+          ...config,
+          version: 'custom-pg',
+          jsonbSupport: false,
+        });
+        tableSql = knexInstance.schema
+          .table('public', function (t) {
+            t.jsonb('test_name');
+          })
+          .toSQL();
+        equal(1, tableSql.length);
+        expect(tableSql[0].sql).to.equal(
+          'alter table "public" add column "test_name" text'
+        );
+      });
+      it('jsonb', function () {
+        knexInstance = knex({
+          ...config,
+          version: 'custom-pg',
+          jsonbSupport: true,
+        });
+        tableSql = knexInstance.schema
+          .table('public', function (t) {
+            t.jsonb('test_name');
+          })
+          .toSQL();
+        equal(1, tableSql.length);
+        expect(tableSql[0].sql).to.equal(
+          'alter table "public" add column "test_name" jsonb'
+        );
+      });
+    });
   });
 });
 
@@ -445,7 +480,6 @@ describe('PostgreSQL SchemaBuilder', function () {
         'refresh materialized view "view_to_refresh"'
       );
     });
-
 
     it('refresh view concurrently', function () {
       tableSql = client

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2310,6 +2310,7 @@ export declare namespace Knex {
     debug?: boolean;
     client?: string | typeof Client;
     dialect?: string;
+    jsonbSupport?: boolean;
     version?: string;
     connection?: string | StaticConnectionConfig | ConnectionConfigProvider;
     pool?: PoolConfig;


### PR DESCRIPTION
I ran into an issue where my `jsonb` columns are created as `text` when using `pg-mem` in tests and aurora friendly clients like `knex-data-api-client`

It resulted in a lot of `cast blah as jsonb` workarounds, but really, the issue is that under the hood, knex just falls back to `text` data type when it cannot resolve a valid pg version.

This change lets custom clients like `knex-data-api` explicitly state they support `jsonb` instead of passing in a potentially wrong postgres version (think serverless setup)