### PR TITLE
Fix .foreign to utilize withSchema setting

### DIFF
--- a/lib/schema/tablebuilder.js
+++ b/lib/schema/tablebuilder.js
@@ -80,7 +80,11 @@ class TableBuilder {
   // `table.foreign('column_name').references('column').on('table').onDelete()...
   // Also called from the ColumnBuilder context when chaining.
   foreign(column, keyName) {
-    const foreignData = { column: column, keyName: keyName };
+    const foreignData = {
+      column: column,
+      keyName: keyName,
+      schema: this._schemaName,
+    };
     this._statements.push({
       grouping: 'alterTable',
       method: 'foreign',

--- a/lib/schema/tablecompiler.js
+++ b/lib/schema/tablecompiler.js
@@ -100,7 +100,11 @@ class TableCompiler {
         : this._indexCommand('foreign', this.tableNameRaw, foreignData.column);
       const column = this.formatter.columnize(foreignData.column);
       const references = this.formatter.columnize(foreignData.references);
-      const inTable = this.formatter.wrap(foreignData.inTable);
+      const inTable = this.formatter.wrap(
+        foreignData.schema
+          ? `${foreignData.schema}.${foreignData.inTable}`
+          : foreignData.inTable
+      );
       const onUpdate = foreignData.onUpdate
         ? (this.lowerCase ? ' on update ' : ' ON UPDATE ') +
           foreignData.onUpdate

--- a/test/unit/schema-builder/mssql.js
+++ b/test/unit/schema-builder/mssql.js
@@ -703,6 +703,19 @@ describe('MSSQL SchemaBuilder', function () {
 
     tableSql = client
       .schemaBuilder()
+      .withSchema('schema1')
+      .table('users', function () {
+        this.foreign('foo_id').references('id').on('orders');
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'ALTER TABLE [schema1].[users] ADD CONSTRAINT [users_foo_id_foreign] FOREIGN KEY ([foo_id]) REFERENCES [schema1].[orders] ([id])'
+    );
+
+    tableSql = client
+      .schemaBuilder()
       .table('users', function () {
         this.integer('foo_id').references('id').on('orders');
       })

--- a/test/unit/schema-builder/oracle.js
+++ b/test/unit/schema-builder/oracle.js
@@ -331,6 +331,19 @@ describe('Oracle SchemaBuilder', function () {
 
     tableSql = client
       .schemaBuilder()
+      .withSchema('schema1')
+      .table('users', function () {
+        this.foreign('foo_id').references('id').on('orders');
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "schema1"."users" add constraint "users_foo_id_foreign" foreign key ("foo_id") references "schema1"."orders" ("id")'
+    );
+
+    tableSql = client
+      .schemaBuilder()
       .table('users', function () {
         this.integer('foo_id').references('id').on('orders');
       })

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -815,6 +815,18 @@ describe('PostgreSQL SchemaBuilder', function () {
 
     tableSql = client
       .schemaBuilder()
+      .withSchema('schema1')
+      .table('users', function () {
+        this.foreign('foo_id').references('id').on('orders');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'alter table "schema1"."users" add constraint "users_foo_id_foreign" foreign key ("foo_id") references "schema1"."orders" ("id")'
+    );
+
+    tableSql = client
+      .schemaBuilder()
       .table('users', function () {
         this.integer('foo_id').references('id').on('orders');
       })

--- a/test/unit/schema-builder/redshift.js
+++ b/test/unit/schema-builder/redshift.js
@@ -454,6 +454,17 @@ describe('Redshift SchemaBuilder', function () {
     expect(tableSql[1].sql).to.equal(
       'alter table "accounts" add constraint "accounts_account_id_foreign" foreign key ("account_id") references "users" ("id")'
     );
+
+    tableSql = client
+      .schemaBuilder()
+      .withSchema('schema1')
+      .createTable('accounts', function (table) {
+        table.integer('account_id').references('users.id');
+      })
+      .toSQL();
+    expect(tableSql[1].sql).to.equal(
+      'alter table "schema1"."accounts" add constraint "accounts_account_id_foreign" foreign key ("account_id") references "schema1"."users" ("id")'
+    );
   });
 
   it('adds foreign key with onUpdate and onDelete', function () {


### PR DESCRIPTION
When using `table.foreign()` it does not utilize the schema from `knex.schema.withSchema()`. As a result, the foreign key ends up referencing a table with no schema specified.

This seems like fragile behavior and I'm not sure what the preferred work around would be.

Also see #4910.

This PR makes `table.foreign()` utilize the schema from `knex.schema.withSchema()` (if set).