### PR TITLE
fix: Use correct pool configuration location in initializePool method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -291,7 +291,7 @@ class Client extends EventEmitter {
     }
 
     const tarnPoolConfig = {
-      ...this.getPoolSettings(config.pool),
+      ...this.getPoolSettings(config.connection.pool),
     };
     // afterCreate is an internal knex param, tarn.js does not support it
     if (tarnPoolConfig.afterCreate) {


### PR DESCRIPTION
The initializePool method now correctly retrieves the pool configuration from config.connection.pool instead of config.pool. This ensures that the connection pool is initialized with the proper settings.