### PR TITLE
fix link to pg-query-stream

### DIFF
--- a/docs/src/guide/interfaces.md
+++ b/docs/src/guide/interfaces.md
@@ -107,7 +107,7 @@ knex
 
 ## Streams
 
-Streams are a powerful way of piping data through as it comes in, rather than all at once. You can read more about streams [here at substack's stream handbook](https://github.com/substack/stream-handbook). See the following for example uses of stream & pipe. If you wish to use streams with PostgreSQL, you must also install the [pg-query-stream](https://github.com/brianc/node-pg-query-stream) module. If you wish to use streams with the `pgnative` dialect, please be aware that the results will not be streamed as they are received, but rather streamed after the entire result set has returned. On an HTTP server, make sure to [manually close your streams](https://github.com/knex/knex/wiki/Manually-Closing-Streams) if a request is aborted.
+Streams are a powerful way of piping data through as it comes in, rather than all at once. You can read more about streams [here at substack's stream handbook](https://github.com/substack/stream-handbook). See the following for example uses of stream & pipe. If you wish to use streams with PostgreSQL, you must also install the [pg-query-stream](https://github.com/brianc/node-postgres/tree/master/packages/pg-query-stream) module. If you wish to use streams with the `pgnative` dialect, please be aware that the results will not be streamed as they are received, but rather streamed after the entire result set has returned. On an HTTP server, make sure to [manually close your streams](https://github.com/knex/knex/wiki/Manually-Closing-Streams) if a request is aborted.
 
 ### stream
 


### PR DESCRIPTION
When following [the documentation link](https://github.com/brianc/node-pg-query-stream), the repository informs us that the code has been merged into the node-postgres repo. This PR aims to use the correct link.

![Screenshot 2024-09-09 at 16 29 31](https://github.com/user-attachments/assets/e5a5ec07-a967-4847-9d60-16f62673170b)
