### PR TITLE
fix: only stringify JSON if insert value is an array containing plain object

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -401,7 +401,8 @@ class Client extends EventEmitter {
       if (i > 0) str += ', ';
       let value = values[i];
       // json columns can have object in values.
-      if (isPlainObject(value) || Array.isArray(value)) {
+      // check for plain object and array containing at least one plain object
+      if (isPlainObject(value) || (Array.isArray(value) && value.some(isPlainObject))) {
         value = JSON.stringify(value);
       }
       str += this.parameter(


### PR DESCRIPTION
Related to https://github.com/knex/knex/issues/5430 regression

The regression is introduced in [PR](https://github.com/knex/knex/pull/5321) follow from a feature requested [5320](https://github.com/knex/knex/issues/5320)

this PR is to add an extra check for value, the check is now also check if the value is an array and containing at least one plain object. 
the PR is trying to refine the feature implemented by @mingoing (rather than rollback the commit)

also add some tests heavily influenced by the PR from @loren138 (https://github.com/knex/knex/pull/5439)