### PR TITLE
Add knex.mjs to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "CHANGELOG.md",
     "CONTRIBUTING.md",
     "knex.js",
+    "knex.mjs",
     "LICENSE",
     "README.md",
     "UPGRADING.md"


### PR DESCRIPTION
I assume that `knex.mjs` is missing from published files simply because it is not listed in "files" field of package.json.

Fixes #5354.