### PR TITLE
Fix changing the default value of a boolean column in SQLite

### DIFF
--- a/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
@@ -51,7 +51,7 @@ class TableCompiler_SQLite3 extends TableCompiler {
         const type = col.getColumnType();
 
         const defaultTo = col.modified['defaultTo']
-          ? formatDefault(col.modified['defaultTo'][0], type, this.client)
+          ? formatDefault(col.modified['defaultTo'][0], col.type, this.client)
           : null;
 
         const notNull =


### PR DESCRIPTION
The `formatDefault()` function expects the type parameter to be a Knex internal type instead of a SQL type.