### PR TITLE
remove __knexTxId from connection on release

### DIFF
--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -255,6 +255,7 @@ class Transaction extends EventEmitter {
     } finally {
       if (!configConnection) {
         debug('%s: releasing connection', this.txid);
+        delete connection.__knexTxId;
         this.client.releaseConnection(connection);
       } else {
         debug('%s: not releasing external connection', this.txid);


### PR DESCRIPTION
This might only affect debugging logs (I confess I don't have enough confidence to say whether this could affect more than just debugging logs), but I got very confused when a query that i knew wasn't supposed to be in a transaction had a debug log that said it was in a transaction. This should clean this up so that other queries that reuse the same connection after it is released will have the correct debug info.

I went with delete over setting the field to undefined, because delete puts the connection back exactly as it was before the transaction, even though setting it to undefined is usually faster. The downside of setting to undefined is that the field will get copied over with Object.assign and similar