### PR TITLE
Missing comments on delete, update and insert for pg dialect

### DIFF
--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -19,7 +19,8 @@ class QueryCompiler_PG extends QueryCompiler {
 
   // Compiles a truncate query.
   truncate() {
-    return `truncate ${this.tableName} restart identity`;
+    let sql = `${this.comments()} truncate ${this.tableName} restart identity`;
+    return sql.trimStart();
   }
 
   // is used if the an array with multiple empty values supplied
@@ -27,7 +28,8 @@ class QueryCompiler_PG extends QueryCompiler {
   // Compiles an `insert` query, allowing for multiple
   // inserts using a single query statement.
   insert() {
-    let sql = super.insert();
+    let sql = this.comments() + ' ' + super.insert();
+    sql = sql.trimStart;
     if (sql === '') return sql;
 
     const { returning, onConflict, ignore, merge, insert } = this.single;
@@ -54,7 +56,7 @@ class QueryCompiler_PG extends QueryCompiler {
     return {
       sql:
         withSQL +
-        `update ${this.single.only ? 'only ' : ''}${this.tableName} ` +
+        (`${this.comments()} update ${this.single.only ? 'only ' : ''}${this.tableName} `).trimStart() +
         `set ${updateData.join(', ')}` +
         this._updateFrom(updateFrom) +
         (wheres ? ` ${wheres}` : '') +
@@ -124,12 +126,12 @@ class QueryCompiler_PG extends QueryCompiler {
     // With 'using' syntax, no tablename between DELETE and FROM.
     const sql =
       withSQL +
-      `delete from ${this.single.only ? 'only ' : ''}${tableName}` +
+      `${this.comments()} delete from ${this.single.only ? 'only ' : ''}${tableName}` +
       (using ? ` ${using}` : '') +
       (wheres ? ` ${wheres}` : '');
     const { returning } = this.single;
     return {
-      sql: sql + this._returning(returning),
+      sql: sql.trimStart() + this._returning(returning),
       returning,
     };
   }

--- a/sourcesknex/seeds/20240123154439_somename.js
+++ b/sourcesknex/seeds/20240123154439_somename.js
@@ -1,0 +1,13 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> } 
+ */
+exports.seed = async function(knex) {
+  // Deletes ALL existing entries
+  await knex('table_name').del()
+  await knex('table_name').insert([
+    {id: 1, colName: 'rowValue1'},
+    {id: 2, colName: 'rowValue2'},
+    {id: 3, colName: 'rowValue3'}
+  ]);
+};

--- a/test/integration/query/deletes.js
+++ b/test/integration/query/deletes.js
@@ -98,6 +98,12 @@ module.exports = function (knex) {
             [1],
             0
           );
+          tester(
+            'pg',
+            '/* removing acccount */ delete from "accounts" where "id" = ?',
+            [1],
+            0
+          );
         });
     });
 

--- a/test/integration2/query/insert/inserts.spec.js
+++ b/test/integration2/query/insert/inserts.spec.js
@@ -652,7 +652,7 @@ describe('Inserts', function () {
                 'There should be a fail when multi-insert are made in unique col.'
               );
             },
-            function () {}
+            function () { }
           );
       });
 
@@ -809,7 +809,7 @@ describe('Inserts', function () {
                 );
               }
             },
-            function () {}
+            function () { }
           );
       });
 
@@ -835,7 +835,7 @@ describe('Inserts', function () {
                 );
               }
             },
-            function () {}
+            function () { }
           );
       });
 
@@ -924,6 +924,13 @@ describe('Inserts', function () {
               '/* insert into test_default_table */ insert into `test_default_table` () values ()',
               [],
               [2]
+            );
+            tester(
+              'pg',
+              '/* insert into test_default_table */ insert into "test_default_table" () values ()',
+              'insert into "test_default_table" default values returning "id"',
+              [],
+              [{ id: 1 }]
             );
           });
       });
@@ -2012,8 +2019,8 @@ describe('Inserts', function () {
         });
         await knex.raw(
           'create unique index email_type1 ' +
-            'on upsert_tests(email) ' +
-            "where type = 'type1'"
+          'on upsert_tests(email) ' +
+          "where type = 'type1'"
         );
 
         await knex('upsert_tests').insert([
@@ -2056,7 +2063,7 @@ describe('Inserts', function () {
               tester(
                 'sqlite3',
                 'insert into `upsert_tests` (`email`, `name`, `type`) select ? as `email`, ? as `name`, ? as `type` union all select ? as `email`, ? as `name`, ? as `type` union all select ? as `email`, ? as `name`, ? as `type` where true ' +
-                  "on conflict (email) where type = 'type1' do update set `email` = excluded.`email`, `name` = excluded.`name`, `type` = excluded.`type`",
+                "on conflict (email) where type = 'type1' do update set `email` = excluded.`email`, `name` = excluded.`name`, `type` = excluded.`type`",
                 [
                   'one@example.com',
                   'AFTER',

--- a/test/integration2/query/update/updates.spec.js
+++ b/test/integration2/query/update/updates.spec.js
@@ -100,6 +100,12 @@ describe('Updates', function () {
               ['User', 'Test', 'test100@example.com', 1],
               1
             );
+            tester(
+              'pg',
+              '/* update in account */ update "accounts" set "first_name" = ?, "last_name" = ?, "email" = ? where "id" = ?',
+              ['User', 'Test', 'test100@example.com', 1],
+              1
+            );
           });
       });
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -9064,7 +9064,7 @@ describe('QueryBuilder', () => {
       qb()
         .select('foo')
         .from('tbl')
-        .where(() => {}),
+        .where(() => { }),
       {
         mysql: 'select `foo` from `tbl`',
         mssql: 'select [foo] from [tbl]',
@@ -9521,6 +9521,10 @@ describe('QueryBuilder', () => {
           sql: '/* Added comment 1 */ /* Added comment 2 */ insert into `users` (`email`) values (?)',
           bindings: ['foo'],
         },
+        pg: {
+          sql: '/* Added comment 1 */ /* Added comment 2 */ insert into "users" ("email") values (?)',
+          bindings: ['foo'],
+        },
       }
     );
   });
@@ -9537,6 +9541,10 @@ describe('QueryBuilder', () => {
           sql: '/* Added comment 1 */ /* Added comment 2 */ update `users` set `email` = ?',
           bindings: ['foo'],
         },
+        pg: {
+          sql: '/* Added comment 1 */ /* Added comment 2 */ update "users" set "email" = ?',
+          bindings: ['foo'],
+        },
       }
     );
   });
@@ -9551,6 +9559,10 @@ describe('QueryBuilder', () => {
       {
         mysql: {
           sql: '/* Added comment 1 */ /* Added comment 2 */ delete from `users`',
+          bindings: [],
+        },
+        pg: {
+          sql: '/* Added comment 1 */ /* Added comment 2 */ delete from "users"',
           bindings: [],
         },
       }
@@ -9835,8 +9847,8 @@ describe('QueryBuilder', () => {
       } catch (error) {
         expect(error.message).to.contain(
           'Undefined binding(s) detected when compiling ' +
-            builder._method.toUpperCase() +
-            `. Undefined column(s): [${undefinedColumns.join(', ')}] query:`
+          builder._method.toUpperCase() +
+          `. Undefined column(s): [${undefinedColumns.join(', ')}] query:`
         ); //This test is not for asserting correct queries
       }
     });
@@ -9856,8 +9868,8 @@ describe('QueryBuilder', () => {
         } else {
           expect(error.message).to.contain(
             'Undefined binding(s) detected when compiling ' +
-              builder._method.toUpperCase() +
-              `. Undefined column(s): [${undefinedColumns.join(', ')}] query:`
+            builder._method.toUpperCase() +
+            `. Undefined column(s): [${undefinedColumns.join(', ')}] query:`
           ); //This test is not for asserting correct queries
         }
       }
@@ -10499,7 +10511,7 @@ describe('QueryBuilder', () => {
   });
 
   it('#2003, properly escapes objects with toPostgres specialization', () => {
-    function TestObject() {}
+    function TestObject() { }
     TestObject.prototype.toPostgres = () => 'foobar';
     testquery(qb().table('sometable').insert({ id: new TestObject() }), {
       pg: 'insert into "sometable" ("id") values (\'foobar\')',


### PR DESCRIPTION
Issue 5738 pointed out that knex does not integrate comments in INSERT/UPDATE/DELETE .
The fix was coded for mysql and merged on Nov 27, 2023.
The present PR fixes the same issue for "pg" dialect.