### PR TITLE
query-builder.md fix section title

### DIFF
--- a/docs/src/guide/query-builder.md
+++ b/docs/src/guide/query-builder.md
@@ -1577,7 +1577,7 @@ The context can be any kind of value and will be passed to the hooks without mod
 
 Calling `queryContext` with no arguments will return any context configured for the query builder instance.
 
-##### Extending Query Builder
+## Extending Query Builder
 
 **Important:** this feature is experimental and its API may change in the future.
 


### PR DESCRIPTION
Fixed section title `Extending Query Builder`.

Made the section the same level as `Common` and `Where Clauses in the document`

Before it was like this:
<img width="1275" alt="image" src="https://github.com/user-attachments/assets/e17ef61c-8737-4209-9773-f6cc60ae9851" />
