### PR TITLE
[TypeScript ]Add missing types for havingNull and havingNotNull

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -729,6 +729,9 @@ export declare namespace Knex {
     havingNotIn: HavingRange<TRecord, TResult>;
     andHavingNotIn: HavingRange<TRecord, TResult>;
     orHavingNotIn: HavingRange<TRecord, TResult>;
+    havingNull: HavingNull<TRecord, TResult>;
+    havingNotNull: HavingNull<TRecord, TResult>;
+
 
     // Clear
     clearSelect(): QueryBuilder<
@@ -2005,6 +2008,11 @@ export declare namespace Knex {
       TRecord,
       TResult
     >;
+  }
+
+  interface HavingNull<TRecord extends {} = any, TResult = unknown[]> {
+    (columnName: keyof TRecord): QueryBuilder<TRecord, TResult>;
+    (columnName: string): QueryBuilder<TRecord, TResult>;
   }
 
   // commons

--- a/types/test.ts
+++ b/types/test.ts
@@ -893,6 +893,18 @@ const main = async () => {
 
   // $ExpectType User[]
   await knexInstance<User>('users')
+    .groupBy('count')
+    .orderBy('name', 'desc')
+    .havingNull('age');
+
+  // $ExpectType User[]
+  await knexInstance<User>('users')
+    .groupBy('count')
+    .orderBy('name', 'desc')
+    .havingNotNull('age');
+
+  // $ExpectType User[]
+  await knexInstance<User>('users')
     .select()
     .orderBy(
       knexInstance<User>('users')


### PR DESCRIPTION
The [documentation has the `havingNull` and `havingNotNull`](https://knexjs.org/guide/query-builder.html#havingnull) methods but they are missing from the TS definition so I added them along with a simple type test.

Tell me if my PR is missing anything