### PR TITLE
fix: use exports to support ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,5 +263,10 @@
       "module": "commonjs",
       "target": "ES2017"
     }
+  },
+  "exports": {
+    "types": "./types/index.d.ts",
+    "import": "./knex.mjs",
+    "default": "./knex.js"
   }
 }


### PR DESCRIPTION
When you call `import { knex } from 'knex'` in a ESM file, it will import CommonJS knex and cause:

```
SyntaxError: The requested module 'knex' does not provide an export named 'knex'
```


Add the `exports` field in the `package.json` file to import ESM knex correctly.