### PR TITLE
fix: prevent uncaught errors

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -80,6 +80,14 @@ class Client_PG extends Client {
   _acquireOnlyConnection() {
     const connection = new this.driver.Client(this.connectionSettings);
 
+    connection.on('error', (err) => {
+      connection.__knex__disposed = err;
+    });
+
+    connection.on('end', (err) => {
+      connection.__knex__disposed = err || 'Connection ended unexpectedly';
+    });
+
     return connection.connect().then(() => connection);
   }
 
@@ -90,14 +98,6 @@ class Client_PG extends Client {
 
     return this._acquireOnlyConnection()
       .then(function (connection) {
-        connection.on('error', (err) => {
-          connection.__knex__disposed = err;
-        });
-
-        connection.on('end', (err) => {
-          connection.__knex__disposed = err || 'Connection ended unexpectedly';
-        });
-
         if (!client.version) {
           return client.checkVersion(connection).then(function (version) {
             client.version = version;


### PR DESCRIPTION
Fixes #5454.

Just needed to attach the error handler _before_ calling `connection.connect()`, in case an error event happens before that finishes. 

The manual test in the linked bug report now works fine. Not sure if it's worth adding a unit test for this specific issue (or how I would even do so). 

This probably isn't a complete solution to the overall problem described there, since AFAIK `terminating connection due to conflict with recovery` shouldn't be possible here—but one thing at a time. 