### PR TITLE
Mysql2 require breaks with Node 12

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm install
 
       - name: Run npm install mysql2@3.2.0 if Node 12.x
-        run: npm install mysql@3.2.0
+        run: npm install mysql2@3.2.0
         if: matrix.node-version == '12.x'
 
       - run: npm run build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Run npm install
         run: npm install
 
+      - name: Run npm install mysql2@3.2.0 if Node 12.x
+        run: npm install mysql@3.2.0
+        if: matrix.node-version == '12.x'
+
       - run: npm run build
 
       - name: Run Tests

--- a/lib/dialects/mysql2/index.js
+++ b/lib/dialects/mysql2/index.js
@@ -14,6 +14,26 @@ class Client_MySQL2 extends Client_MySQL {
   _driver() {
     return require('mysql2');
   }
+
+  initializeDriver() {
+    try {
+      this.driver = this._driver();
+    } catch (e) {
+      let message = `Knex: run\n$ npm install ${this.driverName}`;
+
+      const nodeMajorVersion = process.version.replace(/^v/, '').split('.')[0];
+      if (nodeMajorVersion <= 12) {
+        message += `@3.2.0`;
+        this.logger.error(
+          'Mysql2 version 3.2.0 is the latest version to support Node.js 12 or lower.'
+        );
+      }
+      message += ` --save`;
+      this.logger.error(`${message}\n${e.message}\n${e.stack}`);
+      throw new Error(`${message}\n${e.message}`);
+    }
+  }
+
   validateConnection(connection) {
     return (
       connection &&


### PR DESCRIPTION
- With Mysql2 > 3.2.0 require('mysql2') breaks with Node 12.
- Add an error during mysql2 driver initialization
- Install mysql2@3.2.0 during unit test with Node12.

Close #5578