### PR TITLE
Fix for foreign key's referencing table schemas.

### DIFF
--- a/lib/schema/tablebuilder.js
+++ b/lib/schema/tablebuilder.js
@@ -109,8 +109,8 @@ class TableBuilder {
             },
           };
         }
-        foreignData.inTable = pieces[0];
-        foreignData.references = pieces[1];
+        foreignData.references = pieces.pop();
+        foreignData.inTable = pieces.join('.');
         return returnObj;
       },
       withKeyName(keyName) {

--- a/test/integration2/migrate/migration-integration.spec.js
+++ b/test/integration2/migrate/migration-integration.spec.js
@@ -28,6 +28,7 @@ const { getAllDbs, getKnexForDb } = require('../util/knex-instance-provider');
 const {
   ensureTable,
 } = require('../../../lib/migrations/migrate/table-creator');
+const { DRIVER_NAMES } = require('../../../lib/constants');
 
 describe('Migrations', function () {
   getAllDbs().forEach((db) => {
@@ -80,6 +81,20 @@ describe('Migrations', function () {
               });
             });
         });
+
+        if(db === DRIVER_NAMES.MsSQL) {
+          it('should not fail creating a foreign key referencing a schema', () => {
+            return knex.migrate
+              .latest({
+                directory: 'test/integration2/migrate/test_foreign_key_with_schema',
+              })
+              .then(() => {
+                return knex.migrate.rollback({
+                  directory: 'test/integration2/migrate/test_foreign_key_with_schema',
+                });
+              });
+          });
+        }
 
         if (isPostgreSQL(knex)) {
           it('should not fail drop-and-recreate-column operation when using promise chain and schema', () => {

--- a/test/integration2/migrate/test_foreign_key_with_schema/20250113173201_schema_setup.js
+++ b/test/integration2/migrate/test_foreign_key_with_schema/20250113173201_schema_setup.js
@@ -1,0 +1,13 @@
+exports.up = function up(knex) {
+  if(knex.client.dialect !== 'mssql') {
+    throw new Error('mssql only supported for this test setup at the moment')
+  }
+  return knex.raw('CREATE SCHEMA testSchema')
+}
+
+exports.down = function down(knex) {
+  if(knex.client.dialect !== 'mssql') {
+    throw new Error('mssql only supported for this test setup at the moment')
+  }
+  return knex.raw('DROP SCHEMA testSchema');
+}

--- a/test/integration2/migrate/test_foreign_key_with_schema/20250113173202_foreign_keys_with_schema.js
+++ b/test/integration2/migrate/test_foreign_key_with_schema/20250113173202_foreign_keys_with_schema.js
@@ -1,0 +1,31 @@
+exports.up = function up(knex) {
+  return knex.schema
+    .withSchema('testSchema')
+    .createTable('LeftSide', (table) => {
+      table.increments('LeftSideId').primary();
+      table.string('EmailAddress').unique().notNullable();
+    })
+    .createTable('RightSide', (table) => {
+      table.increments('RightSideId').primary();
+      table.string('EmailAddress').unique().notNullable();
+    })
+    .createTable('ConnectionTable', (table) => {
+      table.integer('LeftSideId').notNullable();
+      table
+        .foreign('LeftSideId')
+        .references('testSchema.LeftSide.LeftSideId');
+      table.integer('RightSideId').notNullable();
+      table
+        .foreign('RightSideId')
+        .references('testSchema.RightSide.RightSideId');
+      table.primary(['LeftSideId', 'RightSideId']);
+    });
+}
+
+exports.down = function down(knex) {
+  return knex.schema
+    .withSchema('testSchema')
+    .dropTable('ConnectionTable')
+    .dropTable('RightSide')
+    .dropTable('LeftSide');
+}


### PR DESCRIPTION
Thanks for such a great project!

I used patch-package with the following when I ran into an issue with foreign keys utilizing schemas as mentioned in the title, so the basic fix for those who use that in the meantime is below.

```diff
diff --git a/node_modules/knex/lib/schema/tablebuilder.js b/node_modules/knex/lib/schema/tablebuilder.js
index 99f849a..5d78396 100644
--- a/node_modules/knex/lib/schema/tablebuilder.js
+++ b/node_modules/knex/lib/schema/tablebuilder.js
@@ -109,8 +109,9 @@ class TableBuilder {
             },
           };
         }
-        foreignData.inTable = pieces[0];
-        foreignData.references = pieces[1];
+        
+        foreignData.references = pieces.pop();
+        foreignData.inTable = pieces.join('.');
         return returnObj;
       },
       withKeyName(keyName) {
```

After reading the contributing guidelines, I also created some migrations and tests for them based off of my main project where I was actually running through my own checklist of tests. As I only have set up for `mssql` so far, I have not tested against other drivers.

As for why I did `if(db === DRIVER_NAMES.MsSQL) {` instead of `if (isMsSql(knex)) {`, through some digging I found that will always return false at that level, since `knex` is undefined there.

During the digging, it looked like `test/util/db-helpers.js`  `function getDriverName(knex)` always had undefined for `knex` passed in, so I am not sure if the switch statements are working for other bits or not. If you would like me to dig into that, I can try to find time as well.

Anyway, thanks again and let me know if I should change anything.