### PR TITLE
Support returning with sqlite3 and better-sqlite3

### DIFF
--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -126,6 +126,8 @@ class Client_SQLite3 extends Client {
     switch (method) {
       case 'insert':
       case 'update':
+        callMethod = obj.returning ? 'all' : 'run';
+        break;
       case 'counter':
       case 'del':
         callMethod = 'run';
@@ -198,8 +200,15 @@ class Client_SQLite3 extends Client {
         }
         return [ctx.lastID];
       }
+      case 'update': {
+        if (returning) {
+          if (response) {
+            return response;
+          }
+        }
+        return ctx.changes;
+      }
       case 'del':
-      case 'update':
       case 'counter':
         return ctx.changes;
       default: {

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -192,11 +192,6 @@ class Client_SQLite3 extends Client {
           if (response) {
             return response;
           }
-
-          // ToDo Implement after https://github.com/microsoft/vscode-node-sqlite3/issues/15 is resolved
-          this.logger.warn(
-            'node-sqlite3 does not currently support RETURNING clause'
-          );
         }
         return [ctx.lastID];
       }

--- a/lib/dialects/sqlite3/query/sqlite-querycompiler.js
+++ b/lib/dialects/sqlite3/query/sqlite-querycompiler.js
@@ -149,6 +149,23 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
     };
   }
 
+  // Compiles an `update` query, allowing for a return value.
+  update() {
+    const withSQL = this.with();
+    const updateData = this._prepUpdate(this.single.update);
+    const wheres = this.where();
+    const { returning } = this.single;
+    return {
+      sql:
+        withSQL +
+        `update ${this.single.only ? 'only ' : ''}${this.tableName} ` +
+        `set ${updateData.join(', ')}` +
+        (wheres ? ` ${wheres}` : '') +
+        this._returning(returning),
+      returning,
+    };
+  }
+
   _ignore(columns) {
     if (columns === true) {
       return ' on conflict do nothing';

--- a/test/integration2/query/insert/inserts.spec.js
+++ b/test/integration2/query/insert/inserts.spec.js
@@ -126,7 +126,7 @@ describe('Inserts', function () {
                 1,
                 TEST_TIMESTAMP,
               ],
-              [1]
+              [{ id: 1 }]
             );
             tester(
               'oracledb',
@@ -270,7 +270,7 @@ describe('Inserts', function () {
                 2,
                 TEST_TIMESTAMP,
               ],
-              [2]
+              [{ id: 1 }, { id: 2 }]
             );
             tester(
               'oracledb',
@@ -488,7 +488,7 @@ describe('Inserts', function () {
                 2,
                 TEST_TIMESTAMP,
               ],
-              [2]
+              [{ id: 1 }, { id: 2 }]
             );
             tester(
               'oracledb',
@@ -724,7 +724,7 @@ describe('Inserts', function () {
                 2,
                 TEST_TIMESTAMP,
               ],
-              [1]
+              [{ id: 1 }]
             );
             tester(
               'oracledb',
@@ -1018,7 +1018,13 @@ describe('Inserts', function () {
                 'Lorem ipsum Minim nostrud Excepteur consectetur enim ut qui sint in veniam in nulla anim do cillum sunt voluptate Duis non incididunt.',
                 0,
               ],
-              [1]
+              [
+                {
+                  account_id: 10,
+                  details:
+                    'Lorem ipsum Minim nostrud Excepteur consectetur enim ut qui sint in veniam in nulla anim do cillum sunt voluptate Duis non incididunt.',
+                },
+              ]
             );
             tester(
               'oracledb',

--- a/test/integration2/query/misc/additional.spec.js
+++ b/test/integration2/query/misc/additional.spec.js
@@ -20,7 +20,6 @@ const {
   isPgBased,
   isPgNative,
   isCockroachDB,
-  isBetterSQLite3,
 } = require('../../../util/db-helpers');
 const { DRIVER_NAMES: drivers } = require('../../../util/constants');
 const {
@@ -272,7 +271,7 @@ describe('Additional', function () {
         });
 
         it('should return the correct column when a single property is given to returning', async function () {
-          if (!isPostgreSQL(knex) && !isMssql(knex) && !isBetterSQLite3(knex)) {
+          if (!isPostgreSQL(knex) && !isMssql(knex) && !isSQLite(knex)) {
             return this.skip();
           }
 
@@ -287,7 +286,7 @@ describe('Additional', function () {
         });
 
         it('should return the correct columns when multiple properties are given to returning', async function () {
-          if (!isPostgreSQL(knex) && !isMssql(knex) && !isBetterSQLite3(knex)) {
+          if (!isPostgreSQL(knex) && !isMssql(knex) && !isSQLite(knex)) {
             return this.skip();
           }
 

--- a/test/integration2/query/update/updates.spec.js
+++ b/test/integration2/query/update/updates.spec.js
@@ -314,9 +314,22 @@ describe('Updates', function () {
             );
             tester(
               'sqlite3',
-              'update `accounts` set `email` = ?, `first_name` = ?, `last_name` = ? where `id` = ?',
+              'update `accounts` set `email` = ?, `first_name` = ?, `last_name` = ? where `id` = ? returning *',
               ['test100@example.com', 'UpdatedUser', 'UpdatedTest', 1],
-              1
+              [
+                {
+                  id: 1,
+                  first_name: 'UpdatedUser',
+                  last_name: 'UpdatedTest',
+                  email: 'test100@example.com',
+                  logins: 1,
+                  balance: 12.240000000000002,
+                  about: 'Lorem ipsum Dolore labore incididunt enim.',
+                  created_at: TEST_TIMESTAMP,
+                  updated_at: TEST_TIMESTAMP,
+                  phone: null,
+                },
+              ]
             );
             tester(
               'oracledb',


### PR DESCRIPTION
The `RETURNING` SQL statement is now supported for insert and update queries.

Fixes #4370.