### PR TITLE
Use implicit check on json fields for OracleDB

### DIFF
--- a/lib/dialects/oracledb/schema/oracledb-columncompiler.js
+++ b/lib/dialects/oracledb/schema/oracledb-columncompiler.js
@@ -4,7 +4,7 @@ const { isObject } = require('../../../util/is');
 class ColumnCompiler_Oracledb extends ColumnCompiler_Oracle {
   constructor() {
     super(...arguments);
-    this.modifiers = ['defaultTo', 'nullable', 'comment'];
+    this.modifiers = ['defaultTo', 'nullable', 'comment', 'checkJson'];
     this._addCheckModifiers();
   }
 
@@ -38,13 +38,19 @@ class ColumnCompiler_Oracledb extends ColumnCompiler_Oracle {
   }
 
   json() {
-    return `varchar2(4000) check (${this.formatter.columnize(
-      this.getColumnName()
-    )} is json)`;
+    // implicitly add the check for json
+    this.columnBuilder._modifiers.checkJson = [
+      this.formatter.columnize(this.getColumnName()),
+    ];
+    return 'varchar2(4000)';
   }
 
   jsonb() {
     return this.json();
+  }
+
+  checkJson(column) {
+    return `check (${column} is json)`;
   }
 }
 

--- a/test/unit/schema-builder/oracledb.js
+++ b/test/unit/schema-builder/oracledb.js
@@ -1096,6 +1096,30 @@ describe('OracleDb SchemaBuilder', function () {
     }).to.throw(TypeError);
   });
 
+  it('allows adding default json objects when the column is json', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('user', function (t) {
+        t.json('preferences').defaultTo({}).notNullable();
+      })
+      .toSQL();
+    expect(tableSql[0].sql).to.equal(
+      'alter table "user" add "preferences" varchar2(4000) default \'{}\' not null check ("preferences" is json)'
+    );
+  });
+
+  it('allows adding default jsonb objects when the column is json', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('user', function (t) {
+        t.jsonb('preferences').defaultTo({}).notNullable();
+      })
+      .toSQL();
+    expect(tableSql[0].sql).to.equal(
+      'alter table "user" add "preferences" varchar2(4000) default \'{}\' not null check ("preferences" is json)'
+    );
+  });
+
   it('is possible to set raw statements in defaultTo, #146', function () {
     tableSql = client
       .schemaBuilder()


### PR DESCRIPTION
The `is json` check on json fields for OracleDB should be implicitly added after the default values and not with the field type.

The issue was found when running tests in https://github.com/directus/directus/pull/15889.

### Before

<img width="605" alt="image" src="https://user-images.githubusercontent.com/26413686/217205569-b8a92cba-4a0a-400b-ab9f-1a9e99d28a3b.png">

<img width="390" alt="image" src="https://user-images.githubusercontent.com/26413686/217206709-96689001-fe23-4e95-8a2e-3476f7f8e4d8.png">

### After

<img width="605" alt="image" src="https://user-images.githubusercontent.com/26413686/217205743-a90eefd9-e388-4bae-a046-1d8488279c7e.png">
