### PR TITLE
Import knex as type in TS migration template

### DIFF
--- a/lib/migrations/migrate/stub/ts.stub
+++ b/lib/migrations/migrate/stub/ts.stub
@@ -1,4 +1,4 @@
-import { Knex } from "knex";
+import type { Knex } from "knex";
 
 <% if (d.tableName) { %>
 export async function up(knex: Knex): Promise<Knex.SchemaBuilder> {


### PR DESCRIPTION
To match `@typescript-eslint/consistent-type-imports` eslint rule.