### PR TITLE
Custom Naming Convention For Migration Files

### DIFF
--- a/lib/migrations/migrate/MigrationGenerator.js
+++ b/lib/migrations/migrate/MigrationGenerator.js
@@ -49,10 +49,10 @@ class MigrationGenerator {
     );
   }
 
-  _getNewMigrationPath(name, getNewMigrationName) {
+  _getNewMigrationPath(name) {
     const fileName = (
-      typeof getNewMigrationName === 'function'
-        ? getNewMigrationName
+      typeof this.config.getNewMigrationName === 'function'
+        ? this.config.getNewMigrationName
         : this._getNewMigrationName.bind(this)
     )(name);
     const dirs = this._absoluteConfigDirs();
@@ -62,8 +62,8 @@ class MigrationGenerator {
 
   // Write a new migration to disk, using the config and generated filename,
   // passing any `variables` given in the config to the template.
-  async _writeNewMigration(name, getNewMigrationName) {
-    const migrationPath = this._getNewMigrationPath(name, getNewMigrationName);
+  async _writeNewMigration(name) {
+    const migrationPath = this._getNewMigrationPath(name);
     await writeJsFileUsingTemplate(
       migrationPath,
       this._getStubPath(),

--- a/lib/migrations/migrate/MigrationGenerator.js
+++ b/lib/migrations/migrate/MigrationGenerator.js
@@ -18,7 +18,10 @@ class MigrationGenerator {
       );
     }
     await this._ensureFolder();
-    const createdMigrationFilePath = await this._writeNewMigration(name);
+    const createdMigrationFilePath = await this._writeNewMigration(
+      name,
+      this.config.getNewMigrationName
+    );
     return createdMigrationFilePath;
   }
 
@@ -41,11 +44,17 @@ class MigrationGenerator {
 
   _getNewMigrationName(name) {
     if (name[0] === '-') name = name.slice(1);
-    return yyyymmddhhmmss() + '_' + name + '.' + this.config.extension.split('-')[0];
+    return (
+      yyyymmddhhmmss() + '_' + name + '.' + this.config.extension.split('-')[0]
+    );
   }
 
-  _getNewMigrationPath(name) {
-    const fileName = this._getNewMigrationName(name);
+  _getNewMigrationPath(name, getNewMigrationName) {
+    const fileName = (
+      typeof getNewMigrationName === 'function'
+        ? getNewMigrationName
+        : this._getNewMigrationName.bind(this)
+    )(name);
     const dirs = this._absoluteConfigDirs();
     const dir = dirs.slice(-1)[0]; // Get last specified directory
     return path.join(dir, fileName);
@@ -53,8 +62,8 @@ class MigrationGenerator {
 
   // Write a new migration to disk, using the config and generated filename,
   // passing any `variables` given in the config to the template.
-  async _writeNewMigration(name) {
-    const migrationPath = this._getNewMigrationPath(name);
+  async _writeNewMigration(name, getNewMigrationName) {
+    const migrationPath = this._getNewMigrationPath(name, getNewMigrationName);
     await writeJsFileUsingTemplate(
       migrationPath,
       this._getStubPath(),

--- a/lib/migrations/migrate/MigrationGenerator.js
+++ b/lib/migrations/migrate/MigrationGenerator.js
@@ -18,10 +18,7 @@ class MigrationGenerator {
       );
     }
     await this._ensureFolder();
-    const createdMigrationFilePath = await this._writeNewMigration(
-      name,
-      this.config.getNewMigrationName
-    );
+    const createdMigrationFilePath = await this._writeNewMigration(name);
     return createdMigrationFilePath;
   }
 
@@ -44,9 +41,7 @@ class MigrationGenerator {
 
   _getNewMigrationName(name) {
     if (name[0] === '-') name = name.slice(1);
-    return (
-      yyyymmddhhmmss() + '_' + name + '.' + this.config.extension.split('-')[0]
-    );
+    return yyyymmddhhmmss() + '_' + name + '.' + this.config.extension.split('-')[0];
   }
 
   _getNewMigrationPath(name) {

--- a/lib/migrations/migrate/migrator-configuration-merger.js
+++ b/lib/migrations/migrate/migrator-configuration-merger.js
@@ -6,6 +6,7 @@ const defaultLogger = new Logger();
 const CONFIG_DEFAULT = Object.freeze({
   extension: 'js',
   loadExtensions: DEFAULT_LOAD_EXTENSIONS,
+  getNewMigrationName: null,
   tableName: 'knex_migrations',
   schemaName: null,
   directory: './migrations',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3100,6 +3100,7 @@ export declare namespace Knex {
     directory?: string | readonly string[];
     extension?: string;
     stub?: string;
+    getNewMigrationName?: (name: string) => string;
     tableName?: string;
     schemaName?: string;
     disableTransactions?: boolean;


### PR DESCRIPTION
Documentation: https://github.com/knex/documentation/pull/484

Purpose: Provide the ability to have a custom naming convention for migration files.

Reasoning: Some projects may want to use a different naming convention other than the default for what this library provides.
