### PR TITLE
Fix unclosed stream connections

### DIFF
--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -66,7 +66,10 @@ class Runner {
       objectMode: true,
       transform: (chunk, _, callback) => {
         callback(null, this.client.postProcessResponse(chunk, queryContext));
-      }
+      },
+    });
+    stream.on('close', () => {
+      this.client.releaseConnection(this.connection);
     });
 
     const connectionAcquirePromise = this.ensureConnection(

--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -61,22 +61,12 @@ class Runner {
     Transform = Transform || require('stream').Transform;
 
     const queryContext = this.builder.queryContext();
-    let queryStream;
 
     const stream = new Transform({
       objectMode: true,
       transform: (chunk, _, callback) => {
         callback(null, this.client.postProcessResponse(chunk, queryContext));
-      },
-      destroy() {
-        // For some reason destroy is not available for mssql on Node 14. Might be a problem with tedious: https://github.com/tediousjs/tedious/issues/1139
-        if (queryStream && queryStream.destroy) {
-          queryStream.destroy(new Error('stream destroyed'));
-        }
-      },
-    });
-    stream.on('pipe', (qs) => {
-      queryStream = qs;
+      }
     });
 
     const connectionAcquirePromise = this.ensureConnection(


### PR DESCRIPTION
Closes #5242 .

This PR fixes the hanging-connection bug when a stream-consuming async iterable throws an error, by manually releasing the connection when the stream closes. 

I've also cherry-picked the commit from the PR #5043 onto this PR, as the `close` event will get silently swallowed otherwise.