### PR TITLE
Bug: fix casting object to string in Seeder.js error handling

### DIFF
--- a/lib/migrations/seed/Seeder.js
+++ b/lib/migrations/seed/Seeder.js
@@ -116,7 +116,7 @@ class Seeder {
         log.push(seedPath);
       } catch (originalError) {
         const error = new Error(
-          `Error while executing "${seedPath}" seed: ${originalError.message}`
+          `Error while executing "${seedPath.name}" seed: ${originalError.message}`
         );
         error.original = originalError;
         error.stack =


### PR DESCRIPTION
TODO(@matthew-benson): write a complete description on this change request

Bug fix TypeError: Cannot convert object to primitive value in Seeder.js error handling case.

## Context

I ran into the following error when working with a buggy seeding job I wrote. The error message was being suppressed because the error handling code path hit an error: `TypeError: Cannot convert object to primitive value at Seeder._waterfallBatch`

seedPath is not a string, it's an object like this:

```
[Module: null prototype] {
    name: 'seed_admins',
    seed: [AsyncFunction: seed]
  },
```

Using it as a string throws an early error and masks the error message expected from a failed seeding job.