### PR TITLE
Builder extend() options w/ force

### DIFF
--- a/lib/knex-builder/Knex.js
+++ b/lib/knex-builder/Knex.js
@@ -26,33 +26,35 @@ knex.Client = Client;
 knex.KnexTimeoutError = KnexTimeoutError;
 
 knex.QueryBuilder = {
-  extend: function (methodName, fn) {
-    QueryBuilder.extend(methodName, fn);
-    QueryInterface.push(methodName);
+  extend: function (methodName, fn, options = {}) {
+    QueryBuilder.extend(methodName, fn, options);
+    if (!options.force || !QueryInterface.includes(methodName)) {
+      QueryInterface.push(methodName);
+    }
   },
 };
 
 knex.SchemaBuilder = {
-  extend: function (methodName, fn) {
-    SchemaBuilder.extend(methodName, fn);
+  extend: function (methodName, fn, options) {
+    SchemaBuilder.extend(methodName, fn, options);
   },
 };
 
 knex.ViewBuilder = {
-  extend: function (methodName, fn) {
-    ViewBuilder.extend(methodName, fn);
+  extend: function (methodName, fn, options) {
+    ViewBuilder.extend(methodName, fn, options);
   },
 };
 
 knex.ColumnBuilder = {
-  extend: function (methodName, fn) {
-    ColumnBuilder.extend(methodName, fn);
+  extend: function (methodName, fn, options) {
+    ColumnBuilder.extend(methodName, fn, options);
   },
 };
 
-knex.TableBuilder  = {
-  extend: function (methodName, fn) {
-    TableBuilder.extend(methodName, fn);
+knex.TableBuilder = {
+  extend: function (methodName, fn, options) {
+    TableBuilder.extend(methodName, fn, options);
   },
 };
 

--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -1758,8 +1758,11 @@ Builder.prototype.del = Builder.prototype.delete;
 augmentWithBuilderInterface(Builder);
 addQueryContext(Builder);
 
-Builder.extend = (methodName, fn) => {
-  if (Object.prototype.hasOwnProperty.call(Builder.prototype, methodName)) {
+Builder.extend = (methodName, fn, options = {}) => {
+  if (
+    !options.force &&
+    Object.prototype.hasOwnProperty.call(Builder.prototype, methodName)
+  ) {
     throw new Error(
       `Can't extend QueryBuilder with existing method ('${methodName}').`
     );

--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -1764,7 +1764,7 @@ Builder.extend = (methodName, fn, options = {}) => {
     Object.prototype.hasOwnProperty.call(Builder.prototype, methodName)
   ) {
     throw new Error(
-      `Can't extend QueryBuilder with existing method ('${methodName}').`
+      `Can't extend QueryBuilder with existing method ('${methodName}'). Try the existing method, or pass the force option to overwrite the existing method.`
     );
   }
 

--- a/lib/schema/builder.js
+++ b/lib/schema/builder.js
@@ -103,7 +103,7 @@ SchemaBuilder.extend = (methodName, fn, options = {}) => {
     Object.prototype.hasOwnProperty.call(SchemaBuilder.prototype, methodName)
   ) {
     throw new Error(
-      `Can't extend SchemaBuilder with existing method ('${methodName}').`
+      `Can't extend SchemaBuilder with existing method ('${methodName}'). Try the existing method, or pass the force option to overwrite the existing method.`
     );
   }
 

--- a/lib/schema/builder.js
+++ b/lib/schema/builder.js
@@ -97,9 +97,11 @@ class SchemaBuilder extends EventEmitter {
   };
 });
 
-
-SchemaBuilder.extend = (methodName, fn) => {
-  if (Object.prototype.hasOwnProperty.call(SchemaBuilder.prototype, methodName)) {
+SchemaBuilder.extend = (methodName, fn, options = {}) => {
+  if (
+    !options.force &&
+    Object.prototype.hasOwnProperty.call(SchemaBuilder.prototype, methodName)
+  ) {
     throw new Error(
       `Can't extend SchemaBuilder with existing method ('${methodName}').`
     );

--- a/lib/schema/columnbuilder.js
+++ b/lib/schema/columnbuilder.js
@@ -88,9 +88,11 @@ ColumnBuilder.prototype.notNull = ColumnBuilder.prototype.notNullable =
   };
 });
 
-
-ColumnBuilder.extend = (methodName, fn) => {
-  if (Object.prototype.hasOwnProperty.call(ColumnBuilder.prototype, methodName)) {
+ColumnBuilder.extend = (methodName, fn, options = {}) => {
+  if (
+    !options.force &&
+    Object.prototype.hasOwnProperty.call(ColumnBuilder.prototype, methodName)
+  ) {
     throw new Error(
       `Can't extend ColumnBuilder with existing method ('${methodName}').`
     );

--- a/lib/schema/columnbuilder.js
+++ b/lib/schema/columnbuilder.js
@@ -94,7 +94,7 @@ ColumnBuilder.extend = (methodName, fn, options = {}) => {
     Object.prototype.hasOwnProperty.call(ColumnBuilder.prototype, methodName)
   ) {
     throw new Error(
-      `Can't extend ColumnBuilder with existing method ('${methodName}').`
+      `Can't extend ColumnBuilder with existing method ('${methodName}'). Try the existing method, or pass the force option to overwrite the existing method.`
     );
   }
 

--- a/lib/schema/tablebuilder.js
+++ b/lib/schema/tablebuilder.js
@@ -367,7 +367,7 @@ TableBuilder.extend = (methodName, fn, options = {}) => {
     Object.prototype.hasOwnProperty.call(TableBuilder.prototype, methodName)
   ) {
     throw new Error(
-      `Can't extend TableBuilder with existing method ('${methodName}').`
+      `Can't extend TableBuilder with existing method ('${methodName}'). Try the existing method, or pass the force option to overwrite the existing method.`
     );
   }
 

--- a/lib/schema/tablebuilder.js
+++ b/lib/schema/tablebuilder.js
@@ -361,9 +361,11 @@ AlterMethods.dropColumn = AlterMethods.dropColumns = function () {
   return this;
 };
 
-
-TableBuilder.extend = (methodName, fn) => {
-  if (Object.prototype.hasOwnProperty.call(TableBuilder.prototype, methodName)) {
+TableBuilder.extend = (methodName, fn, options = {}) => {
+  if (
+    !options.force &&
+    Object.prototype.hasOwnProperty.call(TableBuilder.prototype, methodName)
+  ) {
     throw new Error(
       `Can't extend TableBuilder with existing method ('${methodName}').`
     );

--- a/lib/schema/viewbuilder.js
+++ b/lib/schema/viewbuilder.js
@@ -79,9 +79,11 @@ const AlterMethods = {
 
 helpers.addQueryContext(ViewBuilder);
 
-
-ViewBuilder.extend = (methodName, fn) => {
-  if (Object.prototype.hasOwnProperty.call(ViewBuilder.prototype, methodName)) {
+ViewBuilder.extend = (methodName, fn, options = {}) => {
+  if (
+    !options.force &&
+    Object.prototype.hasOwnProperty.call(ViewBuilder.prototype, methodName)
+  ) {
     throw new Error(
       `Can't extend ViewBuilder with existing method ('${methodName}').`
     );

--- a/lib/schema/viewbuilder.js
+++ b/lib/schema/viewbuilder.js
@@ -85,7 +85,7 @@ ViewBuilder.extend = (methodName, fn, options = {}) => {
     Object.prototype.hasOwnProperty.call(ViewBuilder.prototype, methodName)
   ) {
     throw new Error(
-      `Can't extend ViewBuilder with existing method ('${methodName}').`
+      `Can't extend ViewBuilder with existing method ('${methodName}'). Try the existing method, or pass the force option to overwrite the existing method.`
     );
   }
 

--- a/test/unit/schema-builder/extensions.js
+++ b/test/unit/schema-builder/extensions.js
@@ -49,4 +49,18 @@ describe('SchemaBuilder Extensions', () => {
       })
       .toSQL();
   });
+
+  it('querybuilder has method', () => {
+    knex.QueryBuilder.extend('testQueryBuilderExt', () => true);
+    expect(client.queryBuilder().testQueryBuilderExt()).to.be.true;
+  });
+
+  it('should throw when querybuilder method exists', () => {
+    expect(() => knex.QueryBuilder.extend('upsert', () => true)).to.throw();
+  });
+
+  it('should not throw when querybuilder method exists and force option is given', () => {
+    knex.QueryBuilder.extend('upsert', () => true, { force: true });
+    expect(client.queryBuilder().upsert()).to.be.true;
+  });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -374,6 +374,10 @@ interface DMLOptions {
   includeTriggerModifications?: boolean;
 }
 
+interface BuilderExtendOptions {
+  force?: boolean
+}
+
 export interface Knex<TRecord extends {} = any, TResult = any[]>
   extends Knex.QueryInterface<TRecord, TResult>,
     events.EventEmitter {
@@ -452,32 +456,37 @@ export declare namespace knex {
         | Promise<
             | Knex.QueryBuilder<TRecord | TResult>
             | DeferredKeySelection.Resolve<TResult>
-          >
+          >,
+      options?: BuilderExtendOptions
     ): void;
   }
 
   class TableBuilder {
     static extend<T = Knex.TableBuilder, B = Knex.TableBuilder>(
       methodName: string,
-      fn: (this: T, ...args: any[]) => B
+      fn: (this: T, ...args: any[]) => B,
+      options?: BuilderExtendOptions
     ): void;
   }
   class ViewBuilder {
     static extend<T = Knex.ViewBuilder, B = Knex.ViewBuilder>(
       methodName: string,
-      fn: (this: T, ...args: any[]) => B
+      fn: (this: T, ...args: any[]) => B,
+      options?: BuilderExtendOptions
     ): void;
   }
   class SchemaBuilder {
     static extend<T = Knex.SchemaBuilder, B = Knex.SchemaBuilder>(
       methodName: string,
-      fn: (this: T, ...args: any[]) => B
+      fn: (this: T, ...args: any[]) => B,
+      options?: BuilderExtendOptions
     ): void;
   }
   class ColumnBuilder {
     static extend<T = Knex.ColumnBuilder, B = Knex.ColumnBuilder>(
       methodName: string,
-      fn: (this: T, ...args: any[]) => B
+      fn: (this: T, ...args: any[]) => B,
+      options?: BuilderExtendOptions
     ): void;
   }
 


### PR DESCRIPTION
This PR is to add an Options object to each of the builder.extend functions. Further down the road, the options object can expand without creating breaking changes.

The main motivation for the specific changes was to mitigate breaking changes when new functionalities are incomplete (i.e. the upsert function), but also to allow users to overwrite any of the functionalities if they feel comfortable doing so.

The perfect use case:

knex community adds a new upsert function in the latest version. You have extended the QueryBuilder and created your own version of upsert. When the time comes to update packages, your upsert extension breaks. You can now pass in an options object with `{ force: true }` as the third optional parameter of `knex.QueryBuilder.extend()`. No large refactoring is necessary.