### PR TITLE
fix TypeError on close stream event

### DIFF
--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -69,7 +69,8 @@ class Runner {
       },
     });
     stream.on('close', () => {
-      this.client.releaseConnection(this.connection);
+      if (this.connection)
+          this.client.releaseConnection(this.connection);
     });
 
     // If the stream is manually destroyed, the close event is not


### PR DESCRIPTION
Fix TypeError: Cannot read properties of undefined (reading '__knexUid'). this.onnection may not exist in some cases