### PR TITLE
[Sqlite3] Fix can not get table sql because of case sensitive

### DIFF
--- a/lib/dialects/sqlite3/schema/internal/sqlite-ddl-operations.js
+++ b/lib/dialects/sqlite3/schema/internal/sqlite-ddl-operations.js
@@ -15,7 +15,7 @@ function renameTable(tableName, alteredName) {
 }
 
 function getTableSql(tableName) {
-  return `SELECT type, sql FROM sqlite_master WHERE (type='table' OR (type='index' AND sql IS NOT NULL)) AND tbl_name='${tableName}'`;
+  return `SELECT type, sql FROM sqlite_master WHERE (type='table' OR (type='index' AND sql IS NOT NULL)) AND lower(tbl_name)='${tableName.toLowerCase()}'`;
 }
 
 function isForeignCheckEnabled() {

--- a/package.json
+++ b/package.json
@@ -251,7 +251,8 @@
     ],
     "exclude": [
       "lib/dialects/oracle",
-      "lib/dialects/oracledb"
+      "lib/dialects/oracledb",
+      "test/**/*.spec.js"
     ]
   },
   "tsd": {

--- a/test/integration2/migrate/alter-table-ignore-case-sensitive/01_create.js
+++ b/test/integration2/migrate/alter-table-ignore-case-sensitive/01_create.js
@@ -1,0 +1,9 @@
+exports.up = async (knex) => {
+  await knex.schema.createTableIfNotExists('some_table', (table) => {
+    table.increments();
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.dropTableIfExists('some_table');
+};

--- a/test/integration2/migrate/alter-table-ignore-case-sensitive/02_add_column.js
+++ b/test/integration2/migrate/alter-table-ignore-case-sensitive/02_add_column.js
@@ -1,0 +1,13 @@
+exports.up = async (knex) => {
+  // Use the same table but different case.
+  await knex.schema.table('Some_Table', (table) => {
+    table.string('other_id').after('id');
+    table.string('name').after('other_id');
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.table('Some_Table', (table) => {
+    table.dropColumns('other_id', 'name');
+  });
+};

--- a/test/integration2/migrate/migration-integration.spec.js
+++ b/test/integration2/migrate/migration-integration.spec.js
@@ -81,6 +81,20 @@ describe('Migrations', function () {
             });
         });
 
+        it.only('should not fail alter-table-ignore-case-sensitive', async () => {
+          return knex.migrate
+            .latest({
+              directory:
+                'test/integration2/migrate/alter-table-ignore-case-sensitive',
+            })
+            .then(() => {
+              return knex.migrate.rollback({
+                directory:
+                  'test/integration2/migrate/alter-table-ignore-case-sensitive',
+              });
+            });
+        });
+
         if (isPostgreSQL(knex)) {
           it('should not fail drop-and-recreate-column operation when using promise chain and schema', () => {
             return knex.migrate

--- a/test/integration2/migrate/migration-integration.spec.js
+++ b/test/integration2/migrate/migration-integration.spec.js
@@ -81,7 +81,7 @@ describe('Migrations', function () {
             });
         });
 
-        it.only('should not fail alter-table-ignore-case-sensitive', async () => {
+        it('should not fail alter-table-ignore-case-sensitive', async () => {
           return knex.migrate
             .latest({
               directory:

--- a/test/integration2/migrate/migration-integration.spec.js
+++ b/test/integration2/migrate/migration-integration.spec.js
@@ -82,17 +82,26 @@ describe('Migrations', function () {
         });
 
         it('should not fail alter-table-ignore-case-sensitive', async () => {
-          return knex.migrate
-            .latest({
-              directory:
-                'test/integration2/migrate/alter-table-ignore-case-sensitive',
-            })
-            .then(() => {
-              return knex.migrate.rollback({
-                directory:
-                  'test/integration2/migrate/alter-table-ignore-case-sensitive',
-              });
-            });
+          await knex.migrate.latest({
+            directory:
+              'test/integration2/migrate/alter-table-ignore-case-sensitive',
+          });
+          expect(await knex.schema.hasColumn('Some_Table', 'id')).to.be.true;
+          expect(await knex.schema.hasColumn('Some_Table', 'other_id')).to.be
+            .true;
+          expect(await knex.schema.hasColumn('Some_Table', 'name')).to.be.true;
+          // try different case
+          expect(await knex.schema.hasColumn('some_table', 'id')).to.be.true;
+          expect(await knex.schema.hasColumn('some_table', 'other_id')).to.be
+            .true;
+          expect(await knex.schema.hasColumn('some_table', 'name')).to.be.true;
+
+          await knex.migrate.rollback({
+            directory:
+              'test/integration2/migrate/alter-table-ignore-case-sensitive',
+          });
+          expect(await knex.schema.hasTable('Some_Table')).to.be.false;
+          expect(await knex.schema.hasTable('some_table')).to.be.false;
         });
 
         if (isPostgreSQL(knex)) {

--- a/test/integration2/migrate/migration-integration.spec.js
+++ b/test/integration2/migrate/migration-integration.spec.js
@@ -81,29 +81,6 @@ describe('Migrations', function () {
             });
         });
 
-        it('should not fail alter-table-ignore-case-sensitive', async () => {
-          await knex.migrate.latest({
-            directory:
-              'test/integration2/migrate/alter-table-ignore-case-sensitive',
-          });
-          expect(await knex.schema.hasColumn('Some_Table', 'id')).to.be.true;
-          expect(await knex.schema.hasColumn('Some_Table', 'other_id')).to.be
-            .true;
-          expect(await knex.schema.hasColumn('Some_Table', 'name')).to.be.true;
-          // try different case
-          expect(await knex.schema.hasColumn('some_table', 'id')).to.be.true;
-          expect(await knex.schema.hasColumn('some_table', 'other_id')).to.be
-            .true;
-          expect(await knex.schema.hasColumn('some_table', 'name')).to.be.true;
-
-          await knex.migrate.rollback({
-            directory:
-              'test/integration2/migrate/alter-table-ignore-case-sensitive',
-          });
-          expect(await knex.schema.hasTable('Some_Table')).to.be.false;
-          expect(await knex.schema.hasTable('some_table')).to.be.false;
-        });
-
         if (isPostgreSQL(knex)) {
           it('should not fail drop-and-recreate-column operation when using promise chain and schema', () => {
             return knex.migrate
@@ -137,6 +114,31 @@ describe('Migrations', function () {
             await db.migrate.latest();
             await db.migrate.rollback();
             await knexInstance.destroy();
+          });
+
+          it('should not fail alter-table-ignore-case-sensitive', async () => {
+            await knex.migrate.latest({
+              directory:
+                'test/integration2/migrate/alter-table-ignore-case-sensitive',
+            });
+            expect(await knex.schema.hasColumn('Some_Table', 'id')).to.be.true;
+            expect(await knex.schema.hasColumn('Some_Table', 'other_id')).to.be
+              .true;
+            expect(await knex.schema.hasColumn('Some_Table', 'name')).to.be
+              .true;
+            // try different case
+            expect(await knex.schema.hasColumn('some_table', 'id')).to.be.true;
+            expect(await knex.schema.hasColumn('some_table', 'other_id')).to.be
+              .true;
+            expect(await knex.schema.hasColumn('some_table', 'name')).to.be
+              .true;
+
+            await knex.migrate.rollback({
+              directory:
+                'test/integration2/migrate/alter-table-ignore-case-sensitive',
+            });
+            expect(await knex.schema.hasTable('Some_Table')).to.be.false;
+            expect(await knex.schema.hasTable('some_table')).to.be.false;
           });
         }
 


### PR DESCRIPTION
## Example

Here is an example how to reproduce the issue.
https://github.com/zydmayday/learn-knex/blob/main/knex/knex.test.ts#L34-L44

## Details

Use sqlite3 as database for testing, and has some migration scripts for setting up tables.

If we have one script create a table called "some_table(https://github.com/zydmayday/learn-knex/blob/main/knex/migrations/1_create_table.ts)",
and another script alter table but using table name "Some_Table(https://github.com/zydmayday/learn-knex/blob/main/knex/migrations/2_add_columns.ts)".
Then after running jest, we will have the following error logs.

```
TypeError: Cannot read properties of undefined (reading 'sql')

      at client.transaction.connection (node_modules/knex/lib/dialects/sqlite3/schema/ddl.js:56:13)
```

## How to fix

Because the related SQL script is case sensitive, change it to run in a case insensitive way.