### PR TITLE
Do not overwrite cwd if knexfile and cwd is passed

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -87,7 +87,7 @@ async function initKnex(env, opts, useDefaultClientIfNotSpecified) {
 function invoke() {
   const filetypes = ['js', 'mjs', 'coffee', 'ts', 'eg', 'ls'];
 
-  const cwd = argv.knexfile
+  const cwd = argv.knexfile && !argv.cwd
     ? path.dirname(path.resolve(argv.knexfile))
     : process.cwd();
 

--- a/test/cli/knexfile-test.spec.js
+++ b/test/cli/knexfile-test.spec.js
@@ -164,20 +164,40 @@ module.exports = {
               }
             );
           });
+
+          it("does not change the process's cwd", function () {
+            return execCommand(
+              `node ${KNEX} migrate:latest --cwd=test/jake-util/knexfile --knexfile=subdir/knexfile.js`,
+              {
+                notExpectedOutput: 'Working directory changed to',
+              }
+            );
+          });
         });
 
         context('and --knexfile is an absolute path', function () {
+          // Notice: the Knexfile is using Typescript.  This means that Knex
+          // is pre-loading the appropriate Typescript modules before loading
+          // the Knexfile.
+          const knexfile = path.resolve(
+            'test/jake-util/knexfile-ts/custom-config.ts'
+          );
+          const command = `node ${KNEX} migrate:latest --cwd=test/jake-util/knexfile --knexfile=${knexfile}`;
+
           it('uses the indicated knexfile', function () {
-            // Notice: the Knexfile is using Typescript.  This means that Knex
-            // is pre-loading the appropriate Typescript modules before loading
-            // the Knexfile.
-            const knexfile = path.resolve(
-              'test/jake-util/knexfile-ts/custom-config.ts'
-            );
             return execCommand(
-              `node ${KNEX} migrate:latest --cwd=test/jake-util/knexfile --knexfile=${knexfile}`,
+              command,
               {
                 expectedOutput: 'Batch 1 run: 4 migrations',
+              }
+            );
+          });
+
+          it("does not change the process's cwd", function () {
+            return execCommand(
+              command,
+              {
+                notExpectedOutput: 'Working directory changed to',
               }
             );
           });

--- a/test/jake-util/knexfile-ts/custom-config.ts
+++ b/test/jake-util/knexfile-ts/custom-config.ts
@@ -1,13 +1,13 @@
 export const client = 'sqlite3';
 
 export const connection = {
-  filename: '../test.sqlite3',
+  filename: __dirname + '/../test.sqlite3',
 };
 
 export const migrations = {
-  directory: './knexfile_migrations',
+  directory: __dirname + '/knexfile_migrations',
 };
 
 export const seeds = {
-  directory: './knexfile_seeds',
+  directory: __dirname + '/../knexfile_seeds',
 };

--- a/test/jake-util/knexfile/subdir/knexfile.js
+++ b/test/jake-util/knexfile/subdir/knexfile.js
@@ -1,0 +1,12 @@
+module.exports = {
+  client: 'sqlite3',
+  connection: {
+    filename: __dirname + '/../../test.sqlite3',
+  },
+  migrations: {
+    directory: __dirname + '/../../knexfile_migrations',
+  },
+  seeds: {
+    directory: __dirname + '/../../knexfile_seeds',
+  },
+}


### PR DESCRIPTION
When having both `--cwd` argument and `--knexfile` argument, the knexfile basepath overwrites the process cwd which is strange IMO.

If we pass `--cwd` it should have higher precedence than the basepath of the `--knexfile` for process cwd selection.

My use case for knex is strange. I'm trying to integrate it in firebase project and I want the configuration values for password and username to be loaded by firebase runtime configuration.

The file structure looks like this
```
.
├── src
│   ├── migrations
│   │   └── ...
│   ├── index.ts
│   ├── knexfile.ts
├── .runtimeconfig.json
```

I wanted the `knexfile.ts` and `migrations` to be under `src` directory but the `.runtimeconfig.json` should be in the parent directory and it contains the values for those variables.

When I execute from `.`:
```
knex --knexfile src/knexfile.ts --cwd . migrate:status
```
the working directory is initially `.` but after that it is overwritten by `./src/`.

You cannot tell to firebase where to find its .runtimeconfig.json. It always search for it in the current working directory I think.

I found two pull requests that are related to that topic and based on this PR #3613 and the table which was created by @briandamaged (https://docs.google.com/spreadsheets/d/19TMouhxdIosYGzubO-2lbxm8Ykx4jR-Iu74HXohFYMg/edit#gid=0) I realised that this might be a bug which I think was introduced by PR #4122.



This PR addresses #6103
