### PR TITLE
Fix lib/.gitignore path separator on Windows.

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -7,4 +7,4 @@
 **/*.js.map
 
 # Do not include .js files from .ts files
-dialects\index.js
+dialects/index.js

--- a/scripts/update_gitignore_for_tsc_output.js
+++ b/scripts/update_gitignore_for_tsc_output.js
@@ -64,7 +64,8 @@ function main(cliCommand) {
       const relativeTsPath = filepath.slice(libDirectory.length + 1)
       // Swaps .ts for .js file ending
       const relativeJsPath = relativeTsPath.slice(0, relativeTsPath.length - 3) + '.js'
-      return relativeJsPath
+      // Always use POSIX-style path separators - .gitignore requires it
+      return relativeJsPath.split(path.sep).join(path.posix.sep);
     })
     const jsFilesToIgnoreString = jsFilesToIgnore.join('\n')
     const libGitignorePath = path.join(libDirectory, '.gitignore')


### PR DESCRIPTION
When working on Windows, the script responsible for generating `lib/.gitignore` when executed by git hooks uses the wrong path separator for .gitignore files, preventing TypeScript-generated JS files from being consistently ignored on Windows machines.

On Windows only, the generated path uses the Windows-style backslash path separator due to node's path package conventions. .gitignore syntax always requires use of the POSIX-style forward slash. ([Reference](https://git-scm.com/docs/gitignore#_pattern_format)). This simply normalizes all path separators to forward slashes in the outputted .gitignore file.

Just a very minor issue I encountered when working with the codebase that I had to fix.