### PR TITLE
Fix knex d.ts to work with Node16 module mode

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,8 +13,8 @@ import ResultTypes = require('./result');
 
 import { Tables } from './tables';
 
-import { ConnectionOptions } from 'tls';
 import { Stream } from 'stream';
+import { ConnectionOptions } from 'tls';
 
 // # Generic type-level utilities
 
@@ -374,7 +374,7 @@ interface DMLOptions {
   includeTriggerModifications?: boolean;
 }
 
-export interface Knex<TRecord extends {} = any, TResult = any[]>
+interface Knex<TRecord extends {} = any, TResult = any[]>
   extends Knex.QueryInterface<TRecord, TResult>,
     events.EventEmitter {
   <TTable extends Knex.TableNames>(
@@ -436,12 +436,13 @@ export interface Knex<TRecord extends {} = any, TResult = any[]>
   isTransaction?: boolean;
 }
 
-export declare function knex<TRecord extends {} = any, TResult = unknown[]>(
+declare function knex<TRecord extends {} = any, TResult = unknown[]>(
   config: Knex.Config | string
 ): Knex<TRecord, TResult>;
 
-export declare namespace knex {
-  class QueryBuilder {
+declare namespace knex {
+  export { knex, knex as default, Knex };
+  export class QueryBuilder {
     static extend(
       methodName: string,
       fn: <TRecord extends {} = any, TResult extends {} = unknown[]>(
@@ -456,25 +457,25 @@ export declare namespace knex {
     ): void;
   }
 
-  class TableBuilder {
+  export class TableBuilder {
     static extend<T = Knex.TableBuilder, B = Knex.TableBuilder>(
       methodName: string,
       fn: (this: T, ...args: any[]) => B
     ): void;
   }
-  class ViewBuilder {
+  export class ViewBuilder {
     static extend<T = Knex.ViewBuilder, B = Knex.ViewBuilder>(
       methodName: string,
       fn: (this: T, ...args: any[]) => B
     ): void;
   }
-  class SchemaBuilder {
+  export class SchemaBuilder {
     static extend<T = Knex.SchemaBuilder, B = Knex.SchemaBuilder>(
       methodName: string,
       fn: (this: T, ...args: any[]) => B
     ): void;
   }
-  class ColumnBuilder {
+  export class ColumnBuilder {
     static extend<T = Knex.ColumnBuilder, B = Knex.ColumnBuilder>(
       methodName: string,
       fn: (this: T, ...args: any[]) => B
@@ -486,7 +487,7 @@ export declare namespace knex {
   export const Client: typeof Knex.Client;
 }
 
-export declare namespace Knex {
+declare namespace Knex {
   //
   // Utility Types
   //
@@ -2116,10 +2117,7 @@ export declare namespace Knex {
 
   interface RawBuilder<TRecord extends {} = any, TResult = any> {
     <TResult2 = TResult>(value: Value): Raw<TResult2>;
-    <TResult2 = TResult>(
-      sql: string,
-      binding: RawBinding
-    ): Raw<TResult2>;
+    <TResult2 = TResult>(sql: string, binding: RawBinding): Raw<TResult2>;
     <TResult2 = TResult>(
       sql: string,
       bindings: readonly RawBinding[] | ValueDict
@@ -3271,4 +3269,4 @@ export declare namespace Knex {
   }
 }
 
-export default knex;
+export = knex;


### PR DESCRIPTION
Currently, the knex type declarations use `export default` as if it were an ES module. This has not mattered up until recently with Node's increased ESM support and TypeScript's `node16` module setting, which is the TypeScript's team [recommended setting](https://github.com/microsoft/TypeScript/issues/52529#issuecomment-1672036026) for Node users.

Bear with me - this is a bit convoluted. Node's [behavior when importing CJS from an ES module](https://nodejs.org/api/esm.html#import-statements) is to make `module.exports` the default export. TypeScript adheres to this, which leads to some weird quirks when we look at knex's type declarations. TS properly detects knex as a CJS module, and when it sees a default export in the declarations, it assumes that the `knex` function is set to `module.exports.default` (which it _also_ is) but _not_ to `module.exports`.  So to TS, under `node16` module mode, the default export from knex is simply an object with a `default` property. It cannot be called as a function, even though this is perfectly legal at runtime.

What's the fix here? It's quite simple. Use `export =` syntax to describe the CJS export, and declare the circular references [set in `knex.js`](https://github.com/knex/knex/blob/5ececd35c9520dd2a006ee27721178dc465a8a8c/knex.js#L20-L21). This works perfectly in both the new world and old, since we are explicitly telling TS the shape of the proper CJS export rather than having it make assumptions.