### PR TITLE
Update types for TS 4.8

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -444,7 +444,7 @@ export declare namespace knex {
   class QueryBuilder {
     static extend(
       methodName: string,
-      fn: <TRecord extends {} = any, TResult = unknown[]>(
+      fn: <TRecord extends {} = any, TResult extends {} = unknown[]>(
         this: Knex.QueryBuilder<TRecord, TResult>,
         ...args: any[]
       ) =>


### PR DESCRIPTION
Typescript 4.8 assumes that unconstrained types extend `unknown`, not `{}` (which is `unknown` minus `null` and `undefined`). However, many uses still need to extend `{}`. This PR does that explicitly for knex types.

See https://devblogs.microsoft.com/typescript/announcing-typescript-4-8-beta/#unconstrained-generics-no-longer-assignable-to