### PR TITLE
sqlite: insert use normal values syntax, fix returning

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -5,3 +5,6 @@
 
 # Do not include tsc source maps
 **/*.js.map
+
+# Do not include .js files from .ts files
+dialects/index.js

--- a/lib/dialects/sqlite3/query/sqlite-querycompiler.js
+++ b/lib/dialects/sqlite3/query/sqlite-querycompiler.js
@@ -27,13 +27,11 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
     this.forNoKeyUpdate = emptyStr;
   }
 
-  // SQLite requires us to build the multi-row insert as a listing of select with
-  // unions joining them together. So we'll build out this list of columns and
-  // then join them all together with select unions to complete the queries.
   insert() {
     const insertValues = this.single.insert || [];
     let sql = this.with() + `insert into ${this.tableName} `;
 
+    let emptyInsert = false;
     if (Array.isArray(insertValues)) {
       if (insertValues.length === 0) {
         return '';
@@ -42,102 +40,64 @@ class QueryCompiler_SQLite3 extends QueryCompiler {
         insertValues[0] &&
         isEmpty(insertValues[0])
       ) {
-        return {
-          sql: sql + this._emptyInsertValue,
-        };
+        emptyInsert = true;
       }
     } else if (typeof insertValues === 'object' && isEmpty(insertValues)) {
-      return {
-        sql: sql + this._emptyInsertValue,
-      };
+      emptyInsert = true;
     }
 
-    const insertData = this._prepInsert(insertValues);
+    if (emptyInsert) {
+      sql += this._emptyInsertValue;
+    } else {
+      const insertData = this._prepInsert(insertValues);
 
-    if (isString(insertData)) {
-      return {
-        sql: sql + insertData,
-      };
-    }
+      if (isString(insertData)) {
+        sql += insertData;
+      } else if (insertData.columns.length === 0) {
+        return {
+          sql: '',
+        };
+      } else {
+        sql += `(${this.formatter.columnize(insertData.columns)})`;
 
-    if (insertData.columns.length === 0) {
-      return {
-        sql: '',
-      };
-    }
+        // backwards compatible error
+        if (this.client.valueForUndefined !== null) {
+          insertData.values.forEach((bindings) => {
+            each(bindings, (binding) => {
+              if (binding === undefined)
+                throw new TypeError(
+                  '`sqlite` does not support inserting default values. Specify ' +
+                    'values explicitly or use the `useNullAsDefault` config flag. ' +
+                    '(see docs https://knexjs.org/guide/query-builder.html#insert).'
+                );
+            });
+          });
+        }
 
-    sql += `(${this.formatter.columnize(insertData.columns)})`;
-
-    // backwards compatible error
-    if (this.client.valueForUndefined !== null) {
-      insertData.values.forEach((bindings) => {
-        each(bindings, (binding) => {
-          if (binding === undefined)
-            throw new TypeError(
-              '`sqlite` does not support inserting default values. Specify ' +
-                'values explicitly or use the `useNullAsDefault` config flag. ' +
-                '(see docs https://knexjs.org/guide/query-builder.html#insert).'
-            );
-        });
-      });
-    }
-
-    if (insertData.values.length === 1) {
-      const parameters = this.client.parameterize(
-        insertData.values[0],
-        this.client.valueForUndefined,
-        this.builder,
-        this.bindingsHolder
-      );
-      sql += ` values (${parameters})`;
-
-      const { onConflict, ignore, merge } = this.single;
-      if (onConflict && ignore) sql += this._ignore(onConflict);
-      else if (onConflict && merge) {
-        sql += this._merge(merge.updates, onConflict, insertValues);
-        const wheres = this.where();
-        if (wheres) sql += ` ${wheres}`;
+        sql +=
+          ` values ` +
+          insertData.values
+            .map(
+              (row) =>
+                '(' +
+                this.client.parameterize(
+                  row,
+                  this.client.valueForUndefined,
+                  this.builder,
+                  this.bindingsHolder
+                ) +
+                ')'
+            )
+            .join(', ');
       }
-
-      const { returning } = this.single;
-      if (returning) {
-        sql += this._returning(returning);
-      }
-
-      return {
-        sql,
-        returning,
-      };
     }
-
-    const blocks = [];
-    let i = -1;
-    while (++i < insertData.values.length) {
-      let i2 = -1;
-      const block = (blocks[i] = []);
-      let current = insertData.values[i];
-      current = current === undefined ? this.client.valueForUndefined : current;
-      while (++i2 < insertData.columns.length) {
-        block.push(
-          this.client.alias(
-            this.client.parameter(
-              current[i2],
-              this.builder,
-              this.bindingsHolder
-            ),
-            this.formatter.wrap(insertData.columns[i2])
-          )
-        );
-      }
-      blocks[i] = block.join(', ');
-    }
-    sql += ' select ' + blocks.join(' union all select ');
 
     const { onConflict, ignore, merge } = this.single;
-    if (onConflict && ignore) sql += ' where true' + this._ignore(onConflict);
+    if (onConflict && ignore) sql += this._ignore(onConflict);
     else if (onConflict && merge) {
-      sql +=
-        ' where true' + this._merge(merge.updates, onConflict, insertValues);
+      sql += this._merge(merge.updates, onConflict, insertValues);
+      const wheres = this.where();
+      if (wheres) sql += ` ${wheres}`;
     }
 
     const { returning } = this.single;

--- a/test/integration2/query/insert/inserts.spec.js
+++ b/test/integration2/query/insert/inserts.spec.js
@@ -256,7 +256,7 @@ describe('Inserts', function () {
             );
             tester(
               'sqlite3',
-              'insert into `accounts` (`about`, `created_at`, `email`, `first_name`, `last_name`, `logins`, `updated_at`) select ? as `about`, ? as `created_at`, ? as `email`, ? as `first_name`, ? as `last_name`, ? as `logins`, ? as `updated_at` union all select ? as `about`, ? as `created_at`, ? as `email`, ? as `first_name`, ? as `last_name`, ? as `logins`, ? as `updated_at` returning `id`',
+              'insert into `accounts` (`about`, `created_at`, `email`, `first_name`, `last_name`, `logins`, `updated_at`) values (?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?) returning `id`',
               [
                 'Lorem ipsum Dolore labore incididunt enim.',
                 TEST_TIMESTAMP,
@@ -474,7 +474,7 @@ describe('Inserts', function () {
             );
             tester(
               'sqlite3',
-              'insert into `accounts` (`about`, `created_at`, `email`, `first_name`, `last_name`, `logins`, `updated_at`) select ? as `about`, ? as `created_at`, ? as `email`, ? as `first_name`, ? as `last_name`, ? as `logins`, ? as `updated_at` union all select ? as `about`, ? as `created_at`, ? as `email`, ? as `first_name`, ? as `last_name`, ? as `logins`, ? as `updated_at` returning `id`',
+              'insert into `accounts` (`about`, `created_at`, `email`, `first_name`, `last_name`, `logins`, `updated_at`) values (?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?) returning `id`',
               [
                 'Lorem ipsum Dolore labore incididunt enim.',
                 TEST_TIMESTAMP,
@@ -891,9 +891,9 @@ describe('Inserts', function () {
             );
             tester(
               'sqlite3',
-              'insert into `test_default_table` default values',
+              'insert into `test_default_table` default values returning `id`',
               [],
-              [1]
+              [{ id: 1 }]
             );
             tester(
               'oracledb',
@@ -958,9 +958,9 @@ describe('Inserts', function () {
             );
             tester(
               'sqlite3',
-              'insert into `test_default_table2` default values',
+              'insert into `test_default_table2` default values returning `id`',
               [],
-              [1]
+              [{ id: 1 }]
             );
             tester(
               'oracledb',
@@ -1974,7 +1974,7 @@ describe('Inserts', function () {
               );
               tester(
                 'sqlite3',
-                'insert into `upsert_tests` (`email`, `name`) select ? as `email`, ? as `name` union all select ? as `email`, ? as `name` where true on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name` returning `email`',
+                'insert into `upsert_tests` (`email`, `name`) values (?, ?), (?, ?) on conflict (`email`) do update set `email` = excluded.`email`, `name` = excluded.`name` returning `email`',
                 ['two@example.com', 'AFTER', 'three@example.com', 'AFTER']
               );
             });
@@ -2055,7 +2055,7 @@ describe('Inserts', function () {
               );
               tester(
                 'sqlite3',
-                'insert into `upsert_tests` (`email`, `name`, `type`) select ? as `email`, ? as `name`, ? as `type` union all select ? as `email`, ? as `name`, ? as `type` union all select ? as `email`, ? as `name`, ? as `type` where true ' +
+                'insert into `upsert_tests` (`email`, `name`, `type`) values (?, ?, ?), (?, ?, ?), (?, ?, ?) ' +
                   "on conflict (email) where type = 'type1' do update set `email` = excluded.`email`, `name` = excluded.`name`, `type` = excluded.`type`",
                 [
                   'one@example.com',


### PR DESCRIPTION
Knex was losing the `returning` clause when doing `insert default values` even though [SQLite supports](https://www.sqlite.org/lang_insert.html) it, and arguably the returning clause is most important in the default values case.

Also while I was there, I noticed SQLite was generating a weird `select ... union all select` syntax for multi-row inserts which is not actually necessary as [SQLite supports](https://www.sqlite.org/lang_insert.html) the same `values (), ()` syntax all the others do.

I find it frustrating that if the `returning` clause isn't supported (such as by redshift) that Knex just silently ignores it and returns unexpected values.

Tests pass locally.