### PR TITLE
SchemaBuilder toSql() returns Sql[], not Sql.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2410,7 +2410,7 @@ export declare namespace Knex {
     raw(statement: string): SchemaBuilder;
     queryContext(context: any): SchemaBuilder;
     toString(): string;
-    toSQL(): Sql;
+    toSQL(): Sql[];
   }
 
   interface TableBuilder {


### PR DESCRIPTION
All details are in https://github.com/knex/knex/issues/5593.

I reviewed other commits that fixed typings, and it seems like only `types/index.d.ts` gets changed for those, but let me know if I'm missing something.