### PR TITLE
Chore: clean old CI versions & exceptions

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       # cache node_modules
       - name: Restore cached dependencies

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -109,7 +109,7 @@ jobs:
     name: Test user experience
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
     steps:
       - name: Checkout Repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,10 +36,6 @@ jobs:
       - name: Run npm install
         run: npm install
 
-      - name: Run npm install mysql2@3.2.0 if Node 12.x
-        run: npm install mysql2@3.2.0
-        if: matrix.node-version == '12.x'
-
       - run: npm run build
 
       - name: Run Tests

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Node.js, featuring:
 - both a [promise](https://knex.github.io/documentation/#Interfaces-Promises) and [callback](https://knex.github.io/documentation/#Interfaces-Callbacks) API
 - a [thorough test suite](https://github.com/knex/knex/actions)
 
-Node.js versions 12+ are supported.
+Node.js versions 16+ are supported.
 
 - Take a look at the [full documentation](https://knex.github.io/documentation) to get started!
 - Browse the [list of plugins and tools](https://github.com/knex/knex/blob/master/ECOSYSTEM.md) built for knex


### PR DESCRIPTION
There were some leftovers from when Node 20 was added to CI and 12/14 were dropped. 

- Remove Node 12 specific dependency install. It is not used anymore.
- Run individual one-version-only Node 16 and Node 18 tasks in latest LTS (=20). They were the odd ones out.
- Update supported Node versions in readme. It suggested everything from 12 onwards were still supported.