### PR TITLE
Types no longer allow knex to be called without tablename

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -388,7 +388,7 @@ interface Knex<TRecord extends {} = any, TResult = any[]>
     TRecord2 extends {} = TRecord,
     TResult2 = DeferredKeySelection<TRecord2, never>[]
   >(
-    tableName?: Knex.TableDescriptor | Knex.AliasDict,
+    tableName: Knex.TableDescriptor | Knex.AliasDict,
     options?: TableOptions
   ): Knex.QueryBuilder<TRecord2, TResult2>;
   VERSION: string;


### PR DESCRIPTION
`calling knex without a tableName is deprecated. Use knex.queryBuilder() instead.`

I've seen that error crop up in our code for many years. It's maybe time to knock it on the head.