### PR TITLE
Fix to make nested transaction receive userParams from outer transaction

### DIFF
--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -43,7 +43,10 @@ const validIsolationLevels = [
 class Transaction extends EventEmitter {
   constructor(client, container, config = DEFAULT_CONFIG(), outerTx = null) {
     super();
-    this.userParams = config.userParams;
+    this.userParams =
+      !config.userParams && outerTx && outerTx.userParams
+        ? outerTx.userParams
+        : config.userParams;
     this.doNotRejectOnRollback = config.doNotRejectOnRollback;
 
     const txid = (this.txid = uniqueId('trx'));

--- a/test/unit/knex.js
+++ b/test/unit/knex.js
@@ -381,6 +381,11 @@ describe('knex', () => {
         expect(trx.userParams).to.deep.equal({
           userParam: '451',
         });
+        await trx.transaction(async (trx2) => {
+          expect(trx2.userParams).to.deep.equal({
+            userParam: '451',
+          });
+        });
       });
 
       knex.destroy();


### PR DESCRIPTION
User params are passed from knex to the first transaction, but not from the first transaction to the next nested transaction. This PR fixes that.