### PR TITLE
oracle db returning * fixes

### DIFF
--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -254,10 +254,6 @@ class Client_Oracledb extends Client_Oracle {
             });
           }
         }
-        if (connection.isTransaction) {
-          return obj;
-        }
-        await connection.commitAsync();
         if (obj.returningSql) {
           const response = await connection.executeAsync(
             obj.returningSql(),
@@ -266,6 +262,10 @@ class Client_Oracledb extends Client_Oracle {
           );
           obj.response = response.rows;
         }
+        if (connection.isTransaction) {
+          return obj;
+        }
+        await connection.commitAsync();
         return obj;
       });
   }
@@ -287,7 +287,7 @@ class Client_Oracledb extends Client_Oracle {
       case 'del':
       case 'update':
       case 'counter':
-        if (obj.returning && !isEmpty(obj.returning)) {
+        if ((obj.returning && !isEmpty(obj.returning)) || obj.returningSql) {
           return response;
         } else if (obj.rowsAffected !== undefined) {
           return obj.rowsAffected;

--- a/test/integration2/query/update/updates.spec.js
+++ b/test/integration2/query/update/updates.spec.js
@@ -341,7 +341,20 @@ describe('Updates', function () {
                 1,
                 (v) => v.toString() === '[object ReturningHelper:ROWID]',
               ],
-              1
+              [
+                {
+                  id: accountId1,
+                  first_name: 'UpdatedUser',
+                  last_name: 'UpdatedTest',
+                  email: 'test100@example.com',
+                  logins: 1,
+                  balance: 12.24,
+                  about: 'Lorem ipsum Dolore labore incididunt enim.',
+                  created_at: TEST_TIMESTAMP,
+                  updated_at: TEST_TIMESTAMP,
+                  phone: null,
+                },
+              ]
             );
             tester(
               'mssql',
@@ -363,6 +376,146 @@ describe('Updates', function () {
               ]
             );
           });
+      });
+
+      it('should allow returning for updates with specific transaction', async function () {
+        await knex('accounts').where('id', accountId1).update({
+          balance: 12.240000000000002,
+        });
+
+        await knex.transaction(function (tr) {
+          return knex('accounts')
+            .transacting(tr)
+            .where('id', accountId1)
+            .update(
+              {
+                email: 'test100@example.com',
+                first_name: 'UpdatedUser',
+                last_name: 'UpdatedTest',
+              },
+              '*'
+            )
+            .testSql(function (tester) {
+              tester(
+                'mysql',
+                'update `accounts` set `email` = ?, `first_name` = ?, `last_name` = ? where `id` = ?',
+                ['test100@example.com', 'UpdatedUser', 'UpdatedTest', 1],
+                1
+              );
+              tester(
+                'pg',
+                'update "accounts" set "email" = ?, "first_name" = ?, "last_name" = ? where "id" = ? returning *',
+                ['test100@example.com', 'UpdatedUser', 'UpdatedTest', '1'],
+                [
+                  {
+                    id: '1',
+                    first_name: 'UpdatedUser',
+                    last_name: 'UpdatedTest',
+                    email: 'test100@example.com',
+                    logins: 1,
+                    balance: 12.24,
+                    about: 'Lorem ipsum Dolore labore incididunt enim.',
+                    created_at: TEST_TIMESTAMP,
+                    updated_at: TEST_TIMESTAMP,
+                    phone: null,
+                  },
+                ]
+              );
+              tester(
+                'cockroachdb',
+                'update "accounts" set "email" = ?, "first_name" = ?, "last_name" = ? where "id" = ? returning *',
+                [
+                  'test100@example.com',
+                  'UpdatedUser',
+                  'UpdatedTest',
+                  accountId1,
+                ],
+                [
+                  {
+                    id: accountId1,
+                    first_name: 'UpdatedUser',
+                    last_name: 'UpdatedTest',
+                    email: 'test100@example.com',
+                    logins: '1',
+                    balance: 12.24,
+                    about: 'Lorem ipsum Dolore labore incididunt enim.',
+                    created_at: TEST_TIMESTAMP,
+                    updated_at: TEST_TIMESTAMP,
+                    phone: null,
+                  },
+                ]
+              );
+              tester(
+                'pg-redshift',
+                'update "accounts" set "email" = ?, "first_name" = ?, "last_name" = ? where "id" = ?',
+                ['test100@example.com', 'UpdatedUser', 'UpdatedTest', 1],
+                1
+              );
+              tester(
+                'sqlite3',
+                'update `accounts` set `email` = ?, `first_name` = ?, `last_name` = ? where `id` = ? returning *',
+                ['test100@example.com', 'UpdatedUser', 'UpdatedTest', 1],
+                [
+                  {
+                    id: 1,
+                    first_name: 'UpdatedUser',
+                    last_name: 'UpdatedTest',
+                    email: 'test100@example.com',
+                    logins: 1,
+                    balance: 12.240000000000002,
+                    about: 'Lorem ipsum Dolore labore incididunt enim.',
+                    created_at: TEST_TIMESTAMP,
+                    updated_at: TEST_TIMESTAMP,
+                    phone: null,
+                  },
+                ]
+              );
+              tester(
+                'oracledb',
+                'update "accounts" set "email" = ?, "first_name" = ?, "last_name" = ? where "id" = ? returning "ROWID" into ?',
+                [
+                  'test100@example.com',
+                  'UpdatedUser',
+                  'UpdatedTest',
+                  1,
+                  (v) => v.toString() === '[object ReturningHelper:ROWID]',
+                ],
+                [
+                  {
+                    id: accountId1,
+                    first_name: 'UpdatedUser',
+                    last_name: 'UpdatedTest',
+                    email: 'test100@example.com',
+                    logins: 1,
+                    balance: 12.24,
+                    about: 'Lorem ipsum Dolore labore incididunt enim.',
+                    created_at: TEST_TIMESTAMP,
+                    updated_at: TEST_TIMESTAMP,
+                    phone: null,
+                  },
+                ]
+              );
+              tester(
+                'mssql',
+                'update [accounts] set [email] = ?, [first_name] = ?, [last_name] = ? output inserted.* where [id] = ?',
+                ['test100@example.com', 'UpdatedUser', 'UpdatedTest', '1'],
+                [
+                  {
+                    id: '1',
+                    first_name: 'UpdatedUser',
+                    last_name: 'UpdatedTest',
+                    email: 'test100@example.com',
+                    logins: 1,
+                    balance: 12.240000000000002,
+                    about: 'Lorem ipsum Dolore labore incididunt enim.',
+                    created_at: TEST_TIMESTAMP,
+                    updated_at: TEST_TIMESTAMP,
+                    phone: null,
+                  },
+                ]
+              );
+            });
+        });
       });
 
       it('with update query', async function () {


### PR DESCRIPTION
Should fix #3837 so that using update with returning * actually returns an object instead of the number of rows.
Also fixes the bug introduced within https://github.com/knex/knex/pull/3668 that causes the returning * to fail when run within a transaction