### PR TITLE
[TypeScript] Fix raw bindings typing

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2117,7 +2117,7 @@ export declare namespace Knex {
     <TResult2 = TResult>(value: Value): Raw<TResult2>;
     <TResult2 = TResult>(
       sql: string,
-      ...bindings: readonly RawBinding[]
+      binding: RawBinding
     ): Raw<TResult2>;
     <TResult2 = TResult>(
       sql: string,


### PR DESCRIPTION
As per the [documentation](https://knexjs.org/guide/raw.html#raw-parameter-binding), the `bindings` param can be a single value, an array of values, or a dictionary of named binding values.

The type was incorrect, as it implied that one could bind multiple values by passing multiple parameters, rather than using an array:

```ts
// This was OK before, because TS expects (sql: string, ...bindings: RawBinding[])
// Expectation was bindings ['value for a', 'value for 'b']
// Actual was bindings ['value for a'] and the second binding was ignored
knex().raw('select * from table where a = ? and b = ?', 'value for a', 'value for b');
```

With the correct typing, the above code will now throw a type error "Expected 1-2 arguments, but got 3".