### PR TITLE
chore: update docs reference in sqlite3 warning

### DIFF
--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -24,7 +24,7 @@ class Client_SQLite3 extends Client {
       this.logger.warn(
         'sqlite does not support inserting default values. Set the ' +
           '`useNullAsDefault` flag to hide this warning. ' +
-          '(see docs http://knexjs.org/#Builder-insert).'
+          '(see docs https://knexjs.org/guide/query-builder.html#insert).'
       );
     }
   }

--- a/lib/dialects/sqlite3/query/sqlite-querycompiler.js
+++ b/lib/dialects/sqlite3/query/sqlite-querycompiler.js
@@ -76,7 +76,7 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
             throw new TypeError(
               '`sqlite` does not support inserting default values. Specify ' +
                 'values explicitly or use the `useNullAsDefault` config flag. ' +
-                '(see docs http://knexjs.org/#Builder-insert).'
+                '(see docs https://knexjs.org/guide/query-builder.html#insert).'
             );
         });
       });


### PR DESCRIPTION
Update an out-of-date documentation reference inside warning logged when `useNullAsDefault` configuration property is undefined for SQLite3 client.