### PR TITLE
fix: add missing type for 'expirationChecker' on PgConnectionConfig

### DIFF
--- a/test-tsd/pg-config.test-d.ts
+++ b/test-tsd/pg-config.test-d.ts
@@ -3,7 +3,7 @@ import { expectAssignable } from 'tsd';
 import {Knex} from '../types';
 import * as stream from "stream";
 
-const connectionConfig: Knex.PgConnectionConfig = {
+expectAssignable<Knex.PgConnectionConfig>({
   user: '',
   database: '',
   password: '',
@@ -25,6 +25,4 @@ const connectionConfig: Knex.PgConnectionConfig = {
   },
   options: '',
   expirationChecker: () => {return true;},
-};
-
-expectAssignable<Knex.PgConnectionConfig>(connectionConfig);
+});

--- a/test-tsd/pg-config.test-d.ts
+++ b/test-tsd/pg-config.test-d.ts
@@ -1,0 +1,30 @@
+import { expectAssignable } from 'tsd';
+
+import {Knex} from '../types';
+import * as stream from "stream";
+
+const connectionConfig: Knex.PgConnectionConfig = {
+  user: '',
+  database: '',
+  password: '',
+  port: 1,
+  host: '',
+  connectionString: '',
+  keepAlive: true,
+  stream: new stream.Duplex(),
+  statement_timeout: false,
+  parseInputDatesAsUTC: false,
+  ssl: true,
+  query_timeout: 2,
+  keepAliveInitialDelayMillis: 3,
+  idle_in_transaction_session_timeout: 4,
+  application_name: '',
+  connectionTimeoutMillis: 5,
+  types: {
+    getTypeParser: () => {},
+  },
+  options: '',
+  expirationChecker: () => {return true;},
+};
+
+expectAssignable<Knex.PgConnectionConfig>(connectionConfig);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3024,6 +3024,7 @@ export declare namespace Knex {
     connectionTimeoutMillis?: number;
     types?: PgCustomTypesConfig;
     options?: string;
+    expirationChecker?(): boolean;
   }
 
   type PgGetTypeParser = (oid: number, format: string) => any;


### PR DESCRIPTION
expirationChecker currently works with PgConnectionConfig if you ignore the type error.