### PR TITLE
feat(pg): implement QueryBuilder#updateFrom

### DIFF
--- a/lib/dialects/postgres/query/pg-querybuilder.js
+++ b/lib/dialects/postgres/query/pg-querybuilder.js
@@ -1,6 +1,11 @@
 const QueryBuilder = require('../../../query/querybuilder.js');
 
 module.exports = class QueryBuilder_PostgreSQL extends QueryBuilder {
+  updateFrom(name) {
+    this._single.updateFrom = name;
+    return this;
+  }
+
   using(tables) {
     this._single.using = tables;
     return this;

--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -50,12 +50,13 @@ class QueryCompiler_PG extends QueryCompiler {
     const withSQL = this.with();
     const updateData = this._prepUpdate(this.single.update);
     const wheres = this.where();
-    const { returning } = this.single;
+    const { returning, updateFrom } = this.single;
     return {
       sql:
         withSQL +
         `update ${this.single.only ? 'only ' : ''}${this.tableName} ` +
         `set ${updateData.join(', ')}` +
+        this._updateFrom(updateFrom) +
         (wheres ? ` ${wheres}` : '') +
         this._returning(returning),
       returning,
@@ -139,6 +140,10 @@ class QueryCompiler_PG extends QueryCompiler {
 
   _returning(value) {
     return value ? ` returning ${this.formatter.columnize(value)}` : '';
+  }
+
+  _updateFrom(name) {
+    return name ? ` from ${this.formatter.wrap(name)}` : '';
   }
 
   _ignore(columns) {

--- a/test/integration2/query/update/updates.spec.js
+++ b/test/integration2/query/update/updates.spec.js
@@ -3,6 +3,7 @@
 const { expect } = require('chai');
 
 const { TEST_TIMESTAMP } = require('../../../util/constants');
+const { isPostgreSQL } = require('../../../util/db-helpers');
 const {
   getAllDbs,
   getKnexForDb,
@@ -535,6 +536,10 @@ describe('Updates', function () {
       });
 
       it('should allow explicit from', async function () {
+        if (!isPostgreSQL(knex)) {
+          return this.skip();
+        }
+
         await knex('accounts')
           .update({ last_name: 'olivier' })
           .with('withClause', function () {

--- a/test/integration2/query/update/updates.spec.js
+++ b/test/integration2/query/update/updates.spec.js
@@ -534,6 +534,26 @@ describe('Updates', function () {
         expect(results[0].last_name).to.equal('olivier');
       });
 
+      it('should allow explicit from', async function () {
+        await knex('accounts')
+          .update({ last_name: 'olivier' })
+          .with('withClause', function () {
+            this.select('id', 'last_name')
+              .from('accounts')
+              .where('email', '=', 'test1@example.com');
+          })
+          .updateFrom('withClause')
+          .where('withClause.id', '=', knex.ref('accounts.id'))
+          .testSql(function (tester) {
+            tester(
+              'pg',
+              'with "withClause" as (select "id", "last_name" from "accounts" where "email" = ?) update "accounts" set "last_name" = ? from "withClause" where "withClause"."id" = "accounts"."id"',
+              ['test1@example.com', 'olivier'],
+              1
+            );
+          });
+      });
+
       it('should escaped json objects when update value #5059', async function () {
         await knex.schema.dropTableIfExists('testing');
         await knex.schema.createTable('testing', (t) => {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -6080,6 +6080,22 @@ describe('QueryBuilder', () => {
     );
   });
 
+  it('update from table', () => {
+    testsql(
+      qb()
+        .update({ email: 'foo', name: 'bar' })
+        .table('users')
+        .updateFrom('others')
+        .where('id', '=', 1),
+      {
+        pg: {
+          sql: 'update "users" set "email" = ?, "name" = ? from "others" where "id" = ?',
+          bindings: ['foo', 'bar', 1],
+        },
+      }
+    );
+  });
+
   it('should not update columns undefined values', () => {
     testsql(
       qb()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1151,6 +1151,8 @@ export declare namespace Knex {
 
     onConflict(): OnConflictQueryBuilder<TRecord, TResult>;
 
+    updateFrom: Table<TRecord, TResult>;
+
     del(
       returning: '*',
       options?: DMLOptions


### PR DESCRIPTION
Documentation PR: https://github.com/knex/documentation/pull/476

Introduces the `updateFrom` querybuilder method for PostgreSQL. This allows the creation of `UPDATE <table> SET <data> FROM <name>` queries, which may reference relations or CTEs outside of the target table.

I opted for creating a new QB method (`updateFrom`) to avoid conflict or weird interactions or unexpected changes to behaviour with the target table already being inferred from `knex(table)`, `knex.table(table)`, etc.