### PR TITLE
Force table usage in typing

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -388,7 +388,7 @@ export interface Knex<TRecord extends {} = any, TResult = any[]>
     TRecord2 extends {} = TRecord,
     TResult2 = DeferredKeySelection<TRecord2, never>[]
   >(
-    tableName?: Knex.TableDescriptor | Knex.AliasDict,
+    tableName: Knex.TableDescriptor | Knex.AliasDict,
     options?: TableOptions
   ): Knex.QueryBuilder<TRecord2, TResult2>;
   VERSION: string;


### PR DESCRIPTION
This will get rid of that annoying deprecated message for Typescript users.