### PR TITLE
Fix join table name when using alias and withSchema

### DIFF
--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -410,8 +410,19 @@ class QueryCompiler {
   }
 
   _joinTable(join) {
+    function addSchema(table) {
+      if (typeof table === 'object' && table !== null) {
+        // Make a shallow copy to prevent schema names from being stacked:
+        table = { ...table };
+        Object.keys(table).map((key) => {
+          table[key] = `${join.schema}.${table[key]}`;
+        });
+        return table;
+      }
+      return `${join.schema}.${table}`;
+    }
     return join.schema && !(join.table instanceof Raw)
-      ? `${join.schema}.${join.table}`
+      ? addSchema(join.table)
       : join.table;
   }
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -4720,22 +4720,23 @@ describe('QueryBuilder', () => {
         .select('*')
         .from('users')
         .join('contacts', 'users.id', '=', 'contacts.id')
-        .leftJoin('photos', 'users.id', '=', 'photos.id'),
+        .leftJoin('photos', 'users.id', '=', 'photos.id')
+        .leftJoin({ c: 'cards' }, 'users.id', '=', 'c.id'),
       {
         mysql: {
-          sql: 'select * from `myschema`.`users` inner join `myschema`.`contacts` on `users`.`id` = `contacts`.`id` left join `myschema`.`photos` on `users`.`id` = `photos`.`id`',
+          sql: 'select * from `myschema`.`users` inner join `myschema`.`contacts` on `users`.`id` = `contacts`.`id` left join `myschema`.`photos` on `users`.`id` = `photos`.`id` left join `myschema`.`cards` as `c` on `users`.`id` = `c`.`id`',
           bindings: [],
         },
         mssql: {
-          sql: 'select * from [myschema].[users] inner join [myschema].[contacts] on [users].[id] = [contacts].[id] left join [myschema].[photos] on [users].[id] = [photos].[id]',
+          sql: 'select * from [myschema].[users] inner join [myschema].[contacts] on [users].[id] = [contacts].[id] left join [myschema].[photos] on [users].[id] = [photos].[id] left join [myschema].[cards] as [c] on [users].[id] = [c].[id]',
           bindings: [],
         },
         pg: {
-          sql: 'select * from "myschema"."users" inner join "myschema"."contacts" on "users"."id" = "contacts"."id" left join "myschema"."photos" on "users"."id" = "photos"."id"',
+          sql: 'select * from "myschema"."users" inner join "myschema"."contacts" on "users"."id" = "contacts"."id" left join "myschema"."photos" on "users"."id" = "photos"."id" left join "myschema"."cards" as "c" on "users"."id" = "c"."id"',
           bindings: [],
         },
         'pg-redshift': {
-          sql: 'select * from "myschema"."users" inner join "myschema"."contacts" on "users"."id" = "contacts"."id" left join "myschema"."photos" on "users"."id" = "photos"."id"',
+          sql: 'select * from "myschema"."users" inner join "myschema"."contacts" on "users"."id" = "contacts"."id" left join "myschema"."photos" on "users"."id" = "photos"."id" left join "myschema"."cards" as "c" on "users"."id" = "c"."id"',
           bindings: [],
         },
       }


### PR DESCRIPTION
If you build a query using withSchema and add a join using an object to represent the table so you can utilize an alias, then the resulting query misnames the schema/table as [object, object]. This PR fixes this.