### PR TITLE
Fix regex pattern for escaping question marks in postgres queries

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -139,7 +139,7 @@ class Client_PG extends Client {
   // is \? (e.g. knex.raw("\\?") since javascript requires '\' to be escaped too...)
   positionBindings(sql) {
     let questionCount = 0;
-    return sql.replace(/(\\*)(\?)/g, function (match, escapes) {
+    return sql.replace(/(?<!')(\\*)(\?)(?!')/g, function (match, escapes) {
       if (escapes.length % 2) {
         return '?';
       } else {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -10012,6 +10012,22 @@ describe('QueryBuilder', () => {
     });
   });
 
+  it('ignores ? in string tokens', () => {
+    testNativeSql(
+      qb()
+        .select('*')
+        .from('table')
+        .whereRaw("a = '?'")
+        .whereRaw('b = ?', ['?']),
+      {
+        pg: {
+          sql: `select * from "table" where a = '?' and b = $1`,
+          bindings: ['?'],
+        },
+      }
+    );
+  });
+
   it("wrapped 'with' clause select", () => {
     testsql(
       qb()


### PR DESCRIPTION
Fixes #5626

I wasn't sure how to test the schema builder correctly because the issue only occurs right before the query is executed by calling [`enrichQueryObject`](https://github.com/knex/knex/blob/9bd12999907436c2ef51f786df09a9a7e8931cca/lib/execution/internal/query-executioner.js#L25).
https://github.com/knex/knex/blob/9bd12999907436c2ef51f786df09a9a7e8931cca/lib/client.js#L153

So I added a `toNative` function just for the test file, but maybe this should be added to the [`SchemaCompiler`](https://github.com/knex/knex/blob/9bd12999907436c2ef51f786df09a9a7e8931cca/lib/schema/compiler.js#L93-L100), similar to the `QueryCompiler`
https://github.com/knex/knex/blob/9bd12999907436c2ef51f786df09a9a7e8931cca/lib/query/querycompiler.js#L86-L96

I also added a unit test for the query builder because it also had the same issue.
Maybe this test is enough and we can remove the schema builder test.