### PR TITLE
Fix ESM export and typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,20 @@
   "name": "knex",
   "version": "3.1.0",
   "description": "A batteries-included SQL query & schema builder for PostgresSQL, MySQL, CockroachDB, MSSQL and SQLite3",
-  "main": "knex",
+  "main": "knex.js",
   "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./knex.mjs"
+      },
+      "require": {
+        "types": "./types/index.d.ts",
+        "default": "./knex.js"
+      }
+    }
+  },
   "engines": {
     "node": ">=16"
   },

--- a/types/index.d.mts
+++ b/types/index.d.mts
@@ -1,0 +1,11 @@
+// ESM-specific types for Knex.js
+// This file provides ESM type definitions that wrap the CJS types from index.d.ts
+// to match the exports defined in knex.mjs
+
+import type knexCjs from './index.d.ts';
+
+// Re-export the named export as defined in knex.mjs, without circular self-reference
+export const knex: Omit<typeof knexCjs, 'default' | 'knex'>;
+
+// Re-export the default export as defined in knex.mjs: export default knex
+export default knex;


### PR DESCRIPTION
Fix the `main` field to clearly call out `knex.js` to remove ambiguity.

Introduce the `exports` field for versions of Node that support it, and properly direct ESM imports to `knex.mjs`

Create an `index.d.mts` wrapper that properly matches what is exported from `knex.mjs` - currently, the typings are not accurate for ESM.