### PR TITLE
feat: support partial unique indexes

### DIFF
--- a/lib/dialects/mssql/schema/mssql-tablecompiler.js
+++ b/lib/dialects/mssql/schema/mssql-tablecompiler.js
@@ -280,19 +280,23 @@ class TableCompiler_MSSQL extends TableCompiler {
    * Create a unique index.
    *
    * @param {string | string[]} columns
-   * @param {string | {indexName: undefined | string, deferrable?: 'not deferrable'|'deferred'|'immediate', useConstraint?: true|false }} indexName
+   * @param {string | {indexName: undefined | string, deferrable?: 'not deferrable'|'deferred'|'immediate', useConstraint?: true|false, predicate?: QueryBuilder }} indexName
    */
   unique(columns, indexName) {
     /** @type {string | undefined} */
     let deferrable;
     let useConstraint = false;
+    let predicate;
     if (isObject(indexName)) {
-      ({ indexName, deferrable, useConstraint } = indexName);
+      ({ indexName, deferrable, useConstraint, predicate } = indexName);
     }
     if (deferrable && deferrable !== 'not deferrable') {
       this.client.logger.warn(
         `mssql: unique index [${indexName}] will not be deferrable ${deferrable} because mssql does not support deferred constraints.`
       );
+    }
+    if (useConstraint && predicate) {
+      throw new Error('mssql cannot create constraint with predicate');
     }
     indexName = indexName
       ? this.formatter.wrap(indexName)
@@ -301,10 +305,6 @@ class TableCompiler_MSSQL extends TableCompiler {
     if (!Array.isArray(columns)) {
       columns = [columns];
     }
-
-    const whereAllTheColumnsAreNotNull = columns
-      .map((column) => this.formatter.columnize(column) + ' IS NOT NULL')
-      .join(' AND ');
 
     if (useConstraint) {
       // mssql supports unique indexes and unique constraints.
@@ -315,12 +315,18 @@ class TableCompiler_MSSQL extends TableCompiler {
         )})`
       );
     } else {
-      // make unique constraint that allows null https://stackoverflow.com/a/767702/360060
+      // default to making unique index that allows null https://stackoverflow.com/a/767702/360060
       // to be more or less compatible with other DBs (if any of the columns is NULL then "duplicates" are allowed)
+      const predicateQuery = predicate
+        ? ' ' + this.client.queryCompiler(predicate).where()
+        : ' WHERE ' +
+          columns
+            .map((column) => this.formatter.columnize(column) + ' IS NOT NULL')
+            .join(' AND ');
       this.pushQuery(
         `CREATE UNIQUE INDEX ${indexName} ON ${this.tableName()} (${this.formatter.columnize(
           columns
-        )}) WHERE ${whereAllTheColumnsAreNotNull}`
+        )})${predicateQuery}`
       );
     }
   }

--- a/lib/dialects/postgres/schema/pg-tablecompiler.js
+++ b/lib/dialects/postgres/schema/pg-tablecompiler.js
@@ -189,20 +189,44 @@ class TableCompiler_PG extends TableCompiler {
 
   unique(columns, indexName) {
     let deferrable;
+    let useConstraint = true;
+    let predicate;
     if (isObject(indexName)) {
-      ({ indexName, deferrable } = indexName);
+      ({ indexName, deferrable, useConstraint, predicate } = indexName);
+      if (useConstraint === undefined) {
+        useConstraint = !!deferrable || !predicate;
+      }
+    }
+    if (!useConstraint && deferrable && deferrable !== 'not deferrable') {
+      throw new Error('postgres cannot create deferrable index');
+    }
+    if (useConstraint && predicate) {
+      throw new Error('postgres cannot create constraint with predicate');
     }
     deferrable = deferrable ? ` deferrable initially ${deferrable}` : '';
     indexName = indexName
       ? this.formatter.wrap(indexName)
       : this._indexCommand('unique', this.tableNameRaw, columns);
-    this.pushQuery(
-      `alter table ${this.tableName()} add constraint ${indexName}` +
-        ' unique (' +
-        this.formatter.columnize(columns) +
-        ')' +
-        deferrable
-    );
+
+    if (useConstraint) {
+      this.pushQuery(
+        `alter table ${this.tableName()} add constraint ${indexName}` +
+          ' unique (' +
+          this.formatter.columnize(columns) +
+          ')' +
+          deferrable
+      );
+    } else {
+      const predicateQuery = predicate
+        ? ' ' + this.client.queryCompiler(predicate).where()
+        : '';
+
+      this.pushQuery(
+        `create unique index ${indexName} on ${this.tableName()} (${this.formatter.columnize(
+          columns
+        )})${predicateQuery}`
+      );
+    }
   }
 
   index(columns, indexName, options) {

--- a/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
@@ -132,8 +132,9 @@ class TableCompiler_SQLite3 extends TableCompiler {
   // Compile a unique key command.
   unique(columns, indexName) {
     let deferrable;
+    let predicate;
     if (isObject(indexName)) {
-      ({ indexName, deferrable } = indexName);
+      ({ indexName, deferrable, predicate } = indexName);
     }
     if (deferrable && deferrable !== 'not deferrable') {
       this.client.logger.warn(
@@ -144,8 +145,13 @@ class TableCompiler_SQLite3 extends TableCompiler {
       ? this.formatter.wrap(indexName)
       : this._indexCommand('unique', this.tableNameRaw, columns);
     columns = this.formatter.columnize(columns);
+
+    const predicateQuery = predicate
+      ? ' ' + this.client.queryCompiler(predicate).where()
+      : '';
+
     this.pushQuery(
-      `create unique index ${indexName} on ${this.tableName()} (${columns})`
+      `create unique index ${indexName} on ${this.tableName()} (${columns})${predicateQuery}`
     );
   }
 

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -880,6 +880,22 @@ describe('PostgreSQL SchemaBuilder', function () {
     );
   });
 
+  it('adding unique index', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.unique('foo', {
+          indexName: 'bar',
+          useConstraint: true,
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'create unique index "bar" on "users" ("foo")'
+    );
+  });
+
   it('adding index without value', function () {
     tableSql = client
       .schemaBuilder()
@@ -1011,6 +1027,85 @@ describe('PostgreSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal(
       'create index "baz" on "users" ("foo", "bar") where "email" is not null'
     );
+  });
+
+  it('adding unique index with a predicate', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.unique(['foo', 'bar'], {
+          indexName: 'baz',
+          predicate: client.queryBuilder().whereRaw('email = "foo@bar"'),
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'create unique index "baz" on "users" ("foo", "bar") where email = "foo@bar"'
+    );
+  });
+
+  it('adding unique index with an index type and a predicate', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.unique(['foo', 'bar'], {
+          indexName: 'baz',
+          indexType: 'gist',
+          predicate: client.queryBuilder().whereRaw('email = "foo@bar"'),
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'create unique index "baz" on "users" using gist ("foo", "bar") where email = "foo@bar"'
+    );
+  });
+
+  it('adding unique index with a where not null predicate', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.unique(['foo', 'bar'], {
+          indexName: 'baz',
+          predicate: client.queryBuilder().whereNotNull('email'),
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'create unique index "baz" on "users" ("foo", "bar") where "email" is not null'
+    );
+  });
+
+  it('throws when adding unique constraint with a predicate', function () {
+    expect(() => {
+      client
+        .schemaBuilder()
+        .table('users', function (table) {
+          table.unique(['foo', 'bar'], {
+            indexName: 'baz',
+            useConstraint: true,
+            predicate: client.queryBuilder().whereNotNull('email'),
+          });
+        })
+        .toSQL();
+    }).to.throw('postgres cannot create constraint with predicate');
+  });
+
+  it('throws when adding unique index with deferrable set', function () {
+    expect(() => {
+      client
+        .schemaBuilder()
+        .table('users', function (table) {
+          table.unique(['foo', 'bar'], {
+            indexName: 'baz',
+            useConstraint: false,
+            deferrable: 'immediate',
+          });
+        })
+        .toSQL();
+    }).to.throw('postgres cannot create deferrable index');
   });
 
   it('adding incrementing id', function () {

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -886,7 +886,7 @@ describe('PostgreSQL SchemaBuilder', function () {
       .table('users', function (table) {
         table.unique('foo', {
           indexName: 'bar',
-          useConstraint: true,
+          useConstraint: false,
         });
       })
       .toSQL();
@@ -1042,23 +1042,6 @@ describe('PostgreSQL SchemaBuilder', function () {
     equal(1, tableSql.length);
     expect(tableSql[0].sql).to.equal(
       'create unique index "baz" on "users" ("foo", "bar") where email = "foo@bar"'
-    );
-  });
-
-  it('adding unique index with an index type and a predicate', function () {
-    tableSql = client
-      .schemaBuilder()
-      .table('users', function (table) {
-        table.unique(['foo', 'bar'], {
-          indexName: 'baz',
-          indexType: 'gist',
-          predicate: client.queryBuilder().whereRaw('email = "foo@bar"'),
-        });
-      })
-      .toSQL();
-    equal(1, tableSql.length);
-    expect(tableSql[0].sql).to.equal(
-      'create unique index "baz" on "users" using gist ("foo", "bar") where email = "foo@bar"'
     );
   });
 

--- a/test/unit/schema-builder/sqlite3.js
+++ b/test/unit/schema-builder/sqlite3.js
@@ -547,6 +547,38 @@ describe('SQLite SchemaBuilder', function () {
     );
   });
 
+  it('adding unique index with a predicate', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.unique(['foo', 'bar'], {
+          indexName: 'baz',
+          predicate: client.queryBuilder().whereRaw('email = "foo@bar"'),
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'create unique index `baz` on `users` (`foo`, `bar`) where email = "foo@bar"'
+    );
+  });
+
+  it('adding unique index with a where not null predicate', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.unique(['foo', 'bar'], {
+          indexName: 'baz',
+          predicate: client.queryBuilder().whereNotNull('email'),
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'create unique index `baz` on `users` (`foo`, `bar`) where `email` is not null'
+    );
+  });
+
   it('adding incrementing id', function () {
     tableSql = client
       .schemaBuilder()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2513,6 +2513,7 @@ export declare namespace Knex {
         storageEngineIndexType?: string;
         deferrable?: deferrableType;
         useConstraint?: boolean;
+        predicate?: QueryBuilder;
       }>
     ): TableBuilder;
     /** @deprecated */


### PR DESCRIPTION
Adds MSSQL, PostgreSQL, and SQLite support for partial unique indexes, heavily based on #4768.

The Postgres driver defaults to creating a unique constraint instead of an index, so Postgres support for `useConstraint` was added, defaulting to `true` without predicate and `false` with predicate. The alternative would be to always default to `useConstraint: true`, but then `predicate` would error by default unless `useConstraint: false` is explicitly specified. Dunno which is better.

Docs: knex/documentation#449

Fixes #4870