### PR TITLE
chore: remove bindingHolder for proper scoping

### DIFF
--- a/lib/formatter/wrappingFormatter.js
+++ b/lib/formatter/wrappingFormatter.js
@@ -225,8 +225,7 @@ function rawOrFn(value, method, builder, client, bindingHolder) {
       compileCallback(value, method, client, bindingHolder),
       undefined,
       builder,
-      client,
-      bindingHolder
+      client
     );
   }
   return unwrapRaw(value, undefined, builder, client, bindingHolder) || '';


### PR DESCRIPTION
I've been perusing [lgtm](https://lgtm.com/projects/g/knex/knex/?mode=list) and this one might be in the "makes sense" + 'is minimal" category.

let's see if CI/CD agrees