### PR TITLE
Fix FOR UPDATE OF with explicit schema

### DIFF
--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -205,9 +205,16 @@ class QueryCompiler_PG extends QueryCompiler {
   _lockingClause(lockMode) {
     const tables = this.single.lockTables || [];
 
-    return lockMode + (tables.length
-      ? ' of ' + tables.filter(Boolean).map(table => this.formatter.wrap(table)).join(', ')
-      : '');
+    return (
+      lockMode +
+      (tables.length
+        ? ' of ' +
+          tables
+            .filter(Boolean)
+            .map((table) => this.formatter.wrap(table))
+            .join(', ')
+        : '')
+    );
   }
 
   _groupOrder(item, type) {

--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -202,29 +202,12 @@ class QueryCompiler_PG extends QueryCompiler {
     }
   }
 
-  // Join array of table names and apply default schema.
-  _tableNames(tables) {
-    const schemaName = this.single.schema;
-    const sql = [];
-
-    for (let i = 0; i < tables.length; i++) {
-      let tableName = tables[i];
-
-      if (tableName) {
-        if (schemaName) {
-          tableName = `${schemaName}.${tableName}`;
-        }
-        sql.push(this.formatter.wrap(tableName));
-      }
-    }
-
-    return sql.join(', ');
-  }
-
   _lockingClause(lockMode) {
     const tables = this.single.lockTables || [];
 
-    return lockMode + (tables.length ? ' of ' + this._tableNames(tables) : '');
+    return lockMode + (tables.length
+      ? ' of ' + tables.filter(Boolean).map(table => this.formatter.wrap(table)).join(', ')
+      : '');
   }
 
   _groupOrder(item, type) {

--- a/test/integration2/query/select/selects.spec.js
+++ b/test/integration2/query/select/selects.spec.js
@@ -994,7 +994,7 @@ describe('Selects', function () {
         try {
           await knex.transaction((trx) => {
             // select all from two test tables and lock only one table
-            return trx('test_default_table')
+            return trx.withSchema('public').from('test_default_table')
               .innerJoin(
                 'test_default_table2',
                 'test_default_table.tinyint',
@@ -1011,6 +1011,7 @@ describe('Selects', function () {
               });
           });
         } catch (err) {
+          console.log(err.message);
           expect(err.message).to.be.contain(
             'Defined query timeout of 100ms exceeded when running query'
           );

--- a/test/integration2/query/select/selects.spec.js
+++ b/test/integration2/query/select/selects.spec.js
@@ -1011,7 +1011,6 @@ describe('Selects', function () {
               });
           });
         } catch (err) {
-          console.log(err.message);
           expect(err.message).to.be.contain(
             'Defined query timeout of 100ms exceeded when running query'
           );

--- a/test/integration2/query/select/selects.spec.js
+++ b/test/integration2/query/select/selects.spec.js
@@ -994,7 +994,9 @@ describe('Selects', function () {
         try {
           await knex.transaction((trx) => {
             // select all from two test tables and lock only one table
-            return trx.withSchema('public').from('test_default_table')
+            return trx
+              .withSchema('public')
+              .from('test_default_table')
               .innerJoin(
                 'test_default_table2',
                 'test_default_table.tinyint',

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -7394,6 +7394,23 @@ describe('QueryBuilder', () => {
     );
   });
 
+  it('lock only some tables for update with explicit schema (#5053)', () => {
+    testsql(
+      qb()
+        .withSchema('public')
+        .select('*')
+        .from('foo')
+        .where('bar', '=', 'baz')
+        .forUpdate('lo', 'rem'),
+      {
+        pg: {
+          sql: 'select * from "public"."foo" where "bar" = ? for update of "lo", "rem"',
+          bindings: ['baz'],
+        },
+      }
+    );
+  });
+
   it('lock for update with skip locked #1937', () => {
     testsql(qb().select('*').from('foo').first().forUpdate().skipLocked(), {
       mysql: {


### PR DESCRIPTION
When calling `.withSchema(...)....forUpdate('someTable')`, knex would produce incorrect sql syntax—it included the schema name in the table name, prompting a "FOR UPDATE must specify unqualified relation names" error from postgresql. 

Fixes #5053.