### PR TITLE
fix() manually close source stream

### DIFF
--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -72,6 +72,24 @@ class Runner {
       this.client.releaseConnection(this.connection);
     });
 
+    // If the stream is manually destroyed, the close event is not
+    // propagated to the top of the pipe chain. We need to manually verify
+    // that the source stream is closed and if not, manually destroy it.
+    stream.on('pipe', (sourceStream) => {
+      const cleanSourceStream = () => {
+        if (!sourceStream.closed) {
+          sourceStream.destroy();
+        }
+      };
+
+      // Stream already closed, cleanup immediately
+      if (stream.closed) {
+        cleanSourceStream();
+      } else {
+        stream.on('close', cleanSourceStream);
+      }
+    });
+
     const connectionAcquirePromise = this.ensureConnection(
       ensureConnectionStreamCallback,
       {

--- a/test/integration2/query/misc/additional.spec.js
+++ b/test/integration2/query/misc/additional.spec.js
@@ -128,7 +128,7 @@ describe('Additional', function () {
           });
         });
 
-        it('should close the connection when a stream query iteration errors', async function () {
+        it('should release the connection when a stream query iteration errors', async function () {
           const spy = sinon.spy(knex.client, 'releaseConnection');
 
           const stream = knex.raw('VALUES (1), (2), (3)').stream();
@@ -144,6 +144,27 @@ describe('Additional', function () {
 
           expect(spy).to.have.been.called;
           spy.restore();
+        });
+
+        it('should close the db connection when prematurely closing a stream', async function () {
+          await knex('accounts').truncate();
+          await insertAccounts(knex, 'accounts');
+
+          const stream = knex
+            .raw('VALUES (1), (2), (3)')
+            .stream({ batchSize: 1 });
+
+          // eslint-disable-next-line no-unused-vars
+          for await (const _ of stream) {
+            stream.destroy();
+            break;
+          }
+
+          await new Promise((res) => setTimeout(res, 50));
+
+          // Will timeout if the connection is in the pool, but not closed
+          this.timeout(1000);
+          await knex('accounts').limit(1);
         });
 
         it('should process response done through a stream', async () => {


### PR DESCRIPTION
In case where the knex stream is closed manually, the source stream is not closed. This is due to the fact that close event is not propagated up the pipe chain.

The proposed change is to add another close event handler, but only if the stream get pipped to. This close handler manually closes the source stream if it's not already closed.

For the integration test, I don't know if there is a better way to do it. Is there another way to validate that the connection is released from the database? It seems to work fine, since removing the line 81 (`sourceStream.destroy()`) fails with the timeout.
