### PR TITLE
fix(security): avoid password leaks on query logs

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -44,8 +44,8 @@ class Client extends EventEmitter {
     this.config = config;
     this.logger = new Logger(config);
 
-    if (config.connection.password) {
-      setHiddenProperty(config.connection);
+    if (this.config.connection && this.config.connection.password) {
+      setHiddenProperty(this.config.connection);
     }
 
     //Client is a required field, so throw error if it's not supplied.
@@ -74,7 +74,7 @@ class Client extends EventEmitter {
       this.connectionConfigExpirationChecker = () => true; // causes the provider to be called on first use
     } else {
       this.connectionSettings = cloneDeep(config.connection || {});
-      if (config.connection.password) {
+      if (config.connection && config.connection.password) {
         setHiddenProperty(this.connectionSettings, config.connection);
       }
       this.connectionConfigExpirationChecker = null;

--- a/lib/client.js
+++ b/lib/client.js
@@ -31,6 +31,7 @@ const { POOL_CONFIG_OPTIONS } = require('./constants');
 const ViewBuilder = require('./schema/viewbuilder.js');
 const ViewCompiler = require('./schema/viewcompiler.js');
 const isPlainObject = require('lodash/isPlainObject');
+const { setHiddenProperty } = require('./util/security.js');
 
 const debug = require('debug')('knex:client');
 
@@ -44,10 +45,7 @@ class Client extends EventEmitter {
     this.logger = new Logger(config);
 
     if (config.connection.password) {
-      Object.defineProperty(config.connection, 'password', {
-        enumerable: false,
-        value: config.connection.password,
-      });
+      setHiddenProperty(config.connection);
     }
 
     //Client is a required field, so throw error if it's not supplied.
@@ -77,10 +75,7 @@ class Client extends EventEmitter {
     } else {
       this.connectionSettings = cloneDeep(config.connection || {});
       if (config.connection.password) {
-        Object.defineProperty(this.connectionSettings, 'password', {
-          enumerable: false,
-          value: config.connection.password,
-        });
+        setHiddenProperty(this.connectionSettings, config.connection);
       }
       this.connectionConfigExpirationChecker = null;
     }
@@ -320,24 +315,14 @@ class Client extends EventEmitter {
       debug('acquired connection from pool: %s', connection.__knexUid);
       if (connection.config) {
         if (connection.config.password) {
-          Object.defineProperty(connection.config, 'password', {
-            enumerable: false,
-            value: connection.config.password,
-          });
+          setHiddenProperty(connection.config);
         }
         if (
           connection.config.authentication &&
           connection.config.authentication.options &&
           connection.config.authentication.options.password
         ) {
-          Object.defineProperty(
-            connection.config.authentication.options,
-            'password',
-            {
-              enumerable: false,
-              value: connection.config.authentication.options.password,
-            }
-          );
+          setHiddenProperty(connection.config.authentication.options);
         }
       }
       return connection;

--- a/lib/client.js
+++ b/lib/client.js
@@ -43,6 +43,13 @@ class Client extends EventEmitter {
     this.config = config;
     this.logger = new Logger(config);
 
+    if (config.connection.password) {
+      Object.defineProperty(config.connection, 'password', {
+        enumerable: false,
+        value: config.connection.password,
+      });
+    }
+
     //Client is a required field, so throw error if it's not supplied.
     //If 'this.dialect' is set, then this is a 'super()' call, in which case
     //'client' does not have to be set as it's already assigned on the client prototype.
@@ -69,6 +76,12 @@ class Client extends EventEmitter {
       this.connectionConfigExpirationChecker = () => true; // causes the provider to be called on first use
     } else {
       this.connectionSettings = cloneDeep(config.connection || {});
+      if (config.connection.password) {
+        Object.defineProperty(this.connectionSettings, 'password', {
+          enumerable: false,
+          value: config.connection.password,
+        });
+      }
       this.connectionConfigExpirationChecker = null;
     }
     if (this.driverName && config.connection) {
@@ -305,6 +318,28 @@ class Client extends EventEmitter {
     try {
       const connection = await this.pool.acquire().promise;
       debug('acquired connection from pool: %s', connection.__knexUid);
+      if (connection.config) {
+        if (connection.config.password) {
+          Object.defineProperty(connection.config, 'password', {
+            enumerable: false,
+            value: connection.config.password,
+          });
+        }
+        if (
+          connection.config.authentication &&
+          connection.config.authentication.options &&
+          connection.config.authentication.options.password
+        ) {
+          Object.defineProperty(
+            connection.config.authentication.options,
+            'password',
+            {
+              enumerable: false,
+              value: connection.config.authentication.options.password,
+            }
+          );
+        }
+      }
       return connection;
     } catch (error) {
       let convertedError = error;

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -12,6 +12,7 @@ const TableCompiler = require('./schema/mssql-tablecompiler');
 const ViewCompiler = require('./schema/mssql-viewcompiler');
 const ColumnCompiler = require('./schema/mssql-columncompiler');
 const QueryBuilder = require('../../query/querybuilder');
+const { setHiddenProperty } = require('../../util/security');
 
 const debug = require('debug')('knex:mssql');
 
@@ -67,10 +68,7 @@ class Client_MSSQL extends Client {
     };
 
     if (cfg.authentication.options.password) {
-      Object.defineProperty(cfg.authentication.options, 'password', {
-        enumerable: false,
-        value: cfg.authentication.options.password,
-      });
+      setHiddenProperty(cfg.authentication.options);
     }
 
     // tedious always connect via tcp when port is specified

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -66,6 +66,13 @@ class Client_MSSQL extends Client {
       },
     };
 
+    if (cfg.authentication.options.password) {
+      Object.defineProperty(cfg.authentication.options, 'password', {
+        enumerable: false,
+        value: cfg.authentication.options.password,
+      });
+    }
+
     // tedious always connect via tcp when port is specified
     if (cfg.options.instanceName) delete cfg.options.port;
 

--- a/lib/knex-builder/make-knex.js
+++ b/lib/knex-builder/make-knex.js
@@ -208,6 +208,13 @@ function initContext(knexFn) {
         knexClone.client = Object.create(this.client.constructor.prototype); // Clone client to avoid leaking listeners that are set on it
         merge(knexClone.client, this.client);
         knexClone.client.config = Object.assign({}, this.client.config); // Clone client config to make sure they can be modified independently
+
+        if (this.client.config.password) {
+          Object.defineProperty(knexClone.client.config, 'password', {
+            enumerable: false,
+            value: this.client.config.password,
+          });
+        }
       }
 
       redefineProperties(knexClone, knexClone.client);

--- a/lib/knex-builder/make-knex.js
+++ b/lib/knex-builder/make-knex.js
@@ -7,6 +7,7 @@ const QueryInterface = require('../query/method-constants');
 const merge = require('lodash/merge');
 const batchInsert = require('../execution/batch-insert');
 const { isObject } = require('../util/is');
+const { setHiddenProperty } = require('../util/security');
 
 // Javascript does not officially support "callable objects".  Instead,
 // you must create a regular Function and inject properties/methods
@@ -210,10 +211,7 @@ function initContext(knexFn) {
         knexClone.client.config = Object.assign({}, this.client.config); // Clone client config to make sure they can be modified independently
 
         if (this.client.config.password) {
-          Object.defineProperty(knexClone.client.config, 'password', {
-            enumerable: false,
-            value: this.client.config.password,
-          });
+          setHiddenProperty(knexClone.client.config, this.client.config);
         }
       }
 

--- a/lib/util/security.js
+++ b/lib/util/security.js
@@ -1,0 +1,26 @@
+/**
+ * Sets a hidden (non-enumerable) property on the `target` object, copying it
+ * from `source`.
+ *
+ * This is useful when we want to protect certain data to be accidentally leaked
+ * through logs, also when the property is non-enumerable on the `source` object
+ * and we want to ensure that it is properly copied.
+ *
+ * @param {object} target
+ * @param {object} source - default: target
+ * @param {string} propertyName - default: 'password'
+ */
+function setHiddenProperty(target, source, propertyName = 'password') {
+  if (!source) {
+    source = target;
+  }
+
+  Object.defineProperty(target, propertyName, {
+    enumerable: false,
+    value: source[propertyName],
+  });
+}
+
+module.exports = {
+  setHiddenProperty,
+};

--- a/lib/util/security.js
+++ b/lib/util/security.js
@@ -2,9 +2,9 @@
  * Sets a hidden (non-enumerable) property on the `target` object, copying it
  * from `source`.
  *
- * This is useful when we want to protect certain data to be accidentally leaked
- * through logs, also when the property is non-enumerable on the `source` object
- * and we want to ensure that it is properly copied.
+ * This is useful when we want to protect certain data from being accidentally
+ * leaked through logs, also when the property is non-enumerable on the `source`
+ * object and we want to ensure that it is properly copied.
  *
  * @param {object} target
  * @param {object} source - default: target

--- a/test/db-less-test-suite.js
+++ b/test/db-less-test-suite.js
@@ -10,6 +10,7 @@ describe('Util Tests', function () {
   require('./unit/util/nanoid');
   require('./unit/util/save-async-stack');
   require('./unit/util/comma-no-paren-regex');
+  require('./unit/util/security');
 });
 
 describe('Query Building Tests', function () {

--- a/test/integration/connection-config-provider.js
+++ b/test/integration/connection-config-provider.js
@@ -4,6 +4,7 @@ const { expect } = require('chai');
 
 const _ = require('lodash');
 const makeKnex = require('../../knex');
+const { setHiddenProperty } = require('../../lib/util/security');
 
 module.exports = function (config) {
   describe('Connection configuration provider', function () {
@@ -14,10 +15,7 @@ module.exports = function (config) {
     this.beforeEach(() => {
       configWorkingCopy = _.cloneDeep(config);
       if (config.connection && config.connection.password) {
-        Object.defineProperty(configWorkingCopy.connection, 'password', {
-          enumerable: false,
-          value: config.connection.password,
-        });
+        setHiddenProperty(configWorkingCopy.connection, config.connection);
       }
       configWorkingCopy.pool.min = 1;
       configWorkingCopy.pool.max = 2;

--- a/test/integration/connection-config-provider.js
+++ b/test/integration/connection-config-provider.js
@@ -13,6 +13,12 @@ module.exports = function (config) {
 
     this.beforeEach(() => {
       configWorkingCopy = _.cloneDeep(config);
+      if (config.connection && config.connection.password) {
+        Object.defineProperty(configWorkingCopy.connection, 'password', {
+          enumerable: false,
+          value: config.connection.password,
+        });
+      }
       configWorkingCopy.pool.min = 1;
       configWorkingCopy.pool.max = 2;
       providerInvocationCount = 0;

--- a/test/integration2/query/misc/additional.spec.js
+++ b/test/integration2/query/misc/additional.spec.js
@@ -1,6 +1,7 @@
 /*eslint no-var:0, max-len:0 */
 'use strict';
 
+const util = require('util');
 const chai = require('chai');
 chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
@@ -986,6 +987,16 @@ describe('Additional', function () {
           // To make this test easier, I'm changing the pool settings to max 1.
           // Also setting acquireTimeoutMillis to lower as not to wait the default time
           const knexConfig = _.cloneDeep(knex.client.config);
+          if (
+            knex.client.config.connection &&
+            knex.client.config.connection.password
+          ) {
+            Object.defineProperty(knexConfig.connection, 'password', {
+              enumerable: false,
+              value: knex.client.config.connection.password,
+            });
+          }
+
           knexConfig.pool.min = 0;
           knexConfig.pool.max = 1;
           knexConfig.pool.acquireTimeoutMillis = 100;
@@ -1103,6 +1114,16 @@ describe('Additional', function () {
           // To make this test easier, I'm changing the pool settings to max 1.
           // Also setting acquireTimeoutMillis to lower as not to wait the default time
           const knexConfig = _.cloneDeep(knex.client.config);
+          if (
+            knex.client.config.connection &&
+            knex.client.config.connection.password
+          ) {
+            Object.defineProperty(knexConfig.connection, 'password', {
+              enumerable: false,
+              value: knex.client.config.connection.password,
+            });
+          }
+
           knexConfig.pool.min = 0;
           knexConfig.pool.max = 2;
           knexConfig.pool.acquireTimeoutMillis = 100;
@@ -1399,6 +1420,16 @@ describe('Additional', function () {
             knexDb.initialize();
             expect(knexDb.client.pool.destroyed).to.equal(false);
           });
+        });
+
+        it('should not leak passwords when logged', async function () {
+          const query = knex('test_table_two').select('*');
+          const fakeLog = util.inspect(query, { depth: null });
+          const passwordMatches = fakeLog.match(
+            /(knextest|testpassword|S0meVeryHardPassword|testrootpassword)/g
+          );
+
+          expect(passwordMatches).to.be.null;
         });
       });
     });

--- a/test/integration2/query/misc/additional.spec.js
+++ b/test/integration2/query/misc/additional.spec.js
@@ -1426,10 +1426,11 @@ describe('Additional', function () {
         it('should not leak passwords when logged', async function () {
           const query = knex('test_table_two').select('*');
           const fakeLog = util.inspect(query, { depth: null });
+
+          // These passwords come from `scripts/docker-compose.yml`
           const passwordMatches = fakeLog.match(
             /(knextest|testpassword|S0meVeryHardPassword|testrootpassword)/g
           );
-
           expect(passwordMatches).to.be.null;
         });
       });

--- a/test/integration2/query/misc/additional.spec.js
+++ b/test/integration2/query/misc/additional.spec.js
@@ -35,6 +35,7 @@ const {
 const logger = require('../../../integration/logger');
 const { insertAccounts } = require('../../../util/dataInsertHelper');
 const sinon = require('sinon');
+const { setHiddenProperty } = require('../../../../lib/util/security');
 
 describe('Additional', function () {
   getAllDbs().forEach((db) => {
@@ -991,10 +992,10 @@ describe('Additional', function () {
             knex.client.config.connection &&
             knex.client.config.connection.password
           ) {
-            Object.defineProperty(knexConfig.connection, 'password', {
-              enumerable: false,
-              value: knex.client.config.connection.password,
-            });
+            setHiddenProperty(
+              knexConfig.connection,
+              knex.client.config.connection
+            );
           }
 
           knexConfig.pool.min = 0;
@@ -1118,10 +1119,10 @@ describe('Additional', function () {
             knex.client.config.connection &&
             knex.client.config.connection.password
           ) {
-            Object.defineProperty(knexConfig.connection, 'password', {
-              enumerable: false,
-              value: knex.client.config.connection.password,
-            });
+            setHiddenProperty(
+              knexConfig.connection,
+              knex.client.config.connection
+            );
           }
 
           knexConfig.pool.min = 0;

--- a/test/unit/util/security.js
+++ b/test/unit/util/security.js
@@ -1,0 +1,39 @@
+const { expect } = require('chai');
+const { setHiddenProperty } = require('../../../lib/util/security');
+
+describe('setHiddenProperty', () => {
+  it('hides password property when only target object is passed', () => {
+    const target = { password: 'xyz' };
+    expect(Object.keys(target)).to.contain('password'); // sanity check
+
+    setHiddenProperty(target);
+    expect(Object.keys(target)).to.not.contain('password');
+
+    // Although not enumerable, it is still present
+    expect(target).to.have.property('password');
+    expect(target.password).to.equal('xyz');
+  });
+
+  it('sets property from source even when it is not enumerable', () => {
+    const source = Object.create(
+      {},
+      {
+        password: {
+          enumerable: false,
+          value: 'xyz',
+        },
+      }
+    );
+
+    expect(Object.keys(source)).to.not.contain('password'); // sanity check
+    expect(source).to.have.property('password'); // sanity check
+    expect(source.password).to.equal('xyz'); // sanity check
+
+    const target = {};
+    setHiddenProperty(target, source);
+
+    expect(Object.keys(target)).to.not.contain('password');
+    expect(target).to.have.property('password');
+    expect(target.password).to.equal('xyz');
+  });
+});


### PR DESCRIPTION
## Motivation:
We detected that under certain conditions, passwords could be leaked through logs, when executing code such as:
```typescript
const query = knex('myTable').select('*');
logger.debug({ query }) // passwords are leaked here
```
In our case, the logger was `Pino`, this problem doesn't necessarily happen with other loggers (as they might use different
serialisation methods).

## Fixes:
- password fields are not leaked anymore. Fixes #5560 .
- accepts configuration objects where the password field exists but it is non-enumerable (this might happen when lib users are trying to prevent the same previous problem, but at a higher level).

## Changes:
- marks the password field as non-enumerable when possible, to avoid potential leaks through logs.
- adapts tests
- add new regression test
