### PR TITLE
Fixed issue with bigincrements not working with composite key in MySQL - #5341

### DIFF
--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -160,6 +160,14 @@ class TableCompiler_MySQL extends TableCompiler {
             }
           });
         }
+        const bigIncrementsCols = this._getBigIncrementsColumnNames();
+        if (bigIncrementsCols.length) {
+          bigIncrementsCols.forEach((c) => {
+            if (!columns.includes(c)) {
+              columns.unshift(c);
+            }
+          });
+        }
       }
 
       return `,${constraintName} primary key (${this.formatter.columnize(
@@ -292,10 +300,19 @@ class TableCompiler_MySQL extends TableCompiler {
 
     const primaryCols = columns;
     let incrementsCols = [];
+    let bigIncrementsCols = [];
     if (this.grouped.columns) {
       incrementsCols = this._getIncrementsColumnNames();
       if (incrementsCols) {
         incrementsCols.forEach((c) => {
+          if (!primaryCols.includes(c)) {
+            primaryCols.unshift(c);
+          }
+        });
+      }
+      bigIncrementsCols = this._getBigIncrementsColumnNames();
+      if (bigIncrementsCols) {
+        bigIncrementsCols.forEach((c) => {
           if (!primaryCols.includes(c)) {
             primaryCols.unshift(c);
           }
@@ -314,6 +331,13 @@ class TableCompiler_MySQL extends TableCompiler {
         `alter table ${this.tableName()} modify column ${this.formatter.columnize(
           incrementsCols
         )} int unsigned not null auto_increment`
+      );
+    }
+    if (bigIncrementsCols.length) {
+      this.pushQuery(
+        `alter table ${this.tableName()} modify column ${this.formatter.columnize(
+          bigIncrementsCols
+        )} bigint unsigned not null auto_increment`
       );
     }
   }

--- a/lib/schema/tablecompiler.js
+++ b/lib/schema/tablecompiler.js
@@ -418,6 +418,12 @@ class TableCompiler {
       .filter((c) => c.builder._type === 'increments')
       .map((c) => c.builder._args[0]);
   }
+
+  _getBigIncrementsColumnNames() {
+    return this.grouped.columns
+      .filter((c) => c.builder._type === 'bigincrements')
+      .map((c) => c.builder._args[0]);
+  }
 }
 
 TableCompiler.prototype.pushQuery = pushQuery;

--- a/test/unit/schema-builder/mysql.js
+++ b/test/unit/schema-builder/mysql.js
@@ -723,6 +723,25 @@ module.exports = function (dialect) {
       );
     });
 
+    it('test basic create table with composite key on big incrementing column + other', function () {
+      tableSql = client
+        .schemaBuilder()
+        .createTable('users', function (table) {
+          table.primary(['userId', 'name']);
+          table.bigincrements('userId');
+          table.string('name');
+        })
+        .toSQL();
+
+      equal(2, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'create table `users` (`userId` bigint unsigned not null, `name` varchar(255), primary key (`userId`, `name`))'
+      );
+      expect(tableSql[1].sql).to.equal(
+        'alter table `users` modify column `userId` bigint unsigned not null auto_increment'
+      );
+    });
+
     it('test adding column after another column', function () {
       tableSql = client
         .schemaBuilder()


### PR DESCRIPTION
Fixes issue with bigincrements not working when having a composite keys since the alter table is not present for bigincrements as descriped in #5341 .

Also fixes issue when using bigincrements and the field was not added as a primary key. The below currently fails since logic to handle bigincrements in the primary key function is missing.

```
knex.schema.createTable("test_table", table => {
        table.primary(['name']);
        table.bigincrements('userId');
        table.string('name');
}
```



