### PR TITLE
Updating raw query bind parameter type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -442,6 +442,7 @@ export declare namespace Knex {
     | Array<Date>
     | Array<boolean>
     | Buffer
+    | object
     | Knex.Raw;
 
   interface ValueDict extends Dict<Value | Knex.QueryBuilder> {}


### PR DESCRIPTION
Allowing custom object type in bind parameter for raw query. For example when calling oracle stored procedure like 
```
Person.knex().raw('CALL TEST_PACKAGE.TEST(?, ?)', [
  { type: OracleDB.CURSOR, dir: OracleDB.BIND_OUT },
  { type: OracleDB.NUMBER, dir: OracleDB.BIND_OUT },
]).then(res => {
  console.log(res)
})
```