### PR TITLE
Add `nativeBindings` option to `better-sqlite3` options

### DIFF
--- a/lib/dialects/better-sqlite3/index.js
+++ b/lib/dialects/better-sqlite3/index.js
@@ -9,8 +9,10 @@ class Client_BetterSQLite3 extends Client_SQLite3 {
 
   // Get a raw connection from the database, returning a promise with the connection object.
   async acquireRawConnection() {
+    const options = this.connectionSettings.options || {};
+
     return new this.driver(this.connectionSettings.filename, {
-      nativeBinding: this.connectionSettings.options?.nativeBinding,
+      nativeBinding: options.nativeBinding,
     });
   }
 

--- a/lib/dialects/better-sqlite3/index.js
+++ b/lib/dialects/better-sqlite3/index.js
@@ -9,7 +9,9 @@ class Client_BetterSQLite3 extends Client_SQLite3 {
 
   // Get a raw connection from the database, returning a promise with the connection object.
   async acquireRawConnection() {
-    return new this.driver(this.connectionSettings.filename);
+    return new this.driver(this.connectionSettings.filename, {
+      nativeBinding: this.connectionSettings.options?.nativeBinding,
+    });
   }
 
   // Used to explicitly close a connection, called internally by the pool when

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2730,6 +2730,7 @@ export declare namespace Knex {
     | PgConnectionConfig
     | RedshiftConnectionConfig
     | Sqlite3ConnectionConfig
+    | BetterSqlite3ConnectionConfig
     | SocketConnectionConfig;
 
   type ConnectionConfigProvider =
@@ -3042,6 +3043,14 @@ export declare namespace Knex {
     flags?: string[];
     debug?: boolean;
     expirationChecker?(): boolean;
+  }
+
+  /** Used with `better-sqlite3` adapter */
+  interface BetterSqlite3ConnectionConfig {
+    filename: string;
+    options?: {
+      nativeBinding?: string;
+    };
   }
 
   interface SocketConnectionConfig {


### PR DESCRIPTION
I have a project where I'm bundling knex and better-sqlite3 into a single file and when running it the driver can't find the included binding file which is placed adjacent to the running file.

This can be fixed by setting `new Database(path, { nativeBinding: "path/to/binding.node" })` but this is currently impossible to do with knex.