### PR TITLE
Add transactor.parentTransaction

### DIFF
--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -219,11 +219,11 @@ class Transaction extends EventEmitter {
           return makeTransactor(this, connection, trxClient);
         })
         .then((transactor) => {
+          this.transactor = transactor;
+          if (this.outerTx) {
+            transactor.parentTransaction = this.outerTx.transactor;
+          }
           transactor.executionPromise = executionPromise;
-          transactor.baseExecutionPromise = this.baseExecutionPromise = this
-            .outerTx
-            ? this.outerTx.baseExecutionPromise
-            : executionPromise;
 
           // If we've returned a "thenable" from the transaction container, assume
           // the rollback and commit are chained to this object's success / failure.

--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -220,6 +220,10 @@ class Transaction extends EventEmitter {
         })
         .then((transactor) => {
           transactor.executionPromise = executionPromise;
+          transactor.baseExecutionPromise = this.baseExecutionPromise = this
+            .outerTx
+            ? this.outerTx.baseExecutionPromise
+            : executionPromise;
 
           // If we've returned a "thenable" from the transaction container, assume
           // the rollback and commit are chained to this object's success / failure.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2323,6 +2323,7 @@ declare namespace Knex {
   interface Transaction<TRecord extends {} = any, TResult = any[]>
     extends Knex<TRecord, TResult> {
     executionPromise: Promise<TResult>;
+    parentTransaction?: Transaction;
     isCompleted: () => boolean;
 
     query<TRecord extends {} = any, TResult = void>(


### PR DESCRIPTION
Recently our app has had the need to know when the base transaction has committed, regardless of nested transaction levels. This works with `executionPromise` when you're one transaction deep, but if you have nested transactions the `executionPromise` only refers to the inner-most transaction. This change adds a `baseExecutionPromise` property on the transactor that will always reference the outer-most `executionPromise`.

Our specific use case is that we have functions that receive transactions and may open up nested transactions which can open up more nested transactions. Sometimes in those transactions, offline work records are inserted into a queue table to be processed out-of-band of the current transaction. We want to start that work as soon as the transaction is committed, but if we attempt to process the work when `executionPromise` is resolved in a nested transaction, the outer transaction is still not committed and the records aren't visible to the work processors yet, so no work is consumed.

I've monkey-patched this for our purposes for now, but I think it's a valuable addition to the core. For anyone interested in the patch:

```js
import Transaction from 'knex/lib/execution/transaction.js';
const { _evaluateContainer } = Transaction.prototype;
Object.assign(Transaction.prototype, {
  async _evaluateContainer(config, container) {
    return await _evaluateContainer.call(this, config, tx => {
      this.baseExecutionPromise = tx.baseExecutionPromise =
        this.outerTx?.baseExecutionPromise ?? tx.executionPromise;
      return container(tx);
    });
  }
});
```