### PR TITLE
fix: join clause literal value is treated as Double quotation mark in Postgres Database

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -186,7 +186,7 @@ class Client extends EventEmitter {
     if (this.config.wrapIdentifier) {
       return this.config.wrapIdentifier(value, origImpl, queryContext);
     }
-    return origImpl(value);
+    return origImpl(value, queryContext);
   }
 
   wrapIdentifierImpl(value) {

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -63,8 +63,12 @@ class Client_PG extends Client {
     return require('pg');
   }
 
-  wrapIdentifierImpl(value) {
+  wrapIdentifierImpl(value, queryContext) {
     if (value === '*') return value;
+
+    const isLiteralValue = () => {
+      return queryContext && queryContext.pgValueFlag;
+    };
 
     let arrayAccessor = '';
     const arrayAccessorMatch = value.match(/(.*?)(\[[0-9]+\])/);
@@ -74,7 +78,9 @@ class Client_PG extends Client {
       arrayAccessor = arrayAccessorMatch[2];
     }
 
-    return `"${value.replace(/"/g, '""')}"${arrayAccessor}`;
+    return isLiteralValue()
+      ? `'${value.replace(/"/g, '""')}'${arrayAccessor}`
+      : `"${value.replace(/"/g, '""')}"${arrayAccessor}`;
   }
 
   _acquireOnlyConnection() {

--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -977,6 +977,12 @@ class QueryCompiler {
   // ------
 
   _valueClause(statement) {
+    // When DataBase is Postgres. it should be handled with single quotation.
+    if (this._getDBVendor() === 'pg') {
+      const exists = this.builder._queryContext || {};
+      this.builder.queryContext({ ...exists, pgValueFlag: true });
+    }
+
     return statement.asColumn
       ? wrap_(
           statement.value,
@@ -1585,6 +1591,10 @@ class QueryCompiler {
       ) +
       ')'
     );
+  }
+
+  _getDBVendor() {
+    return this.client.config.client;
   }
 }
 

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -10863,6 +10863,25 @@ describe('QueryBuilder', () => {
       }
     );
 
+    // Related with -> https://github.com/knex/knex/issues/6124
+    it('Should be treated as Literal Value(single quotation marked) in Postgres Database', () => {
+      const query = qb()
+        .delete()
+        .from({ p: 'wp_posts' })
+        .innerJoin('wp_postmeta', (join) => {
+          join.onVal('wp_postmeta.id', '123');
+        })
+        .toQuery();
+
+      expect(query).to.equal(
+        `delete from "wp_posts" as "p" using "wp_postmeta" where "wp_postmeta"."id" = '123'`
+      );
+
+      expect(query).to.not.equal(
+        `delete from "wp_posts" as "p" using "wp_postmeta" where "wp_postmeta"."id" = "123"`
+      );
+    });
+
     testsql(
       qb()
         .select({


### PR DESCRIPTION
# Related Issue

[Literal Value treated as Column name in Where Clause (Postgres Database)]
- https://github.com/knex/knex/issues/6124


## Issue Detail

```javscript
db // Knex instance

// Basic query that includes a join with literal join value
const qb = db('table_a').innerJoin('table_b', join => {
  join.onVal('table_b.id', '123')
})

// Executing select on this query results in proper formatting of literal value
// SQL: select "table_a"."id" from "table_a" inner join "table_b" on "table_b"."id" = '123' 👈👈 (This Allows in Postgres!)
console.log(qb.select('table_a.id').toQuery())

// Executing delete on this query results in literal value being formatted as if it were a column name
// SQL: delete from "table_a" using "table_b" where "table_b"."id" = "123"  👈👈 (This is Not Allowed in Postgres. 123 must be single quoted like '123')
console.log(qb.delete().toQuery())
```

## Description (Solution)

i fixed this issue by using `builder._queryContext` that cannot be shared to string format method (`wrapIdentifierImpl`)