### PR TITLE
feat: add migration .cts stub

### DIFF
--- a/lib/migrations/migrate/stub/cts.stub
+++ b/lib/migrations/migrate/stub/cts.stub
@@ -1,0 +1,21 @@
+import type { Knex } from "knex";
+
+<% if (d.tableName) { %>
+export async function up(knex: Knex): Promise<Knex.SchemaBuilder> {
+    return knex.schema.createTable("<%= d.tableName %>", (t) => {
+        t.increments();
+        t.timestamps();
+    });
+}
+<% } else { %>
+export async function up(knex: Knex): Promise<void> {
+}
+<% } %>
+<% if (d.tableName) { %>
+export async function down(knex: Knex): Promise<Knex.SchemaBuilder> {
+    return knex.schema.dropTable("<%= d.tableName %>");
+}
+<% } else { %>
+export async function down(knex: Knex): Promise<void> {
+}
+<% } %>


### PR DESCRIPTION
In a project with "type": "module" set in package.json, I had to save the Knex configuration file with the CommonJS extension .cts in order to use it properly.

As a result, when running

`knex --knexfile knexfile.cts migrate:make some-migration-name`
I got this error

`ENOENT: no such file or directory, open '/Users/temez/WebstormProjects/entity-acl/node_modules/knex/lib/migrations/migrate/stub/cts.stub'`