### PR TITLE
fix: add mjs extension type

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -85,7 +85,7 @@ async function initKnex(env, opts, useDefaultClientIfNotSpecified) {
 }
 
 function invoke() {
-  const filetypes = ['js', 'coffee', 'ts', 'eg', 'ls'];
+  const filetypes = ['js', 'mjs', 'coffee', 'ts', 'eg', 'ls'];
 
   const cwd = argv.knexfile
     ? path.dirname(path.resolve(argv.knexfile))


### PR DESCRIPTION
ES Modules are supported as migrations and seed file types (thanks to [prior PR](https://github.com/knex/knex/pull/4631)) but it didn't show up in the supported file types on the command-line.