### PR TITLE
Updated sqlite3 and better-sqlite3 to use more accurate numeric types

### DIFF
--- a/lib/dialects/sqlite3/schema/sqlite-columncompiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-columncompiler.js
@@ -37,10 +37,9 @@ class ColumnCompiler_SQLite3 extends ColumnCompiler {
 
 ColumnCompiler_SQLite3.prototype.json = 'json';
 ColumnCompiler_SQLite3.prototype.jsonb = 'json';
-ColumnCompiler_SQLite3.prototype.double =
-  ColumnCompiler_SQLite3.prototype.decimal =
-  ColumnCompiler_SQLite3.prototype.floating =
-    'float';
+ColumnCompiler_SQLite3.prototype.double = 'double'
+ColumnCompiler_SQLite3.prototype.decimal = 'decimal'
+ColumnCompiler_SQLite3.prototype.floating = 'float';
 ColumnCompiler_SQLite3.prototype.timestamp = 'datetime';
 // autoincrement without primary key is a syntax error in SQLite, so it's necessary
 ColumnCompiler_SQLite3.prototype.increments =

--- a/test/unit/schema-builder/better-sqlite3.js
+++ b/test/unit/schema-builder/better-sqlite3.js
@@ -755,6 +755,7 @@ describe('BetterSQLite3 SchemaBuilder', function () {
     equal(tableSql[0].sql, 'alter table `users` add column `foo` float');
   });
 
+
   it('adding double', function () {
     tableSql = client
       .schemaBuilder()
@@ -764,7 +765,19 @@ describe('BetterSQLite3 SchemaBuilder', function () {
       .toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'alter table `users` add column `foo` float');
+    equal(tableSql[0].sql, 'alter table `users` add column `foo` double');
+  });
+
+  it('adding double, no precision', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.double('foo', null);
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    equal(tableSql[0].sql, 'alter table `users` add column `foo` double');
   });
 
   it('adding decimal', function () {
@@ -776,7 +789,7 @@ describe('BetterSQLite3 SchemaBuilder', function () {
       .toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'alter table `users` add column `foo` float');
+    equal(tableSql[0].sql, 'alter table `users` add column `foo` decimal');
   });
 
   it('test adding decimal, no precision', function () {
@@ -788,7 +801,7 @@ describe('BetterSQLite3 SchemaBuilder', function () {
       .toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'alter table `users` add column `foo` float');
+    equal(tableSql[0].sql, 'alter table `users` add column `foo` decimal');
   });
 
   it('adding boolean', function () {

--- a/test/unit/schema-builder/sqlite3.js
+++ b/test/unit/schema-builder/sqlite3.js
@@ -815,7 +815,19 @@ describe('SQLite SchemaBuilder', function () {
       .toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'alter table `users` add column `foo` float');
+    equal(tableSql[0].sql, 'alter table `users` add column `foo` double');
+  });
+
+  it('adding double, no precision', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.double('foo', null);
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    equal(tableSql[0].sql, 'alter table `users` add column `foo` double');
   });
 
   it('adding decimal', function () {
@@ -827,7 +839,7 @@ describe('SQLite SchemaBuilder', function () {
       .toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'alter table `users` add column `foo` float');
+    equal(tableSql[0].sql, 'alter table `users` add column `foo` decimal');
   });
 
   it('test adding decimal, no precision', function () {
@@ -839,7 +851,7 @@ describe('SQLite SchemaBuilder', function () {
       .toSQL();
 
     equal(1, tableSql.length);
-    equal(tableSql[0].sql, 'alter table `users` add column `foo` float');
+    equal(tableSql[0].sql, 'alter table `users` add column `foo` decimal');
   });
 
   it('adding boolean', function () {


### PR DESCRIPTION
Fixing `sqlite3` and `better-sqlite3` numeric types. When trying to use `knex.decimal()` or `knex.double()` with sqlite3 it turns them to `float`. Issue https://github.com/knex/knex/issues/5789