### PR TITLE
docs: formulated behavior of knex.transaction more explicitly

### DIFF
--- a/docs/src/guide/transactions.md
+++ b/docs/src/guide/transactions.md
@@ -134,7 +134,8 @@ try {
 
 Throwing an error directly from the transaction handler function automatically rolls back the transaction, same as returning a rejected promise.
 
-Notice that if a promise is not returned within the handler, it is up to you to ensure `trx.commit`, or `trx.rollback` are called, otherwise the transaction connection will hang.
+Notice that if the handler does not return a promise, it is up to you to ensure `trx.commit`, or `trx.rollback` are called, otherwise the transaction connection will hang.
+If the handler does not return a promise, `knex.transaction` will return the transaction `trx`.
 
 Calling `trx.rollback` will return a rejected Promise. If you don't pass any argument to `trx.rollback`, a generic `Error` object will be created and passed in to ensure the Promise always rejects with something.
 


### PR DESCRIPTION
Thank you for this great library! Working with the library I also use `knex.transaction` method. To understand the method's behavior, I read the respective part in knex's [guide](https://knexjs.org/guide/transactions.html).

After I understood how `knex.transaction` behaves, when given a handler, I felt that the guide's formulation could be improved a bit, hence this PR.

If there's anything else that needs to be done for this PR to be considered mergeable, let me know!