### PR TITLE
Add object syntax overload to decrement method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -804,6 +804,11 @@ export declare namespace Knex {
       columnName: string,
       amount?: number
     ): QueryBuilder<TRecord, number>;
+    decrement(
+      columns: {
+        [column in keyof TRecord]: number
+      }
+    ): QueryBuilder<TRecord, number>;
 
     // Analytics
     rank: AnalyticFunction<TRecord, TResult>;


### PR DESCRIPTION
Hello. This PR is similar to https://github.com/knex/knex/pull/5512, but updates the `decrement` method.