### PR TITLE
Handle Vendor Prefixed Postgres Version Strings

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -132,7 +132,7 @@ class Client_PG extends Client {
   }
 
   _parseVersion(versionString) {
-    return /^PostgreSQL (.*?)( |$)/.exec(versionString)[1];
+    return /PostgreSQL (.*?)( |$)/.exec(versionString)[1];
   }
 
   // Position the bindings for the query. The escape sequence for question mark


### PR DESCRIPTION
The existing regex pattern expects the version string to start with 'PostgresSQL'. Unfortunately, some vendors like Oracle are getting creative with version strings: 'OCI Optimized PostgreSQL 14.9, 64-bit'