### PR TITLE
fix: update types for migrator config

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3149,6 +3149,7 @@ declare namespace Knex {
     loadExtensions?: readonly string[];
     migrationSource?: MigrationSource<unknown>;
     name?: string;
+    getNewMigrationName?: (name: string) => string;
   }
 
   // Note that the shape of the `migration` depends on the MigrationSource which may be custom.


### PR DESCRIPTION
## Why
In the docs and code it seems you can use a function to create a migration name. But the type does not reflect that.

See:
https://knexjs.org/guide/migrations.html#custom-migration-name
https://github.com/knex/knex/blob/176151d8048b2a7feeb89a3d649a5580786d4f4e/lib/migrations/migrate/MigrationGenerator.js#L42-L47