### PR TITLE
Add type definitions for orHavingNull and orHavingNotNull

### DIFF
--- a/test-tsd/having.test-d.ts
+++ b/test-tsd/having.test-d.ts
@@ -16,6 +16,22 @@ const main = async () => {
     await knex<User>('users')
       .groupBy('count')
       .orderBy('name', 'desc')
+      .havingNull('age')
+      .orHavingNull('name')
+  );
+
+  expectType<User[]>(
+    await knex<User>('users')
+      .groupBy('count')
+      .orderBy('name', 'desc')
       .havingNotNull('age')
   );
+
+  expectType<User[]>(
+    await knex<User>('users')
+      .groupBy('count')
+      .orderBy('name', 'desc')
+      .havingNotNull('age')
+      .orHavingNotNull('name')
+  );  
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -733,6 +733,8 @@ export declare namespace Knex {
     orHavingNotIn: HavingRange<TRecord, TResult>;
     havingNull: HavingNull<TRecord, TResult>;
     havingNotNull: HavingNull<TRecord, TResult>;
+    orHavingNull: HavingNull<TRecord, TResult>;
+    orHavingNotNull: HavingNull<TRecord, TResult>;
 
     // Clear
     clearSelect(): QueryBuilder<


### PR DESCRIPTION
This PR is to add type definitions for `orHavingNull` and `orHavingNotNull`

This is a follow up from https://github.com/knex/knex/pull/5529 which added type definitions for `havingNull` and `havingNotNull` which I've used as a reference

