### PR TITLE
[TypeScript] Add Object syntax overload to increment method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -788,6 +788,11 @@ export declare namespace Knex {
       columnName: string,
       amount?: number
     ): QueryBuilder<TRecord, number>;
+    increment(
+      columns: {
+        [column in keyof TRecord]: number
+      }
+    ): QueryBuilder<TRecord, number>;
 
     decrement(
       columnName: keyof TRecord,


### PR DESCRIPTION
The [documentation for `QueryBuilder#icrement`](https://knexjs.org/guide/query-builder.html#increment) says, that the method accepts columns and values either as separate arguments, or in Object syntax ([the code also checks if the `column` is an object](https://github.com/knex/knex/blob/0d27bcb60b9bfd57fabf896715350089e0b1050c/lib/query/querybuilder.js#L1111)). 

But currently this code:

````typescript
knex("table")
    .where({ id: 1 })
    .increment({
      foo: 1,
      bar: 2,
    });
````

Throws an error: 

````
No overload matches this call.
  Overload 1 of 2, '(columnName: string | number | symbol, amount?: number): QueryBuilder<any, number>', gave the following error.
    Argument of type '{ foo: number; bar: number; }' is not assignable to parameter of type 'string | number | symbol'.
  Overload 2 of 2, '(columnName: string, amount?: number): QueryBuilder<any, number>', gave the following error.
    Argument of type '{ foo: number; bar: number; }' is not assignable to parameter of type 'string'.
````

This adds an overload to the `increment` Method Type Definition for the case where the first argument is an Object consisting of keys from `TRecord` and numbers as values.