### PR TITLE
fix(sqlite): append RETURNING statement when insert empty row

### DIFF
--- a/lib/dialects/sqlite3/query/sqlite-querycompiler.js
+++ b/lib/dialects/sqlite3/query/sqlite-querycompiler.js
@@ -42,13 +42,29 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
         insertValues[0] &&
         isEmpty(insertValues[0])
       ) {
+        sql += this._emptyInsertValue;
+        const { returning } = this.single;
+
+        if (returning) {
+          sql += this._returning(returning);
+        }
+
         return {
-          sql: sql + this._emptyInsertValue,
+          sql,
+          returning,
         };
       }
     } else if (typeof insertValues === 'object' && isEmpty(insertValues)) {
+      sql += this._emptyInsertValue;
+      const { returning } = this.single;
+
+      if (returning) {
+        sql += this._returning(returning);
+      }
+
       return {
-        sql: sql + this._emptyInsertValue,
+        sql,
+        returning,
       };
     }
 


### PR DESCRIPTION
when on sqlite:

`knex(tableName).insert({}).returning(['field1', 'field2'])`

No `returning` sql statement was appended.