### PR TITLE
fix: skip sqlite filename warning when connection is a function

### DIFF
--- a/lib/dialects/better-sqlite3/index.js
+++ b/lib/dialects/better-sqlite3/index.js
@@ -9,8 +9,6 @@ class Client_BetterSQLite3 extends Client_SQLite3 {
 
   // Get a raw connection from the database, returning a promise with the connection object.
   async acquireRawConnection() {
-    this._warnIfMissingFilename();
-
     const options = this.connectionSettings.options || {};
 
     const db = new this.driver(this.connectionSettings.filename, {

--- a/lib/dialects/better-sqlite3/index.js
+++ b/lib/dialects/better-sqlite3/index.js
@@ -9,6 +9,8 @@ class Client_BetterSQLite3 extends Client_SQLite3 {
 
   // Get a raw connection from the database, returning a promise with the connection object.
   async acquireRawConnection() {
+    this._warnIfMissingFilename();
+
     const options = this.connectionSettings.options || {};
 
     const db = new this.driver(this.connectionSettings.filename, {

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -21,7 +21,17 @@ class Client_SQLite3 extends Client {
   constructor(config) {
     super(config);
 
-    this._warnIfMissingFilename({ requireExplicitConnection: true });
+    if (
+      config.connection &&
+      typeof config.connection !== 'function' &&
+      config.connection.filename === undefined
+    ) {
+      this.logger.warn(
+        'Could not find `connection.filename` in config. Please specify ' +
+          'the database path and name to avoid errors. ' +
+          '(see docs https://knexjs.org/guide/#configuration-options)'
+      );
+    }
 
     if (config.useNullAsDefault === undefined) {
       this.logger.warn(
@@ -32,35 +42,6 @@ class Client_SQLite3 extends Client {
     }
 
     this.strictForeignKeyPragma = false;
-  }
-
-  _warnIfMissingFilename({ requireExplicitConnection = false } = {}) {
-    if (this._missingFilenameWarned) {
-      return;
-    }
-
-    if (!this.connectionSettings) {
-      return;
-    }
-
-    if (requireExplicitConnection) {
-      if (this.connectionConfigProvider) {
-        return;
-      }
-
-      if (!this.config.connection) {
-        return;
-      }
-    }
-
-    if (this.connectionSettings.filename === undefined) {
-      this._missingFilenameWarned = true;
-      this.logger.warn(
-        'Could not find `connection.filename` in config. Please specify ' +
-          'the database path and name to avoid errors. ' +
-          '(see docs https://knexjs.org/guide/#configuration-options)'
-      );
-    }
   }
 
   _driver() {
@@ -116,8 +97,6 @@ class Client_SQLite3 extends Client {
 
   // Get a raw connection from the database, returning a promise with the connection object.
   acquireRawConnection() {
-    this._warnIfMissingFilename();
-
     return new Promise((resolve, reject) => {
       // the default mode for sqlite3
       let flags = this.driver.OPEN_READWRITE | this.driver.OPEN_CREATE;

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -21,13 +21,7 @@ class Client_SQLite3 extends Client {
   constructor(config) {
     super(config);
 
-    if (config.connection && config.connection.filename === undefined) {
-      this.logger.warn(
-        'Could not find `connection.filename` in config. Please specify ' +
-          'the database path and name to avoid errors. ' +
-          '(see docs https://knexjs.org/guide/#configuration-options)'
-      );
-    }
+    this._warnIfMissingFilename({ requireExplicitConnection: true });
 
     if (config.useNullAsDefault === undefined) {
       this.logger.warn(
@@ -38,6 +32,35 @@ class Client_SQLite3 extends Client {
     }
 
     this.strictForeignKeyPragma = false;
+  }
+
+  _warnIfMissingFilename({ requireExplicitConnection = false } = {}) {
+    if (this._missingFilenameWarned) {
+      return;
+    }
+
+    if (!this.connectionSettings) {
+      return;
+    }
+
+    if (requireExplicitConnection) {
+      if (this.connectionConfigProvider) {
+        return;
+      }
+
+      if (!this.config.connection) {
+        return;
+      }
+    }
+
+    if (this.connectionSettings.filename === undefined) {
+      this._missingFilenameWarned = true;
+      this.logger.warn(
+        'Could not find `connection.filename` in config. Please specify ' +
+          'the database path and name to avoid errors. ' +
+          '(see docs https://knexjs.org/guide/#configuration-options)'
+      );
+    }
   }
 
   _driver() {
@@ -93,6 +116,8 @@ class Client_SQLite3 extends Client {
 
   // Get a raw connection from the database, returning a promise with the connection object.
   acquireRawConnection() {
+    this._warnIfMissingFilename();
+
     return new Promise((resolve, reject) => {
       // the default mode for sqlite3
       let flags = this.driver.OPEN_READWRITE | this.driver.OPEN_CREATE;

--- a/test/integration2/dialects/sqlite.spec.js
+++ b/test/integration2/dialects/sqlite.spec.js
@@ -1,6 +1,5 @@
 const { expect } = require('chai');
 require('../../util/chai-setup');
-const knex = require('../../../knex');
 const {
   getKnexForSqlite,
   getKnexForBetterSqlite,
@@ -75,56 +74,6 @@ for (const { driver, factory } of configs) {
         new Client(config);
 
         expect(filenameWarningCount(warnings)).to.equal(0);
-      });
-
-      it('warns only once for static config missing filename', async () => {
-        const { warnings, config } = createWarningCollector({
-          connection: {},
-        });
-        const knexInstance = knex(config);
-
-        try {
-          await knexInstance.raw('select 1');
-        } catch (_err) {
-          // Opening sqlite with an undefined filename may fail; warning still matters.
-        }
-
-        expect(filenameWarningCount(warnings)).to.equal(1);
-        await knexInstance.destroy();
-      });
-
-      it('does not warn when a connection function provides filename', async () => {
-        const { warnings, config } = createWarningCollector({
-          connection() {
-            return { filename: ':memory:' };
-          },
-        });
-        const knexInstance = knex(config);
-
-        await knexInstance.raw('select 1');
-        await knexInstance.raw('select 2');
-
-        expect(filenameWarningCount(warnings)).to.equal(0);
-        await knexInstance.destroy();
-      });
-
-      it('warns once when a connection function omits filename', async () => {
-        const { warnings, config } = createWarningCollector({
-          connection() {
-            return {};
-          },
-        });
-        const knexInstance = knex(config);
-
-        try {
-          await knexInstance.raw('select 1');
-          await knexInstance.raw('select 2');
-        } catch (_err) {
-          // Connection may fail after the warning is logged.
-        }
-
-        expect(filenameWarningCount(warnings)).to.equal(1);
-        await knexInstance.destroy();
       });
     });
 

--- a/test/integration2/dialects/sqlite.spec.js
+++ b/test/integration2/dialects/sqlite.spec.js
@@ -1,10 +1,12 @@
 const { expect } = require('chai');
 require('../../util/chai-setup');
+const knex = require('../../../knex');
 const {
   getKnexForSqlite,
   getKnexForBetterSqlite,
 } = require('../util/knex-instance-provider');
 const Client_SQLite3 = require('../../../lib/dialects/sqlite3');
+const Client_BetterSQLite3 = require('../../../lib/dialects/better-sqlite3');
 const Transaction_Sqlite = require('../../../lib/dialects/sqlite3/execution/sqlite-transaction');
 
 const configs = [
@@ -15,8 +17,117 @@ const configs = [
 for (const { driver, factory } of configs) {
   const knexChecked = factory(true);
   const knexUnchecked = factory(false);
+  const Client =
+    driver === 'better-sqlite3' ? Client_BetterSQLite3 : Client_SQLite3;
 
   describe(`Sqlite3 dialect (${driver})`, () => {
+    describe('connection.filename warning', () => {
+      function filenameWarningCount(warnings) {
+        return warnings.filter((message) =>
+          message.includes('connection.filename')
+        ).length;
+      }
+
+      function createWarningCollector(extraConfig = {}) {
+        const warnings = [];
+        return {
+          warnings,
+          config: {
+            client: driver,
+            useNullAsDefault: true,
+            log: {
+              warn(message) {
+                warnings.push(message);
+              },
+            },
+            ...extraConfig,
+          },
+        };
+      }
+
+      it('warns at construction for static config missing filename', () => {
+        const { warnings, config } = createWarningCollector({
+          connection: {},
+        });
+
+        new Client(config);
+
+        expect(filenameWarningCount(warnings)).to.equal(1);
+      });
+
+      it('does not warn at construction for static config with filename', () => {
+        const { warnings, config } = createWarningCollector({
+          connection: { filename: ':memory:' },
+        });
+
+        new Client(config);
+
+        expect(filenameWarningCount(warnings)).to.equal(0);
+      });
+
+      it('does not warn at construction when connection is a function', () => {
+        const { warnings, config } = createWarningCollector({
+          connection() {
+            return { filename: ':memory:' };
+          },
+        });
+
+        new Client(config);
+
+        expect(filenameWarningCount(warnings)).to.equal(0);
+      });
+
+      it('warns only once for static config missing filename', async () => {
+        const { warnings, config } = createWarningCollector({
+          connection: {},
+        });
+        const knexInstance = knex(config);
+
+        try {
+          await knexInstance.raw('select 1');
+        } catch (_err) {
+          // Opening sqlite with an undefined filename may fail; warning still matters.
+        }
+
+        expect(filenameWarningCount(warnings)).to.equal(1);
+        await knexInstance.destroy();
+      });
+
+      it('does not warn when a connection function provides filename', async () => {
+        const { warnings, config } = createWarningCollector({
+          connection() {
+            return { filename: ':memory:' };
+          },
+        });
+        const knexInstance = knex(config);
+
+        await knexInstance.raw('select 1');
+        await knexInstance.raw('select 2');
+
+        expect(filenameWarningCount(warnings)).to.equal(0);
+        await knexInstance.destroy();
+      });
+
+      it('warns once when a connection function omits filename', async () => {
+        const { warnings, config } = createWarningCollector({
+          connection() {
+            return {};
+          },
+        });
+        const knexInstance = knex(config);
+
+        try {
+          await knexInstance.raw('select 1');
+          await knexInstance.raw('select 2');
+        } catch (_err) {
+          // Connection may fail after the warning is logged.
+        }
+
+        expect(filenameWarningCount(warnings)).to.equal(1);
+        await knexInstance.destroy();
+      });
+    });
+
     describe('strict transactions', () => {
       /** @type {Client_SQLite3} checked */
       let checked;


### PR DESCRIPTION
## Summary

When `connection` is a function, Knex stores it as a `connectionConfigProvider` and does not resolve settings synchronously in the constructor. The sqlite constructor was checking `config.connection.filename` directly, which is always `undefined` for a function — so users with a valid dynamic config got a false warning.

Guard the existing constructor check with `typeof config.connection !== 'function'`. Static misconfiguration (e.g. `connection: {}` without `filename`) still warns at construction.

## Test plan

- [x] `test/integration2/dialects/sqlite.spec.js` — `connection.filename warning` block for both `sqlite3` and `better-sqlite3`
- [x] Targeted mocha grep for the new tests — 6 passing