### PR TITLE
fix:drop only FKRefs which are related to changed column

### DIFF
--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -83,7 +83,7 @@ class TableCompiler_MySQL extends TableCompiler {
       output(resp) {
         const column = resp[0];
         const runner = this;
-        return compiler.getFKRefs(runner).then(([refs]) =>
+        return compiler.getFKRefs(runner, column.Field).then(([refs]) =>
           new Promise((resolve, reject) => {
             try {
               if (!refs.length) {
@@ -176,7 +176,7 @@ class TableCompiler_MySQL extends TableCompiler {
     }
   }
 
-  getFKRefs(runner) {
+  getFKRefs(runner, columnName) {
     const bindingsHolder = {
       bindings: [],
     };
@@ -191,6 +191,13 @@ class TableCompiler_MySQL extends TableCompiler {
       'WHERE KCU.REFERENCED_TABLE_NAME = ' +
       this.client.parameter(
         this.tableNameRaw,
+        this.tableBuilder,
+        bindingsHolder
+      ) +
+      ' ' +
+      '  AND KCU.REFERENCED_COLUMN_NAME = ' +
+      this.client.parameter(
+        columnName,
         this.tableBuilder,
         bindingsHolder
       ) +


### PR DESCRIPTION
## Bug Description
When using `renameColumn()` in a migration for MySQL, Knex drops all foreign keys of the table, renames the specified column, and then re-adds all the foreign keys. The correct behavior should be for Knex to drop only the foreign keys referencing the column being renamed.

## Steps to Reproduce
1. Create the following tables:
   - `users` with columns `id`, `name`, and `email`
   - `user_books` with columns `id`, `userId`, and `name`. The `userId` column should have a foreign key referencing `users.id`.
2. Create a migration for `users` table that renames the `name` column to `nickname` using `table.renameColumn('name', 'nickname')`.