### PR TITLE
Replace the use of knex with the knexInstance that is created using the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ const config: Knex.Config = {
 const knexInstance = knex(config);
 
 try {
-  const users = await knex<User>('users').select('id', 'age');
+  const users = await knexInstance<User>('users').select('id', 'age');
 } catch (err) {
   // error handling
 }


### PR DESCRIPTION
The sample code for the typescript implementation creates an instance of the knex using the config, but does not use this instance variable when querying the db. 

This results in a SQLITE_ERROR (using mssql)

This commit makes use of the instance and resolves the problem.