### PR TITLE
feat(transaction): add method to execute functions after transaction

### DIFF
--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -54,6 +54,7 @@ class Transaction extends EventEmitter {
     this.trxClient = undefined;
     this._completed = false;
     this._debug = client.config && client.config.debug;
+    this._afterTxFunctions = [];
 
     this.readOnly = config.readOnly;
     if (config.isolationLevel) {
@@ -90,6 +91,11 @@ class Transaction extends EventEmitter {
       //      exceptions are caught and ignored.
       outerTx._lastChild = basePromise.catch(() => {});
     }
+  }
+
+  addFunctionOnAfterTransaction(cb) {
+    this._afterTxFunctions.push(cb);
+    return;
   }
 
   isCompleted() {
@@ -173,12 +179,20 @@ class Transaction extends EventEmitter {
       })
       .then((res) => {
         if (status === 1) {
-          this._resolver(value);
+          if (this._afterTxFunctions.length > 0) {
+            this._processAfterTransaction(value);
+          } else {
+            this._resolver(value);
+          }
         }
         if (status === 2) {
           if (value === undefined) {
             if (this.doNotRejectOnRollback && /^ROLLBACK\b/i.test(sql)) {
-              this._resolver();
+              if (this._afterTxFunctions.length > 0) {
+                this._processAfterTransaction();
+              } else {
+                this._resolver();
+              }
               return;
             }
 
@@ -197,6 +211,12 @@ class Transaction extends EventEmitter {
   debug(enabled) {
     this._debug = arguments.length ? enabled : true;
     return this;
+  }
+
+  _processAfterTransaction(value) {
+    return this._afterTxFunctions
+      .reduce((prev, cur) => prev.then(cur), Promise.resolve())
+      .then(() => this._resolver(value));
   }
 
   async _evaluateContainer(config, container) {
@@ -226,7 +246,9 @@ class Transaction extends EventEmitter {
           // Directly thrown errors are treated as automatic rollbacks.
           let result;
           try {
+            console.log('que');
             result = container(transactor);
+            console.log('no');
           } catch (err) {
             result = Promise.reject(err);
           }
@@ -324,6 +346,8 @@ function makeTransactor(trx, connection, trxClient) {
   }
 
   transactor.isCompleted = () => trx.isCompleted();
+  transactor.addFunctionOnAfterTransaction = (cb) =>
+    trx.addFunctionOnAfterTransaction(cb);
 
   return transactor;
 }

--- a/test/integration/execution/transaction.js
+++ b/test/integration/execution/transaction.js
@@ -395,6 +395,27 @@ module.exports = function (knex) {
         });
     });
 
+    it('should execute functions after transaction', function () {
+      let change1 = false;
+      let change2 = false;
+      return knex
+        .transaction(function (trx) {
+          trx.addFunctionOnAfterTransaction(async () => {
+            change1 = true;
+          });
+          trx.addFunctionOnAfterTransaction(async () => {
+            change2 = true;
+          });
+          trx.debugging = true;
+          return Promise.resolve(null);
+        })
+        .then(function (result) {
+          expect(result).to.equal(null);
+          expect(change1).to.be.true;
+          expect(change2).to.be.true;
+        });
+    });
+
     it('does not reject promise when rolling back a transaction', async () => {
       const trxProvider = knex.transactionProvider();
       const trx = await trxProvider();


### PR DESCRIPTION
When using transactions, people can have some functions that must be executed if transaction is committed, but these function could also depend on results of db operations. It could be useful to save these functions on the transaction itself and only at the end of its execution to be able to execute all the expected async logic to be executed too. 