### PR TITLE
feat(default-schema): allow addition of default schema through config

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -64,6 +64,10 @@ class Client extends EventEmitter {
       this.version = config.version;
     }
 
+    if (config.schema) {
+      this.defaultSchemaName = config.schema;
+    }
+
     if (config.connection && config.connection instanceof Function) {
       this.connectionConfigProvider = config.connection;
       this.connectionConfigExpirationChecker = () => true; // causes the provider to be called on first use

--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -61,6 +61,7 @@ class Builder extends EventEmitter {
     this.client = client;
     this.and = this;
     this._single = {};
+    this._single.schema = client.defaultSchemaName;
     this._statements = [];
     this._method = 'select';
     if (client.config) {

--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -61,12 +61,14 @@ class Builder extends EventEmitter {
     this.client = client;
     this.and = this;
     this._single = {};
-    this._single.schema = client.defaultSchemaName;
     this._statements = [];
     this._method = 'select';
     if (client.config) {
       saveAsyncStack(this, 5);
       this._debug = client.config.debug;
+    }
+    if (client.defaultSchemaName) {
+      this._single.schema = client.defaultSchemaName;
     }
     // Internal flags used in the builder.
     this._joinFlag = 'inner';


### PR DESCRIPTION
I faced a situation in production which I had to change all queries to target a specific schema and I found no way to do so without changing the huge amount of knex query codes or editting the library method itself by adding this:
```js
const Knex = require('knex')({
  client,
  connection,
})

const QueryBuilder = require('knex/lib/query/builder')
Knex.client.queryBuilder = () =>
  (new QueryBuilder(Knex.client)).withSchema('mySchema')
```

However, I think allowing the schema to be set from the very inital configuration like below can be of help to a few others like me.
```js
const Knex = require('knex')({
  client,
  connection,
  schema: 'mySchema'
})
```
