### PR TITLE
fix: add @types/minimatch to fix TypeScript build

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.1",
+    "@types/minimatch": "^5.1.2",
     "@types/node": "^20.4.0",
     "better-sqlite3": "^9.1.1",
     "chai": "^4.3.6",


### PR DESCRIPTION
## Summary
Fixes TypeScript compilation error that's breaking CI for all PRs.

## Error
```
error TS2688: Cannot find type definition file for 'minimatch'.
  The file is in the program because:
    Entry point for implicit type library 'minimatch'
```

## Solution
Added `@types/minimatch` v5 to devDependencies. Version 6 is a stub package that doesn't work properly.

## Testing
- ✅ `npm run build:ts` completes successfully
- ✅ TypeScript compilation works

This should unblock all pending PRs including #6239.