### PR TITLE
Infer specific column value type in aggregations

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1864,7 +1864,7 @@ export declare namespace Knex {
         }
       >
     >(
-      columnName: Readonly<TKey>,
+      columnName: TKey,
       options: Readonly<TOptions>
     ): QueryBuilder<TRecord, TResult2>;
     <

--- a/types/test.ts
+++ b/types/test.ts
@@ -1197,7 +1197,7 @@ const main = async () => {
   // $ExpectType Dict<any>
   await knexInstance.first().min('age').from<User>('users');
 
-  // $ExpectType ({ a: string | Date; } & { b: string | Date; })[]
+  // $ExpectType ({ a: Date; } & { b: Date; })[]
   await knexInstance<Ticket>('tickets')
     .min('at', {as: 'a'})
     .max('at', {as: 'b'});


### PR DESCRIPTION
👋 Hi folks, thanks for a great library! I came across what looks like a typing bug to me:

---

The first overload of TypePreservingAggregation (taking columnName and options) used `Readonly<TKey>` for the columnName type. In this context, `TKey` is supposed to be a single column name, but `Readonly<TKey>` maps over the full constraint of `keyof ResolveTableType<TRecord>`.

This results in `TKey` being a union of all keys in the table, rather than a single key. Because of this, the result type ends up being a union of all values in the table.

The fix is to remove the `Readonly` type, which is fine since `TKey` is a string and not an object like in the other overloads.