### PR TITLE
Import knex as type in TS seed template

### DIFF
--- a/lib/migrations/seed/stub/ts.stub
+++ b/lib/migrations/seed/stub/ts.stub
@@ -1,4 +1,4 @@
-import { Knex } from "knex";
+import type { Knex } from "knex";
 
 export async function seed(knex: Knex): Promise<void> {
     // Deletes ALL existing entries


### PR DESCRIPTION
Relates #5741

Saves fixing `@typescript-eslint/consistent-type-imports` eslint rule every time.