### PR TITLE
Issue #6201: Add support for Spanner Postgres

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -107,10 +107,19 @@ jobs:
 
       - name: Run Tests
         run: npm run test:db
-        if: matrix.database-type != 'oracledb'
+        if: matrix.database-type != 'oracledb' && matrix.database-type != 'postgres-spanner'
         env:
           CI: true
           DB: ${{ matrix.database-type }}
+          KNEX_TEST_TIMEOUT: 60000
+
+      # Spanner's PostgreSQL interface is a limited subset (no schemas/migrations),
+      # so it runs a dedicated spec instead of the shared integration suite.
+      - name: Run Tests (postgres-spanner)
+        run: npm run test:spanner
+        if: matrix.database-type == 'postgres-spanner'
+        env:
+          CI: true
           KNEX_TEST_TIMEOUT: 60000
 
       # This allows for oracle tests to run and fail as part of PR #4889.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -113,8 +113,7 @@ jobs:
           DB: ${{ matrix.database-type }}
           KNEX_TEST_TIMEOUT: 60000
 
-      # Spanner's PostgreSQL interface is a limited subset (no schemas/migrations),
-      # so it runs a dedicated spec instead of the shared integration suite.
+      # Spanner runs a dedicated spec instead of the shared integration suite.
       - name: Run Tests (postgres-spanner)
         run: npm run test:spanner
         if: matrix.database-type == 'postgres-spanner'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,6 +35,7 @@ jobs:
         database-type:
           [
             postgres,
+            postgres-spanner,
             pgnative,
             mysql,
             mariadb,

--- a/docs/src/guide/index.md
+++ b/docs/src/guide/index.md
@@ -84,6 +84,19 @@ const pg = require('knex')({
 
 :::
 
+::: info Google Cloud Spanner (PostgreSQL)
+The `postgres-spanner` client targets [Google Cloud Spanner's PostgreSQL interface](https://cloud.google.com/spanner/docs/pgadapter), reached over the pg wire protocol through PGAdapter. It reuses the `pg` driver, so install [`pg`](https://github.com/brianc/node-postgres) as for regular PostgreSQL.
+
+```js
+const knex = require('knex')({
+  client: 'postgres-spanner',
+  connection: 'postgresql://localhost:5432/my-database',
+});
+```
+
+Spanner's PostgreSQL interface only implements a subset of PostgreSQL. Notably, it has no concept of schemas, so schema-dependent features (including knex migrations, which rely on `current_schema()`) are not supported.
+:::
+
 The following are SQLite usage patterns for instantiating the Knex configuration object:
 
 ::: info SQLite3 or Better-SQLite3

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -13,6 +13,7 @@ const SUPPORTED_CLIENTS = Object.freeze(
     'mysql2',
     'oracledb',
     'postgres',
+    'postgres-spanner',
     'pgnative',
     'redshift',
     'sqlite3',

--- a/lib/dialects/index.js
+++ b/lib/dialects/index.js
@@ -13,6 +13,7 @@ const dbNameToDialectLoader = Object.freeze({
   oracledb: () => require('./oracledb'),
   pgnative: () => require('./pgnative'),
   postgres: () => require('./postgres'),
+  'postgres-spanner': () => require('./postgres-spanner'),
   redshift: () => require('./redshift'),
   sqlite3: () => require('./sqlite3'),
 });

--- a/lib/dialects/index.ts
+++ b/lib/dialects/index.ts
@@ -11,6 +11,7 @@ const dbNameToDialectLoader: Record<string, () => any> = Object.freeze({
   oracledb: () => require('./oracledb'),
   pgnative: () => require('./pgnative'),
   postgres: () => require('./postgres'),
+  'postgres-spanner': () => require('./postgres-spanner'),
   redshift: () => require('./redshift'),
   sqlite3: () => require('./sqlite3'),
 });

--- a/lib/dialects/postgres-spanner/index.js
+++ b/lib/dialects/postgres-spanner/index.js
@@ -1,0 +1,27 @@
+// Postgres Spanner Driver (postgres-spanner)
+// -------
+const Client_PG = require('../postgres');
+
+const QueryCompiler = require('./query/pg-spanner-querycompiler');
+const SchemaCompiler = require('./schema/pg-spanner-compiler');
+
+class Client_PgSpanner extends Client_PG {
+  constructor(...args) {
+    super(...args);
+    this.driverName = 'postgres-spanner';
+  }
+
+  queryCompiler(builder, formatter) {
+    return new QueryCompiler(this, builder, formatter);
+  }
+
+  schemaCompiler() {
+    return new SchemaCompiler(this, ...arguments);
+  }
+}
+
+Object.assign(Client_PG.prototype, {
+  dialect: 'postgresql-spanner',
+})
+
+module.exports = Client_PgSpanner;

--- a/lib/dialects/postgres-spanner/index.js
+++ b/lib/dialects/postgres-spanner/index.js
@@ -22,6 +22,6 @@ class Client_PgSpanner extends Client_PG {
 
 Object.assign(Client_PG.prototype, {
   dialect: 'postgresql-spanner',
-})
+});
 
 module.exports = Client_PgSpanner;

--- a/lib/dialects/postgres-spanner/index.js
+++ b/lib/dialects/postgres-spanner/index.js
@@ -6,11 +6,6 @@ const QueryCompiler = require('./query/pg-spanner-querycompiler');
 const SchemaCompiler = require('./schema/pg-spanner-compiler');
 
 class Client_PgSpanner extends Client_PG {
-  constructor(...args) {
-    super(...args);
-    this.driverName = 'postgres-spanner';
-  }
-
   queryCompiler(builder, formatter) {
     return new QueryCompiler(this, builder, formatter);
   }
@@ -20,8 +15,10 @@ class Client_PgSpanner extends Client_PG {
   }
 }
 
-Object.assign(Client_PG.prototype, {
+Object.assign(Client_PgSpanner.prototype, {
+  // The "dialect", for reference elsewhere.
   dialect: 'postgresql-spanner',
+  driverName: 'postgres-spanner',
 });
 
 module.exports = Client_PgSpanner;

--- a/lib/dialects/postgres-spanner/query/pg-spanner-querycompiler.js
+++ b/lib/dialects/postgres-spanner/query/pg-spanner-querycompiler.js
@@ -1,0 +1,41 @@
+// PostgreSQL Query Builder & Compiler
+// ------
+const reduce = require('lodash/reduce');
+
+const QueryCompiler_PG = require('../../postgres/query/pg-querycompiler');
+
+class QueryCompiler_PgSpanner extends QueryCompiler_PG {
+  constructor(client, builder, formatter) {
+    super(client, builder, formatter);
+  }
+
+  _buildColumnInfoQuery(schema, sql, bindings, column) {
+    if (schema) {
+      sql += ' and table_schema = ?';
+      bindings.push(schema);
+    }
+
+    return {
+      sql,
+      bindings,
+      output(resp) {
+        const out = reduce(
+          resp.rows,
+          function (columns, val) {
+            columns[val.column_name] = {
+              type: val.data_type,
+              maxLength: val.character_maximum_length,
+              nullable: val.is_nullable === 'YES',
+              defaultValue: val.column_default,
+            };
+            return columns;
+          },
+          {}
+        );
+        return (column && out[column]) || out;
+      },
+    };
+  }
+}
+
+module.exports = QueryCompiler_PgSpanner;

--- a/lib/dialects/postgres-spanner/query/pg-spanner-querycompiler.js
+++ b/lib/dialects/postgres-spanner/query/pg-spanner-querycompiler.js
@@ -1,14 +1,32 @@
-// PostgreSQL Query Builder & Compiler
+// PostgreSQL Spanner Query Builder & Compiler
 // ------
+const identity = require('lodash/identity');
 const reduce = require('lodash/reduce');
 
 const QueryCompiler_PG = require('../../postgres/query/pg-querycompiler');
 
 class QueryCompiler_PgSpanner extends QueryCompiler_PG {
-  constructor(client, builder, formatter) {
-    super(client, builder, formatter);
+  // Compiles a columnInfo query. Spanner's PostgreSQL interface does not
+  // support current_database(), so the base dialect's `table_catalog =
+  // current_database()` filter is omitted here.
+  columnInfo() {
+    const column = this.single.columnInfo;
+    let schema = this.single.schema;
+
+    const table = this.client.customWrapIdentifier(this.single.table, identity);
+
+    if (schema) {
+      schema = this.client.customWrapIdentifier(schema, identity);
+    }
+
+    const sql = 'select * from information_schema.columns where table_name = ?';
+    const bindings = [table];
+
+    return this._buildColumnInfoQuery(schema, sql, bindings, column);
   }
 
+  // current_schema() is likewise unsupported, so unlike the base dialect we do
+  // not fall back to it when no schema is given.
   _buildColumnInfoQuery(schema, sql, bindings, column) {
     if (schema) {
       sql += ' and table_schema = ?';

--- a/lib/dialects/postgres-spanner/query/pg-spanner-querycompiler.js
+++ b/lib/dialects/postgres-spanner/query/pg-spanner-querycompiler.js
@@ -6,9 +6,7 @@ const reduce = require('lodash/reduce');
 const QueryCompiler_PG = require('../../postgres/query/pg-querycompiler');
 
 class QueryCompiler_PgSpanner extends QueryCompiler_PG {
-  // Compiles a columnInfo query. Spanner's PostgreSQL interface does not
-  // support current_database(), so the base dialect's `table_catalog =
-  // current_database()` filter is omitted here.
+  // Spanner doesn't support current_database(); drop the table_catalog filter.
   columnInfo() {
     const column = this.single.columnInfo;
     let schema = this.single.schema;
@@ -25,8 +23,7 @@ class QueryCompiler_PgSpanner extends QueryCompiler_PG {
     return this._buildColumnInfoQuery(schema, sql, bindings, column);
   }
 
-  // current_schema() is likewise unsupported, so unlike the base dialect we do
-  // not fall back to it when no schema is given.
+  // No current_schema() fallback — Spanner doesn't support it.
   _buildColumnInfoQuery(schema, sql, bindings, column) {
     if (schema) {
       sql += ' and table_schema = ?';

--- a/lib/dialects/postgres-spanner/schema/pg-spanner-compiler.js
+++ b/lib/dialects/postgres-spanner/schema/pg-spanner-compiler.js
@@ -1,0 +1,51 @@
+// PostgreSQL Spanner Schema Compiler
+// -------
+
+const SchemaCompiler_PG = require('../../postgres/schema/pg-compiler');
+
+class SchemaCompiler_PgSpanner extends SchemaCompiler_PG {
+  constructor(client, builder) {
+    super(client, builder);
+  }
+
+  // Check whether the current table
+  hasTable(tableName) {
+    let sql = 'select * from information_schema.tables where table_name = ?';
+    const bindings = [tableName];
+
+    if (this.schema) {
+      sql += ' and table_schema = ?';
+      bindings.push(this.schema);
+    }
+
+    this.pushQuery({
+      sql,
+      bindings,
+      output(resp) {
+        return resp.rows.length > 0;
+      },
+    });
+  }
+
+  // Compile the query to determine if a column exists in a table.
+  hasColumn(tableName, columnName) {
+    let sql =
+      'select * from information_schema.columns where table_name = ? and column_name = ?';
+    const bindings = [tableName, columnName];
+
+    if (this.schema) {
+      sql += ' and table_schema = ?';
+      bindings.push(this.schema);
+    }
+
+    this.pushQuery({
+      sql,
+      bindings,
+      output(resp) {
+        return resp.rows.length > 0;
+      },
+    });
+  }
+}
+
+module.exports = SchemaCompiler_PgSpanner;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:unit": "npm run test:unit-only && npm run test:cli",
     "test:unit-only": "mocha --exit -t 10000 --config test/mocha-unit-config-test.js",
     "test:db": "mocha --exit -t 10000 --config test/mocha-integration-config-test.js",
+    "test:spanner": "cross-env DB=postgres-spanner mocha --exit -t 10000 --config test/mocha-spanner-config-test.js",
     "test:db:coverage": "nyc mocha --exit --check-leaks -t 10000 --config test/mocha-integration-config-test.js && npm run test:tape",
     "test:db:no-oracle": "cross-env DB=\"mssql mysql mysql2 postgres sqlite3\" mocha --exit -t 10000 --config test/mocha-integration-config-test.js && npm run test:tape",
     "test": "mocha --exit -t 10000 --config test/mocha-all-config-test.js && npm run test:tape && npm run test:cli",

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -135,19 +135,18 @@ services:
       - 9010:9010
       - 9020:9020
 
-
   spanner-pgadapter:
     # Most recent container as of 2025-04-25
     image: gcr.io/cloud-spanner-pg-adapter/pgadapter:v0.46.2
     container_name: uis-test-spanner-pgadapter
     command:
-      - "-p test-project"
-      - "-i test-instance"
-      - "-r autoConfigEmulator=true"
-      - "-e spanner-emulator:9010"
-      - "-ddl=AutocommitExplicitTransaction"
-      - "-c \"\""
-      - "-x"
+      - '-p test-project'
+      - '-i test-instance'
+      - '-r autoConfigEmulator=true'
+      - '-e spanner-emulator:9010'
+      - '-ddl=AutocommitExplicitTransaction'
+      - '-c ""'
+      - '-x'
     # Mapping to port 25434 as the next available port following the incrementing of Postgres
     # services in this file
     ports:

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -135,8 +135,7 @@ services:
       - 9010:9010
       - 9020:9020
 
-  # pgadapter exposes Spanner's PostgreSQL interface on the pg wire protocol.
-  # Named `postgres-spanner` so the CI matrix can start it like the other dialects.
+  # pgadapter exposes Spanner over the pg wire protocol.
   postgres-spanner:
     # Most recent container as of 2025-04-25
     image: gcr.io/cloud-spanner-pg-adapter/pgadapter:v0.46.2
@@ -157,7 +156,6 @@ services:
       spanner-emulator:
         condition: service_started
   waitpostgres-spanner:
-    # pgadapter speaks the pg wire protocol, so we reuse the postgres image's psql client.
     # mirror-from: postgres:17-alpine
     image: ghcr.io/knex/postgres:17-alpine
     links:
@@ -167,7 +165,7 @@ services:
     entrypoint:
       - bash
       - -c
-      # autoConfigEmulator auto-creates the instance; create the test database, then wait until it answers.
+      # create the test database, then wait until it answers
       - 'until /usr/local/bin/psql "postgresql://postgres-spanner:5432/knex_test" -c "SELECT 1"; do /usr/local/bin/psql "postgresql://postgres-spanner:5432/postgres" -c "CREATE DATABASE knex_test" || true; sleep 5; done'
 
   cockroachdb:

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -128,6 +128,35 @@ services:
       - -c
       - 'until /usr/local/bin/psql postgres://testuser:knextest@postgres/knex_test -c "SELECT 1"; do sleep 5; done'
 
+  spanner-emulator:
+    # Most recent container as of 2025-04-25
+    image: gcr.io/cloud-spanner-emulator/emulator:1.5.32
+    ports:
+      - 9010:9010
+      - 9020:9020
+
+
+  spanner-pgadapter:
+    # Most recent container as of 2025-04-25
+    image: gcr.io/cloud-spanner-pg-adapter/pgadapter:v0.46.2
+    container_name: uis-test-spanner-pgadapter
+    command:
+      - "-p test-project"
+      - "-i test-instance"
+      - "-r autoConfigEmulator=true"
+      - "-e spanner-emulator:9010"
+      - "-ddl=AutocommitExplicitTransaction"
+      - "-c \"\""
+      - "-x"
+    # Mapping to port 25434 as the next available port following the incrementing of Postgres
+    # services in this file
+    ports:
+      - 25434:5432
+    restart: on-failure
+    depends_on:
+      spanner-emulator:
+        condition: service_started
+
   cockroachdb:
     # mirror-from: cockroachdb/cockroach:latest-v23.2
     image: ghcr.io/knex/cockroach:latest-v23.2

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -135,10 +135,11 @@ services:
       - 9010:9010
       - 9020:9020
 
-  spanner-pgadapter:
+  # pgadapter exposes Spanner's PostgreSQL interface on the pg wire protocol.
+  # Named `postgres-spanner` so the CI matrix can start it like the other dialects.
+  postgres-spanner:
     # Most recent container as of 2025-04-25
     image: gcr.io/cloud-spanner-pg-adapter/pgadapter:v0.46.2
-    container_name: uis-test-spanner-pgadapter
     command:
       - '-p test-project'
       - '-i test-instance'
@@ -155,6 +156,19 @@ services:
     depends_on:
       spanner-emulator:
         condition: service_started
+  waitpostgres-spanner:
+    # pgadapter speaks the pg wire protocol, so we reuse the postgres image's psql client.
+    # mirror-from: postgres:17-alpine
+    image: ghcr.io/knex/postgres:17-alpine
+    links:
+      - postgres-spanner
+    depends_on:
+      - postgres-spanner
+    entrypoint:
+      - bash
+      - -c
+      # autoConfigEmulator auto-creates the instance; create the test database, then wait until it answers.
+      - 'until /usr/local/bin/psql "postgresql://postgres-spanner:5432/knex_test" -c "SELECT 1"; do /usr/local/bin/psql "postgresql://postgres-spanner:5432/postgres" -c "CREATE DATABASE knex_test" || true; sleep 5; done'
 
   cockroachdb:
     # mirror-from: cockroachdb/cockroach:latest-v23.2

--- a/test/integration2/dialects/postgres-spanner.spec.js
+++ b/test/integration2/dialects/postgres-spanner.spec.js
@@ -7,11 +7,8 @@ const {
   getAllDbs,
 } = require('../util/knex-instance-provider');
 
-// Spanner's PostgreSQL interface only implements a subset of PostgreSQL (no
-// schemas, stricter typing, no migrations), so it does not run the shared
-// integration suite. These tests cover the operations Spanner does support and
-// exercise the dialect's own query/schema compiler overrides (columnInfo,
-// hasTable, hasColumn) against the Spanner emulator via PGAdapter.
+// Spanner supports only a subset of PostgreSQL, so it runs this focused spec
+// against the emulator instead of the shared integration suite.
 describe('PostgreSQL Spanner dialect', () => {
   getAllDbs()
     .filter((db) => db === Db.PostgresSpanner)
@@ -22,8 +19,7 @@ describe('PostgreSQL Spanner dialect', () => {
         before(async () => {
           knex = getKnexForDb(db);
           await knex.raw('DROP TABLE IF EXISTS spanner_test');
-          // Created with raw DDL: Spanner requires the PRIMARY KEY inline at
-          // table creation and does not support ALTER TABLE ADD PRIMARY KEY.
+          // raw DDL: Spanner needs the PRIMARY KEY inline at creation.
           await knex.raw(
             'CREATE TABLE spanner_test (id bigint NOT NULL, name varchar, value bigint, PRIMARY KEY (id))'
           );

--- a/test/integration2/dialects/postgres-spanner.spec.js
+++ b/test/integration2/dialects/postgres-spanner.spec.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const { expect } = require('chai');
+const {
+  Db,
+  getKnexForDb,
+  getAllDbs,
+} = require('../util/knex-instance-provider');
+
+// Spanner's PostgreSQL interface only implements a subset of PostgreSQL (no
+// schemas, stricter typing, no migrations), so it does not run the shared
+// integration suite. These tests cover the operations Spanner does support and
+// exercise the dialect's own query/schema compiler overrides (columnInfo,
+// hasTable, hasColumn) against the Spanner emulator via PGAdapter.
+describe('PostgreSQL Spanner dialect', () => {
+  getAllDbs()
+    .filter((db) => db === Db.PostgresSpanner)
+    .forEach((db) => {
+      describe(db, () => {
+        let knex;
+
+        before(async () => {
+          knex = getKnexForDb(db);
+          await knex.raw('DROP TABLE IF EXISTS spanner_test');
+          // Created with raw DDL: Spanner requires the PRIMARY KEY inline at
+          // table creation and does not support ALTER TABLE ADD PRIMARY KEY.
+          await knex.raw(
+            'CREATE TABLE spanner_test (id bigint NOT NULL, name varchar, value bigint, PRIMARY KEY (id))'
+          );
+        });
+
+        after(async () => {
+          await knex.raw('DROP TABLE IF EXISTS spanner_test');
+          await knex.destroy();
+        });
+
+        it('hasTable / hasColumn reflect the live schema', async () => {
+          expect(await knex.schema.hasTable('spanner_test')).to.equal(true);
+          expect(await knex.schema.hasTable('does_not_exist')).to.equal(false);
+          expect(await knex.schema.hasColumn('spanner_test', 'name')).to.equal(
+            true
+          );
+          expect(
+            await knex.schema.hasColumn('spanner_test', 'missing_column')
+          ).to.equal(false);
+        });
+
+        it('inserts and selects rows', async () => {
+          await knex('spanner_test').insert([
+            { id: 1, name: 'alice', value: 10 },
+            { id: 2, name: 'bob', value: 20 },
+          ]);
+          const names = (
+            await knex('spanner_test').orderBy('id').select('name')
+          ).map((row) => row.name);
+          expect(names).to.eql(['alice', 'bob']);
+        });
+
+        it('filters rows with where', async () => {
+          const rows = await knex('spanner_test')
+            .where('name', 'bob')
+            .select('name');
+          expect(rows.map((row) => row.name)).to.eql(['bob']);
+        });
+
+        it('updates and deletes rows', async () => {
+          await knex('spanner_test').where('id', 1).update({ name: 'alice2' });
+          const updated = await knex('spanner_test')
+            .where('id', 1)
+            .first('name');
+          expect(updated.name).to.equal('alice2');
+
+          await knex('spanner_test').where('id', 2).del();
+          const remaining = await knex('spanner_test').select('id');
+          expect(remaining.length).to.equal(1);
+        });
+
+        it('columnInfo returns metadata for each column', async () => {
+          const info = await knex('spanner_test').columnInfo();
+          expect(Object.keys(info)).to.include.members(['id', 'name', 'value']);
+          expect(info.name).to.have.property('type');
+        });
+      });
+    });
+});

--- a/test/integration2/util/knex-instance-provider.js
+++ b/test/integration2/util/knex-instance-provider.js
@@ -7,6 +7,7 @@ const { cloneDeep, merge } = require('lodash');
 
 const Db = /** @type {const} */ ({
   PostgresSQL: 'postgres',
+  PostgresSpanner: 'postgres-spanner',
   PgNative: 'pgnative',
   MySQL: 'mysql',
   MySQL2: 'mysql2',
@@ -171,6 +172,21 @@ const testConfigs = {
     connection: testConfig.postgres || {
       adapter: 'postgresql',
       port: 25432,
+      host: 'localhost',
+      database: 'knex_test',
+      user: 'testuser',
+      password: 'knextest',
+    },
+    pool,
+    migrations,
+    seeds,
+  },
+
+  'postgres-spanner': {
+    client: 'postgres-spanner',
+    connection: testConfig['postgres-spanner'] || {
+      adapter: 'postgresql',
+      port: 25434,
       host: 'localhost',
       database: 'knex_test',
       user: 'testuser',

--- a/test/knexfile.js
+++ b/test/knexfile.js
@@ -138,6 +138,21 @@ const testConfigs = {
     seeds,
   },
 
+  'postgres-spanner': {
+    client: 'postgres-spanner',
+    connection: testConfig['postgres-spanner'] || {
+      adapter: 'postgresql',
+      port: 25434,
+      host: 'localhost',
+      database: 'knex_test',
+      user: 'testuser',
+      password: 'knextest',
+    },
+    pool,
+    migrations,
+    seeds,
+  },
+
   cockroachdb: {
     client: 'cockroachdb',
     connection: testConfig.cockroachdb || {

--- a/test/mocha-spanner-config-test.js
+++ b/test/mocha-spanner-config-test.js
@@ -1,0 +1,6 @@
+// Spanner runs a dedicated, self-contained spec instead of the shared
+// integration suite (which assumes schemas and migrations that Spanner's
+// PostgreSQL interface does not support).
+module.exports = {
+  spec: ['test/integration2/dialects/postgres-spanner.spec.js'],
+};

--- a/test/mocha-spanner-config-test.js
+++ b/test/mocha-spanner-config-test.js
@@ -1,6 +1,4 @@
-// Spanner runs a dedicated, self-contained spec instead of the shared
-// integration suite (which assumes schemas and migrations that Spanner's
-// PostgreSQL interface does not support).
+// Spanner runs a dedicated spec instead of the shared integration suite.
 module.exports = {
   spec: ['test/integration2/dialects/postgres-spanner.spec.js'],
 };


### PR DESCRIPTION
## Related PRs and Issues

1. #6201

## Reason 

This PR addresses issue #6201 by adding a dedicated dialect for Google Cloud Spanner's flavor of "Postgres". This is because Spanner's Postgres implementation (via `pgadapter`) is a limited subset of the full Postgres dialect and thus minor changes are needed.

## Todo

- [ ] Code changes
- [ ] Add tests
- [ ] Update docs

## Changes

1. Added dialect `postgres-spanner` via `lib/constants.js`, `lib/dialects/index.js`, and `lib/dialects/postgres-spanner/`.
2. Added Docker Compose entries for the local Spanner emulator and PgAdapter which proxies the Postgres dialect requests, via `scripts/docker-compose.yml`.

## References
1. https://cloud.google.com/spanner/docs/postgresql-interface
2. https://cloud.google.com/spanner/docs/pgadapter