### PR TITLE
Update index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1400,7 +1400,7 @@ declare namespace Knex {
       TRecord2 extends {} = {},
       TResult2 = DeferredKeySelection.ReplaceBase<TResult, TRecord2>
     >(
-      callback: Function,
+      callback: (this: QueryBuilder<TRecord2, TResult2>) => QueryBuilder<TRecord2, TResult2>,
       options?: TableOptions
     ): QueryBuilder<TRecord2, TResult2>;
     <


### PR DESCRIPTION
for below example will tell me `'this' implicitly has type 'any' because it does not have a type annotation.ts(2683)`
```ts
const b = knex.select().from(function () {
        return this.select().as('a');
    }).toQuery();
```