### PR TITLE
refactor: remove resolve dependency

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,7 +2,6 @@
 const rechoir = require('rechoir');
 const merge = require('lodash/merge');
 const interpret = require('interpret');
-const resolveFrom = require('resolve-from');
 const path = require('path');
 const tildify = require('tildify');
 const commander = require('commander');
@@ -23,6 +22,7 @@ const {
   findUpModulePath,
   findUpConfig,
 } = require('./utils/cli-config-utils');
+const { silent } = require('./utils/resolve-from');
 const {
   existsSync,
   readFile,
@@ -93,7 +93,7 @@ function invoke() {
 
   // TODO add knexpath here eventually
   const modulePath =
-    resolveFrom.silent(cwd, 'knex') ||
+    silent(cwd, 'knex') ||
     findUpModulePath(cwd, 'knex') ||
     process.env.KNEX_PATH;
 

--- a/bin/utils/resolve-from.js
+++ b/bin/utils/resolve-from.js
@@ -1,0 +1,9 @@
+function silent(fromDirectory, moduleId) {
+  try {
+    return require.resolve(moduleId, { paths: [fromDirectory] })
+  } catch (e) {
+    return '';
+  }
+}
+
+module.exports = { silent };

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "lodash": "^4.17.21",
     "pg-connection-string": "2.6.2",
     "rechoir": "^0.8.0",
-    "resolve-from": "^5.0.0",
     "tarn": "^3.0.2",
     "tildify": "2.0.0"
   },


### PR DESCRIPTION
This replaces the dependency on resolve-from with node's native `require.resolve` method.

If this and gulpjs/rechoir#47 are merged, a false positive related to [resolve's `monorepo-symlink-test`](https://github.com/browserify/resolve/issues/312) file will be resolved.