### PR TITLE
fix: remove sqlite warning for default value

### DIFF
--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -28,14 +28,6 @@ class Client_SQLite3 extends Client {
           '(see docs https://knexjs.org/guide/#configuration-options)'
       );
     }
-
-    if (config.useNullAsDefault === undefined) {
-      this.logger.warn(
-        'sqlite does not support inserting default values. Set the ' +
-          '`useNullAsDefault` flag to hide this warning. ' +
-          '(see docs https://knexjs.org/guide/query-builder.html#insert).'
-      );
-    }
   }
 
   _driver() {


### PR DESCRIPTION
sqlite support default values. see https://www.sqlite.org/lang_createtable.html#the_default_clause