### PR TITLE
fix error on postgres when setting query_timeout

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -194,7 +194,9 @@ class Client_PG extends Client {
 
     return new Promise(function (resolver, rejecter) {
       const queryStream = connection.query(
-        new PGQueryStream(sql, obj.bindings, options)
+        new PGQueryStream(sql, obj.bindings, options), err => {
+          rejecter(err);
+        }
       );
 
       queryStream.on('error', function (error) {


### PR DESCRIPTION
This should fix the unhandled error when using Postgres stream with query_timeout.
After the fix, you can use: pipeline API and catch the error on query timeout as expected.