### PR TITLE
Add Type Definition for orderBy with Raw Expression Issue 5711

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1954,12 +1954,12 @@ declare namespace Knex {
 
   interface OrderBy<TRecord extends {} = any, TResult = unknown[]> {
     (
-      columnName: keyof TRecord | QueryBuilder,
+      columnName: keyof TRecord | QueryBuilder | Raw,
       order?: 'asc' | 'desc',
       nulls?: 'first' | 'last'
     ): QueryBuilder<TRecord, TResult>;
     (
-      columnName: string | QueryBuilder,
+      columnName: string | QueryBuilder | Raw,
       order?: string,
       nulls?: string
     ): QueryBuilder<TRecord, TResult>;
@@ -1967,7 +1967,7 @@ declare namespace Knex {
       columnDefs: Array<
         | keyof TRecord
         | Readonly<{
-            column: keyof TRecord | QueryBuilder;
+            column: keyof TRecord | QueryBuilder | Raw;
             order?: 'asc' | 'desc';
             nulls?: 'first' | 'last';
           }>
@@ -1977,7 +1977,7 @@ declare namespace Knex {
       columnDefs: Array<
         | string
         | Readonly<{
-            column: string | QueryBuilder;
+            column: string | QueryBuilder | Raw;
             order?: string;
             nulls?: string;
           }>


### PR DESCRIPTION
This change adds the `Raw` type when used as a column definition in `orderBy` in order to satisfy the type checks. Typescript will currently indicate that there's no overload for any of the following:
```javascript
knex('foo').orderBy(knex.raw('count(*)'), 'desc');
```

```javascript
knex('foo').orderBy([{ column: knex.raw('count(*)') }]);
```
Use of a `Raw` result for the column will no longer result in a type error.