### PR TITLE
Fix: Stream postProcessResponse error is not catchable with .on('error')

### DIFF
--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -65,7 +65,11 @@ class Runner {
     const stream = new Transform({
       objectMode: true,
       transform: (chunk, _, callback) => {
-        callback(null, this.client.postProcessResponse(chunk, queryContext));
+        try{
+          callback(null, this.client.postProcessResponse(chunk, queryContext));
+        } catch (err) {
+          callback(err);
+        }
       },
     });
     stream.on('close', () => {

--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -65,7 +65,7 @@ class Runner {
     const stream = new Transform({
       objectMode: true,
       transform: (chunk, _, callback) => {
-        try{
+        try {
           callback(null, this.client.postProcessResponse(chunk, queryContext));
         } catch (err) {
           callback(err);

--- a/test/integration2/query/misc/additional.spec.js
+++ b/test/integration2/query/misc/additional.spec.js
@@ -130,6 +130,28 @@ describe('Additional', function () {
           });
         });
 
+        it('should emit an error on the stream when postProcessResponse throws (#6032)', async function () {
+          await knex('accounts').truncate();
+          await insertAccounts(knex, 'accounts');
+
+          const original = knex.client.config.postProcessResponse;
+          knex.client.config.postProcessResponse = () => {
+            throw new Error('postProcessResponse boom');
+          };
+
+          try {
+            const stream = knex('accounts').limit(1).stream();
+            const error = await new Promise((resolve) => {
+              stream.on('error', resolve);
+              stream.on('data', () => {});
+            });
+            expect(error).to.be.an('error');
+            expect(error.message).to.equal('postProcessResponse boom');
+          } finally {
+            knex.client.config.postProcessResponse = original;
+          }
+        });
+
         it('should emit an error rather than crash when the stream cannot acquire a connection (#6460)', async function () {
           const limitedKnex = getKnexForDb(db, {
             acquireConnectionTimeout: 200,


### PR DESCRIPTION
Fixes the issue #6032