### PR TITLE
fix(postgresql): add primaryKey option for uuid

### DIFF
--- a/lib/dialects/postgres/schema/pg-columncompiler.js
+++ b/lib/dialects/postgres/schema/pg-columncompiler.js
@@ -124,6 +124,13 @@ class ColumnCompiler_PG extends ColumnCompiler {
       (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '')
     );
   }
+
+  uuid(options = { primaryKey: false }) {
+    return (
+      'uuid' +
+      (this.tableCompiler._canBeAddPrimaryKey(options) ? ' primary key' : '')
+    );
+  }
 }
 
 ColumnCompiler_PG.prototype.bigint = 'bigint';
@@ -133,7 +140,6 @@ ColumnCompiler_PG.prototype.double = 'double precision';
 ColumnCompiler_PG.prototype.floating = 'real';
 ColumnCompiler_PG.prototype.smallint = 'smallint';
 ColumnCompiler_PG.prototype.tinyint = 'smallint';
-ColumnCompiler_PG.prototype.uuid = 'uuid';
 
 function jsonColumn(client, jsonb) {
   if (

--- a/lib/schema/columncompiler.js
+++ b/lib/schema/columncompiler.js
@@ -277,8 +277,10 @@ ColumnCompiler.prototype.geography = 'geography';
 ColumnCompiler.prototype.point = 'point';
 ColumnCompiler.prototype.enu = 'varchar';
 ColumnCompiler.prototype.bit = ColumnCompiler.prototype.json = 'text';
-ColumnCompiler.prototype.uuid = ({ useBinaryUuid = false } = {}) =>
-  useBinaryUuid ? 'binary(16)' : 'char(36)';
+ColumnCompiler.prototype.uuid = ({
+  useBinaryUuid = false,
+  primaryKey = false,
+} = {}) => (useBinaryUuid ? 'binary(16)' : 'char(36)');
 ColumnCompiler.prototype.integer =
   ColumnCompiler.prototype.smallint =
   ColumnCompiler.prototype.mediumint =

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -137,6 +137,19 @@ describe('PostgreSQL SchemaBuilder', function () {
     );
   });
 
+  it('create table with uuid primary key in one go', function () {
+    tableSql = client
+      .schemaBuilder()
+      .createTable('uuid_primary', function (table) {
+        table.uuid('id', { primaryKey: true });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'create table "uuid_primary" ("id" uuid primary key)'
+    );
+  });
+
   it('basic alter table', function () {
     tableSql = client
       .schemaBuilder()
@@ -445,7 +458,6 @@ describe('PostgreSQL SchemaBuilder', function () {
         'refresh materialized view "view_to_refresh"'
       );
     });
-
 
     it('refresh view concurrently', function () {
       tableSql = client


### PR DESCRIPTION
Adds support for creating a uuid field as primary key directly in a create statement using `uuid('id', { primaryKey: true })` for PostgreSQL dialects.

For now the option is only implemented for PostgreSQL dialects since it should work for all of them and it's only really an issue for CockroachDB.

As far as i can tell, using `uuid('id', { primaryKey: true }).primary()` would still work if you need to support other dialects (the `primary()` would just generate a no-op alter statement).

It's getting late here, so i'll add a docs PR tomorrow. Please let me know if the integration test is too hacky and i'll improve on it.

Fixes #5211

