### PR TITLE
Fix raw sql replacer to correctly escape question marks as documented

### DIFF
--- a/lib/formatter/rawFormatter.js
+++ b/lib/formatter/rawFormatter.js
@@ -10,7 +10,7 @@ function replaceRawArrBindings(raw, client) {
   const values = raw.bindings;
   let index = 0;
 
-  const sql = raw.sql.replace(/\\?\?\??/g, function (match) {
+  const sql = raw.sql.replace(/\\?\\?\?\??/g, function (match) {
     if (match === '\\?') {
       return match;
     }


### PR DESCRIPTION
Raw formatter was using incorrect regex to correctly parse binding escapes, as it could never select `\\?` so its escape if on lines 14,15 and 16 would never trigger

Could not test fully because of working on arm platform currently, so please check