### PR TITLE
tests(insert): add insert tests for json, text array and integer array

### DIFF
--- a/test/integration2/query/insert/inserts.spec.js
+++ b/test/integration2/query/insert/inserts.spec.js
@@ -31,7 +31,10 @@ const {
   createTestTableTwo,
   createDataType,
 } = require('../../../util/tableCreatorHelper');
-const { assertNumber } = require('../../../util/assertHelper');
+const {
+  assertNumber,
+  assertJsonEquals,
+} = require('../../../util/assertHelper');
 
 describe('Inserts', function () {
   getAllDbs().forEach((db) => {
@@ -2132,6 +2135,172 @@ describe('Inserts', function () {
               [{ id: 1 }]
             );
           });
+      });
+
+      it('insert json object to json column', async function () {
+        if (!isPostgreSQL(knex)) {
+          return this.skip();
+        }
+        const tableName = 'json';
+        const jsonObject = {
+          foo: {
+            bar: 'baz',
+          },
+        };
+
+        await knex.schema.dropTableIfExists(tableName);
+        await knex.schema.createTable(tableName, (table) => {
+          table.increments();
+          table.string('name');
+          table.jsonb('content');
+        });
+
+        await knex(tableName)
+          .insert(
+            {
+              name: 'json_object',
+              content: jsonObject,
+            },
+            'id'
+          )
+          .testSql(function (tester) {
+            tester(
+              'pg',
+              `insert into "${tableName}" ("content", "name") values (?, ?) returning "id"`,
+              [JSON.stringify(jsonObject), 'json_object']
+            );
+          })
+          .then(([insertResult]) =>
+            knex(tableName).where('id', insertResult.id)
+          )
+          .then((result) => {
+            expect(result.length).to.equal(1);
+            assertJsonEquals(result[0].content, jsonObject);
+          });
+      });
+
+      it('insert number array to integer ARRAY column', async function () {
+        if (!isPostgreSQL(knex)) {
+          return this.skip();
+        }
+        const tableName = 'integer_array';
+        const integerArrayContent = [1, 2, 3, 42, -100];
+
+        await knex.schema.dropTableIfExists(tableName);
+        await knex.schema.createTable(tableName, (table) => {
+          table.increments();
+          table.string('name');
+          table.specificType('content', 'integer ARRAY');
+        });
+
+        await knex(tableName)
+          .insert(
+            {
+              name: 'integer_array',
+              content: integerArrayContent,
+            },
+            'id'
+          )
+          .testSql(function (tester) {
+            tester(
+              'pg',
+              `insert into "${tableName}" ("content", "name") values (?, ?) returning "id"`,
+              [integerArrayContent, 'integer_array']
+            );
+          })
+          .then(([insertResult]) =>
+            knex(tableName).where('id', insertResult.id)
+          )
+          .then((result) => {
+            expect(result.length).to.equal(1);
+            assertJsonEquals(result[0].content, integerArrayContent);
+          });
+      });
+
+      describe('text array', () => {
+        const tableName = 'text_array';
+
+        beforeEach(async () => {
+          if (!isPostgreSQL(knex)) {
+            return true;
+          }
+          await knex.schema.dropTableIfExists(tableName);
+          await knex.schema.createTable(tableName, (table) => {
+            table.increments();
+            table.string('name');
+            table.specificType('content', 'text ARRAY');
+          });
+        });
+
+        it('#5365 should insert string array to text ARRAY column', async function () {
+          if (!isPostgreSQL(knex)) {
+            return this.skip();
+          }
+
+          const stringArrayContent = ['SOME TEXT', 'SOME OTHER TEXT'];
+
+          await knex(tableName)
+            .insert(
+              {
+                name: 'array_of_string',
+                content: stringArrayContent,
+              },
+              'id'
+            )
+            .testSql(function (tester) {
+              tester(
+                'pg',
+                `insert into "${tableName}" ("content", "name") values (?, ?) returning "id"`,
+                [stringArrayContent, 'array_of_string'],
+                [{ id: 1 }]
+              );
+            })
+            .then(([insertResult]) =>
+              knex(tableName).where('id', insertResult.id)
+            )
+            .then((result) => {
+              expect(result.length).to.equal(1);
+              expect(result[0].content).to.deep.equal(stringArrayContent);
+            });
+        });
+
+        it(`#5430 should insert data to text array column if it's an array of object`, async function () {
+          if (!isPostgreSQL(knex)) {
+            return this.skip();
+          }
+
+          const arrayOfObject = [
+            {
+              foo: {
+                bar: 'baz',
+              },
+            },
+          ];
+
+          await knex(tableName)
+            .insert(
+              {
+                name: 'array_of_object',
+                content: arrayOfObject,
+              },
+              'id'
+            )
+            .testSql(function (tester) {
+              tester(
+                'pg',
+                `insert into "${tableName}" ("content", "name") values (?, ?) returning "id"`,
+                [arrayOfObject, 'array_of_object'],
+                [{ id: 1 }]
+              );
+            })
+            .then(([insertResult]) =>
+              knex(tableName).where('id', insertResult.id)
+            )
+            .then((result) => {
+              expect(result.length).to.equal(1);
+              assertJsonEquals(result[0].content, arrayOfObject);
+            });
+        });
       });
     });
   });


### PR DESCRIPTION
TLDR: add various tests case for the PR https://github.com/knex/knex/pull/5431 (rollback of https://github.com/knex/knex/pull/5321)

- insert tests for array of object into `text array` column #5430
- insert tests for array of integer into `integer array` column #5365
- insert tests for array of string into `text array` column #5365
- insert tests for json object into `jsonb` column

the PR https://github.com/knex/knex/pull/5431 by @caseywebdev should be merged first


A little bit more explanation: 

#5365 : user want to insert array of string into `text array` column, or array of integer into `integer array` column, which is valid and should be inserted, but the PR https://github.com/knex/knex/pull/5321 merged sometime ago break it (it will always stringify the array to json string)

@kibertoad At first I thought I can add a check for Array containing at least one plainObject with my previous PR https://github.com/knex/knex/pull/5444, but turn out it will not solve the #5430, my previous changes will need user to input a valid array of string into `text array` column

#5430 : user want to insert array of object into `text array` column (worked in previous version of knex). the PR https://github.com/knex/knex/pull/5321 break it (it will always stringify the array of object to json string)