### PR TITLE
Add native support for PostgreSQL array default values

### DIFF
--- a/lib/formatter/formatterUtils.js
+++ b/lib/formatter/formatterUtils.js
@@ -1,5 +1,18 @@
 const { isObject } = require('../util/is');
 
+function escapeArrayElement(value) {
+  if (value === null || value === undefined) {
+    return 'NULL';
+  }
+  if (Array.isArray(value)) {
+    return `{${value.map(escapeArrayElement).join(',')}}`;
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  return `"${value.toString().replace(/"/g, '""')}"`;
+}
+
 // Compiles a callback using the query builder.
 function compileCallback(callback, method, client, bindingsHolder) {
   // Build the callback
@@ -30,6 +43,8 @@ function formatDefault(value, type, client) {
     return `'${value ? 1 : 0}'`;
   } else if ((type === 'json' || type === 'jsonb') && isObject(value)) {
     return `'${JSON.stringify(value)}'`;
+  } else if (Array.isArray(value) && type && type.endsWith('[]')) {
+    return `'${escapeArrayElement(value)}'`;
   } else {
     return client._escapeBinding(value.toString());
   }


### PR DESCRIPTION
## Current Behavior
Currently, when trying to set a default value for a PostgreSQL array column in Knex, we need to use `knex.raw()` to properly format the array literal. For example:

```js
table.specificType('my_array', 'integer[]').defaultTo(knex.raw('{1,2,3}'));
```

Users need to manually format the array literal with curly braces as exposed in https://github.com/knex/knex/issues/6192

## Implementation

We need to handle PostgreSQL array default values natively, allowing users to simply pass a JavaScript array:

```js
table.specificType('my_array', 'integer[]').defaultTo([1, 2, 3]);
```

The array should be automatically converted to the proper PostgreSQL array literal format.

The fix involves modifying the `formatDefault()` function in `lib/formatter/formatterUtils.js` to properly handle arrays when the column type ends with `[]`.

## Examples

The following cases should work:

```js
// Simple integer array
table.specificType('int_array', 'integer[]').defaultTo([1, 2, 3]);
// => '{1,2,3}'

// Text array with special characters
table.specificType('text_array', 'text[]').defaultTo(['a,b', 'c"d', "e'f"]);
// => '{"a,b","c""d","e\'f"}'

// Nested arrays
table.specificType('matrix', 'integer[][]').defaultTo([[1, 2], [3, 4]]);
// => '{{1,2},{3,4}}'

// Array with null values
table.specificType('nullable', 'text[]').defaultTo(['a', null, 'b']);
// => '{"a",NULL,"b"}'

// Empty array
table.specificType('empty', 'integer[]').defaultTo([]);
// => '{}'
```
