### PR TITLE
sqlite3: Add warning for unspecified connection file

### DIFF
--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -20,6 +20,15 @@ const QueryBuilder = require('./query/sqlite-querybuilder');
 class Client_SQLite3 extends Client {
   constructor(config) {
     super(config);
+
+    if (config.connection && config.connection.filename === undefined) {
+      this.logger.warn(
+        'Could not find `connection.filename` in config. Please specify ' +
+          'the database path and name to avoid errors. ' +
+          '(see docs https://knexjs.org/guide/#configuration-options)'
+      );
+    }
+
     if (config.useNullAsDefault === undefined) {
       this.logger.warn(
         'sqlite does not support inserting default values. Set the ' +


### PR DESCRIPTION
This PR is but a simple quality of life update that warns the user when the SQLite file has not been specified.

Closes #5216 