### PR TITLE
Add gin_trgm_ops to storageEngineIndexType

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2606,7 +2606,7 @@ declare namespace Knex {
   }
 
   type deferrableType = 'not deferrable' | 'immediate' | 'deferred';
-  type storageEngineIndexType = 'hash' | 'btree';
+  type storageEngineIndexType = 'hash' | 'btree' | 'gin_trgm_ops';
   type lengthOperator = '>' | '<' | '<=' | '>=' | '!=' | '=';
 
   interface ColumnBuilder {


### PR DESCRIPTION
postgres supports gin_trgm_ops, so we can add this to typing