### PR TITLE
Bug fix: Issue 6272, fixed delete with joins using alias

### DIFF
--- a/lib/dialects/mysql/query/mysql-querycompiler.js
+++ b/lib/dialects/mysql/query/mysql-querycompiler.js
@@ -27,9 +27,32 @@ class QueryCompiler_MySQL extends QueryCompiler {
 
     this._emptyInsertValue = '() values ()';
   }
-  // Compiles an `delete` allowing comments
+  
+   checkAliasForDelete(tableName) {
+    let deleteSelector = tableName.trim().split(/\s+as\s+/i)
+    deleteSelector = deleteSelector[deleteSelector.length - 1]
+    return deleteSelector
+  }
+
+  // Compiles a `delete` query.
   del() {
-    const sql = super.del();
+    // Make sure tableName is processed by the formatter first.
+    const {table}  = this.single;
+    const withSQL = super.with();
+    const wheres = super.where();
+    const joins = super.join();
+    
+    // When using joins, delete the "from" table values as a default
+    const deleteSelector = joins ? this.checkAliasForDelete(table) + ' ' : '';
+    console.log(table, this.options, this.single,this.client,"this.builder", "tableName")
+
+    const sql = withSQL +
+      `delete ${deleteSelector}from ${this.single.only ? 'only ' : ''
+      }${table}` +
+      (joins ? ` ${joins}` : '') +
+      (wheres ? ` ${wheres}` : '');
+
+    // Compiles an `delete` allowing comments
     if (sql === '') return sql;
     const comments = this.comments();
     return (comments === '' ? '' : comments + ' ') + sql;


### PR DESCRIPTION
issue 6272: Using an alias while using delete with joins in mysql is resulting in an error. So, the del() method of mysqlQueryCompiler is modified to identify the alias used in the query.
