### PR TITLE
Add `createSchema` to migrator config

### DIFF
--- a/lib/migrations/migrate/Migrator.js
+++ b/lib/migrations/migrate/Migrator.js
@@ -60,6 +60,10 @@ class Migrator {
     this._disableProcessing();
     this.config = getMergedConfig(config, this.config, this.knex.client.logger);
 
+    if (this.config.createSchema && this.config.schemaName) {
+      await this.knex.schema.createSchemaIfNotExists(this.config.schemaName);
+    }
+
     const allAndCompleted = await migrationListResolver.listAllAndCompleted(
       this.config,
       this.knex
@@ -102,6 +106,10 @@ class Migrator {
   async up(config) {
     this._disableProcessing();
     this.config = getMergedConfig(config, this.config, this.knex.client.logger);
+
+    if (this.config.createSchema && this.config.schemaName) {
+      await this.knex.schema.createSchemaIfNotExists(this.config.schemaName);
+    }
 
     const allAndCompleted = await migrationListResolver.listAllAndCompleted(
       this.config,

--- a/test/integration2/migrate/migration-integration.spec.js
+++ b/test/integration2/migrate/migration-integration.spec.js
@@ -17,6 +17,7 @@ const _ = require('lodash');
 const testMemoryMigrations = require('./memory-migrations');
 const {
   isPostgreSQL,
+  isPgBased,
   isOracle,
   isMssql,
   isMysql,
@@ -484,6 +485,37 @@ describe('Migrations', function () {
               })
             );
           });
+
+          describe('with createSchema enabled', function () {
+            const schemaName = 'test_create_schema';
+
+            before(async () => {
+              if (isPgBased(knex) || isMssql(knex) || isOracle(knex)) {
+                await knex.schema.dropSchemaIfExists(schemaName, true);
+              }
+            });
+
+            after(async () => {
+              if (isPgBased(knex) || isMssql(knex) || isOracle(knex)) {
+                await knex.schema.dropSchemaIfExists(schemaName, true);
+              }
+            });
+
+            it('should create the schema', async function () {
+              if (!(isPgBased(knex) || isMssql(knex) || isOracle(knex))) {
+                this.skip();
+              } else {
+                await knex.migrate.latest({
+                  directory: ['test/integration2/migrate/test_create_schema'],
+                  schemaName,
+                  createSchema: true,
+                });
+
+                const exists = await knex.schema.withSchema(schemaName).hasTable('migration_test_1');
+                expect(exists).to.equal(true);
+              }
+            });
+          });
         });
 
         describe('knex.migrate.latest - multiple directories', () => {
@@ -762,6 +794,37 @@ describe('Migrations', function () {
                 .select('value')
                 .first();
               assertNumber(knex, value, 1); // updated by migration before error
+            });
+          });
+
+          describe('with createSchema enabled', function () {
+            const schemaName = 'test_create_schema';
+
+            before(async () => {
+              if (isPgBased(knex) || isMssql(knex) || isOracle(knex)) {
+                await knex.schema.dropSchemaIfExists(schemaName, true);
+              }
+            });
+
+            after(async () => {
+              if (isPgBased(knex) || isMssql(knex) || isOracle(knex)) {
+                await knex.schema.dropSchemaIfExists(schemaName, true);
+              }
+            });
+
+            it('should create the schema', async function () {
+              if (!(isPgBased(knex) || isMssql(knex) || isOracle(knex))) {
+                this.skip();
+              } else {
+                await knex.migrate.latest({
+                  directory: ['test/integration2/migrate/test_create_schema'],
+                  schemaName,
+                  createSchema: true,
+                });
+
+                const exists = await knex.schema.withSchema(schemaName).hasTable('migration_test_1');
+                expect(exists).to.equal(true);
+              }
             });
           });
         });

--- a/test/integration2/migrate/test_create_schema/20250819130639_migration_1.js
+++ b/test/integration2/migrate/test_create_schema/20250819130639_migration_1.js
@@ -1,0 +1,12 @@
+'use strict';
+
+exports.up = function (knex) {
+  return knex.schema.withSchema('test_create_schema').createTable('migration_test_1', function (t) {
+    t.increments();
+    t.string('name');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.withSchema('test_create_schema').dropTable('migration_test_1');
+};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3143,6 +3143,7 @@ declare namespace Knex {
     stub?: string;
     tableName?: string;
     schemaName?: string;
+    createSchema?: boolean;
     disableTransactions?: boolean;
     disableMigrationsListValidation?: boolean;
     sortDirsSeparately?: boolean;


### PR DESCRIPTION
Addresses #5374

Adds a `createSchema` option to the migrator config that will create the schema specified in `schemaName` if it does not already exist