### PR TITLE
implement faster table rename for mysql version >= 8

### DIFF
--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -76,6 +76,22 @@ class TableCompiler_MySQL extends TableCompiler {
     const table = this.tableName();
     const wrapped = this.formatter.wrap(from) + ' ' + this.formatter.wrap(to);
 
+    let majorVersion = 0;
+    if (this.client.version) {
+      const s = this.client.version.split('.');
+      if (s.length) {
+        majorVersion = Number.parseInt(s[0]);
+      }
+    }
+
+    if (majorVersion >= 8) {
+      return this.pushQuery({
+        sql: `alter table ${this.tableName()} rename column ${this.formatter.wrap(
+          from
+        )} to ${this.formatter.wrap(to)}`,
+      });
+    }
+
     this.pushQuery({
       sql:
         `show full fields from ${table} where field = ` +

--- a/test/integration2/query/misc/additional.spec.js
+++ b/test/integration2/query/misc/additional.spec.js
@@ -640,6 +640,9 @@ describe('Additional', function () {
               tester('mysql', [
                 'show full fields from `accounts` where field = ?',
               ]);
+              tester('mysql2', [
+                'alter table `accounts` rename column `about` to `about_col`',
+              ]);
               tester('pg', [
                 'alter table "accounts" rename "about" to "about_col"',
               ]);

--- a/test/integration2/util/knex-instance-provider.js
+++ b/test/integration2/util/knex-instance-provider.js
@@ -91,6 +91,7 @@ const testConfigs = {
 
   mysql2: {
     client: 'mysql2',
+    version: '8.0.13',
     connection: testConfig.mysql || {
       port: 23306,
       database: 'knex_test',

--- a/test/unit/schema-builder/mysql.js
+++ b/test/unit/schema-builder/mysql.js
@@ -489,6 +489,24 @@ module.exports = function (dialect) {
       expect(tableSql[0].sql).to.equal('rename table `users` to `foo`');
     });
 
+    it('test rename column with mysql >= 8', function () {
+      client.version = '8.0.13';
+
+      tableSql = tableSql = client
+        .schemaBuilder()
+        .table('users', function () {
+          this.renameColumn('foo', 'bar');
+        })
+        .toSQL();
+
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'alter table `users` rename column `foo` to `bar`'
+      );
+
+      delete client.version;
+    });
+
     it('test adding primary key', function () {
       tableSql = client
         .schemaBuilder()


### PR DESCRIPTION
hello!

since mysql version 8 there is a faster way to do column renames: `alter table t rename column x to y`. The performance difference is huge if the altered table is big. I've implemented this new way of doing things in this PR.

This is my first contribution, please be gentle. I'm sure there are certain things to be fixed before this can be merged, so feel free to let me know.

One thing that is up for debate for example is that this code will try to read a version config given by the user. Up until now it seems like we're doing this only for postgres.

Another thing: do we want to extract the version parsing into its own function?

cheers