### PR TITLE
Fix types for TypeScript 5.4

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -561,7 +561,7 @@ declare namespace Knex {
   type ResolveTableType<
     TCompositeTableType,
     TScope extends TableInterfaceScope = 'base'
-  > = TCompositeTableType extends CompositeTableType<unknown>
+  > = TCompositeTableType extends CompositeTableType<{}>
     ? TCompositeTableType[TScope]
     : TCompositeTableType;
 


### PR DESCRIPTION
Compiling the file `types/index.d.ts` with version 5.4 of TypeScript (currently nightly) produces the following errors:

```
knex/types/index.d.ts(1241,50): error TS2344: Type 'ResolveTableType<TRecord, "base">' does not satisfy the constraint '{}'.
  Type 'unknown' is not assignable to type '{}'.
knex/types/index.d.ts(1256,50): error TS2344: Type 'ResolveTableType<TRecord, "base">' does not satisfy the constraint '{}'.
```
This was caused by [this change](https://github.com/microsoft/TypeScript/pull/56004).

This PR fixes these errors.