### PR TITLE
Fix type for AnalyticFunction

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1918,11 +1918,11 @@ export declare namespace Knex {
         | TKey
         | TKey[]
         | {
-            columnName: TKey;
+            column: TKey;
             order?: 'asc' | 'desc';
             nulls?: 'first' | 'last';
           },
-      partitionBy?: TKey | TKey[] | { columnName: TKey; order?: 'asc' | 'desc' }
+      partitionBy?: TKey | TKey[] | { column: TKey; order?: 'asc' | 'desc' }
     ): QueryBuilder<TRecord, TResult2>;
   }
 


### PR DESCRIPTION
Fix `AnalyticFunction` type affecting `rowNumber`, `rank` and `DenseRank`. 

## The problem

I discovered during development, where TypeScript complains:
```
Argument of type '{ column: string; order: "desc"; }' is not assignable to parameter of type '"oid" | "oid"[] | { columnName: "oid"; order?: "asc" | "desc" | undefined; nulls?: "first" | "last" | undefined; }'.
  Object literal may only specify known properties, and 'column' does not exist in type '"oid"[] | { columnName: "oid"; order?: "asc" | "desc" | undefined; nulls?: "first" | "last" | undefined; }'.
```

However, they are clearly using `column` in the code:
https://github.com/knex/knex/blob/4c79ac1fe64618ed0d1bd63dcae3f9b812827f69/lib/query/analytic.js#L21-L49

Also, this can verify that using `columnName` is apparently incorrect: 

<img width="1157" alt="Screenshot 2022-08-18 at 15 34 57" src="https://user-images.githubusercontent.com/15316889/185341770-acf70034-bfbe-43b3-9290-3737e4da7abf.png">
