### PR TITLE
fix: precision lost with bigint in sqlite3

### DIFF
--- a/lib/dialects/better-sqlite3/index.js
+++ b/lib/dialects/better-sqlite3/index.js
@@ -1,5 +1,7 @@
 // better-sqlite3 Client
 // -------
+const mapValues = require('lodash/mapValues');
+const isArray = require('lodash/isArray');
 const Client_SQLite3 = require('../sqlite3');
 
 class Client_BetterSQLite3 extends Client_SQLite3 {
@@ -31,7 +33,31 @@ class Client_BetterSQLite3 extends Client_SQLite3 {
     const bindings = this._formatBindings(obj.bindings);
 
     if (statement.reader) {
-      const response = await statement.all(bindings);
+      if(this.connectionSettings.supportBigNumbers) {
+        statement.safeIntegers(true)
+      }
+      let response = await statement.all(bindings);
+      if(this.connectionSettings.supportBigNumbers) {
+        const bigNumberStrings = this.connectionSettings.bigNumberStrings
+        const processBigintModeRow = (row) => {
+          return mapValues(row,v=>{
+            if(typeof v === 'bigint') {
+              const numV = Number(v);
+              if(numV == v) return numV;
+              else {
+                if(bigNumberStrings) return v.toString()
+                else return v
+              }
+            }
+            else return v
+          })
+        }
+        if(isArray(response)) {
+          response = response.map(r=>processBigintModeRow(r))
+        } else {
+          response = processBigintModeRow(response)
+        }
+      }
       obj.response = response;
       return obj;
     }


### PR DESCRIPTION
add supportBigNumbers, bigNumberStrings options like mysql to support sqlite can read bigint by string