### PR TITLE
add MariaDB to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 > **A SQL query builder that is _flexible_, _portable_, and _fun_ to use!**
 
-A batteries-included, multi-dialect (PostgreSQL, MySQL, CockroachDB, MSSQL, SQLite3, Oracle (including Oracle Wallet Authentication)) query builder for
+A batteries-included, multi-dialect (PostgreSQL, MariaDB, MySQL, CockroachDB, MSSQL, SQLite3, Oracle (including Oracle Wallet Authentication)) query builder for
 Node.js, featuring:
 
 - [transactions](https://knex.github.io/documentation/#Transactions)


### PR DESCRIPTION
MariaDB is mentioned at https://knexjs.org/, so suggest to add MariaDB to github README too :) I asked in discussion https://github.com/knex/knex/issues/6119 about MariaDB support in general too. 