### PR TITLE
Fix TypeError when a connection error occurs with Streams

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -341,6 +341,11 @@ class Client extends EventEmitter {
   // Releases a connection back to the connection pool,
   // returning a promise resolved when the connection is released.
   releaseConnection(connection) {
+    if (!connection) {
+      debug('no connection to release');
+      return Promise.resolve();
+    }
+
     debug('releasing connection to pool: %s', connection.__knexUid);
     const didRelease = this.pool.release(connection);
 


### PR DESCRIPTION
Encountered a TypeError when dealing with a failed connection attempt when using Knex's streams. This introduces a check in `releaseConnection` to ensure the connection is set.

```
/Users/mmollick/repos/knex-repro/node_modules/knex/lib/client.js:344
    debug('releasing connection to pool: %s', connection.__knexUid);
                                                         ^

TypeError: Cannot read properties of undefined (reading '__knexUid')
    at Client_PG.releaseConnection (/Users/mmollick/repos/knex-repro/node_modules/knex/lib/client.js:344:58)
    at Transform.<anonymous> (/Users/mmollick/repos/knex-repro/node_modules/knex/lib/execution/runner.js:72:19)
    at Transform.emit (node:events:530:35)
    at emitCloseNT (node:internal/streams/destroy:148:10)
    at emitErrorCloseNT (node:internal/streams/destroy:130:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
```

Reproduction
```js
const knex = require('knex')({
    client: 'pg',
    connection: 'postgres:///knex_test' // Non existent database - connection will fail
});

async function mainNoStream() {
    try {
        const rows = await knex.table('users');

        for (const row of rows) {
            console.log(row);
        }
    } catch (err) {
        // Expected: Caught: Error: SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string
        console.error('NO STREAM CAUGHT:', err.message);
    }
}

async function mainWithStream() {
    try {
        const stream = knex.table('users').stream();

        for await (const row of stream) {
            console.log(row);
        }
    } catch (err) {

        // Expected: Caught: Error: SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string
        console.error('STREAM CAUGHT:', err.message);
    }
}


const main = async () => {
    // 
    await mainNoStream();

    // Unexpected TypeError thrown
    await mainWithStream();
}

main();

```