### PR TITLE
Add create and drop schema for mssql

### DIFF
--- a/lib/dialects/mssql/schema/mssql-compiler.js
+++ b/lib/dialects/mssql/schema/mssql-compiler.js
@@ -80,6 +80,26 @@ class SchemaCompiler_MSSQL extends SchemaCompiler {
       `and object_id = object_id(${formattedTable})`;
     this.pushQuery({ sql, output: (resp) => resp.length > 0 });
   }
+
+  createSchema(schemaName) {
+    this.pushQuery(`CREATE SCHEMA ${this.formatter.wrap(schemaName)}`);
+  }
+
+  createSchemaIfNotExists(schemaName) {
+    this.pushQuery(
+      `IF schema_id('${schemaName}') IS NULL EXEC('CREATE SCHEMA ${this.formatter.wrap(
+        schemaName
+      )}')`
+    );
+  }
+
+  dropSchema(schemaName) {
+    this.pushQuery(`DROP SCHEMA ${this.formatter.wrap(schemaName)}`);
+  }
+
+  dropSchemaIfExists(schemaName) {
+    this.pushQuery(`DROP SCHEMA IF EXISTS ${this.formatter.wrap(schemaName)}`);
+  }
 }
 
 SchemaCompiler_MSSQL.prototype.dropTablePrefix = 'DROP TABLE ';

--- a/lib/schema/compiler.js
+++ b/lib/schema/compiler.js
@@ -22,19 +22,19 @@ class SchemaCompiler {
   }
 
   createSchema() {
-    throwOnlyPGError('createSchema');
+    throwOnlyPGAndMSSQLError('createSchema');
   }
 
   createSchemaIfNotExists() {
-    throwOnlyPGError('createSchemaIfNotExists');
+    throwOnlyPGAndMSSQLError('createSchemaIfNotExists');
   }
 
   dropSchema() {
-    throwOnlyPGError('dropSchema');
+    throwOnlyPGAndMSSQLError('dropSchema');
   }
 
   dropSchemaIfExists() {
-    throwOnlyPGError('dropSchemaIfExists');
+    throwOnlyPGAndMSSQLError('dropSchemaIfExists');
   }
 
   dropTable(tableName) {
@@ -178,9 +178,9 @@ function prefixedTableName(prefix, table) {
   return prefix ? `${prefix}.${table}` : table;
 }
 
-function throwOnlyPGError(operationName) {
+function throwOnlyPGAndMSSQLError(operationName) {
   throw new Error(
-    `${operationName} is not supported for this dialect (only PostgreSQL supports it currently).`
+    `${operationName} is not supported for this dialect (only PostgreSQL and MSSQL supports it currently).`
   );
 }
 


### PR DESCRIPTION
Add createSchema/createIfNotExistsSchema and dropSchema/dropSchemaIfExists to mssql
Fix mssql test, when running 2x or more integration tests "npm run test:mssql" one error occurred