### PR TITLE
feat: add Hooks for Query Lifecycle (issue #6270)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -12,6 +12,7 @@ const {
   executeQuery,
   enrichQueryObject,
 } = require('./execution/internal/query-executioner');
+const Hooks = require('./hooks');
 const QueryBuilder = require('./query/querybuilder');
 const QueryCompiler = require('./query/querycompiler');
 const SchemaBuilder = require('./schema/builder');
@@ -43,6 +44,7 @@ class Client extends EventEmitter {
     super();
     this.config = config;
     this.logger = new Logger(config);
+    this.hooks = new Hooks(this);
 
     if (this.config.connection && this.config.connection.password) {
       setHiddenProperty(this.config.connection);
@@ -94,8 +96,8 @@ class Client extends EventEmitter {
     return new Formatter(this, builder);
   }
 
-  queryBuilder() {
-    return new QueryBuilder(this);
+  queryBuilder(userParams) {
+    return new QueryBuilder(this, userParams);
   }
 
   queryCompiler(builder, formatter) {
@@ -306,13 +308,15 @@ class Client extends EventEmitter {
   }
 
   // Acquire a connection from the pool.
-  async acquireConnection() {
+  async acquireConnection(hookContext) {
     if (!this.pool) {
       throw new Error('Unable to acquire a connection');
     }
     try {
+      await this.hooks.run('beforeAcquire', hookContext);
       const connection = await this.pool.acquire().promise;
       debug('acquired connection from pool: %s', connection.__knexUid);
+      await this.hooks.run('afterAcquire', hookContext, connection);
       if (connection.config) {
         if (connection.config.password) {
           setHiddenProperty(connection.config);
@@ -340,15 +344,17 @@ class Client extends EventEmitter {
 
   // Releases a connection back to the connection pool,
   // returning a promise resolved when the connection is released.
-  releaseConnection(connection) {
+  async releaseConnection(connection, hookContext) {
     debug('releasing connection to pool: %s', connection.__knexUid);
+    await this.hooks.run('beforeRelease', hookContext, connection);
     const didRelease = this.pool.release(connection);
+    await this.hooks.run('afterRelease', hookContext);
 
     if (!didRelease) {
       debug('pool refused connection: %s', connection.__knexUid);
     }
 
-    return Promise.resolve();
+    return;
   }
 
   // Destroy the current connection pool for the client.

--- a/lib/dialects/cockroachdb/index.js
+++ b/lib/dialects/cockroachdb/index.js
@@ -32,8 +32,8 @@ class Client_CockroachDB extends Client_PostgreSQL {
     return new ViewCompiler(this, ...arguments);
   }
 
-  queryBuilder() {
-    return new QueryBuilder(this);
+  queryBuilder(userParams) {
+    return new QueryBuilder(this, userParams);
   }
 
   _parseVersion(versionString) {

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -119,8 +119,8 @@ class Client_MSSQL extends Client {
   viewCompiler() {
     return new ViewCompiler(this, ...arguments);
   }
-  queryBuilder() {
-    const b = new QueryBuilder(this);
+  queryBuilder(userParams) {
+    const b = new QueryBuilder(this, userParams);
     return b;
   }
 

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -24,8 +24,8 @@ class Client_MySQL extends Client {
     return require('mysql');
   }
 
-  queryBuilder() {
-    return new QueryBuilder(this);
+  queryBuilder(userParams) {
+    return new QueryBuilder(this, userParams);
   }
 
   queryCompiler(builder, formatter) {

--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -173,8 +173,8 @@ class Client_Oracledb extends Client_Oracle {
   // Must do this here since only the client used to create a connection would be updated with version
   // information on creation. Poses a problem when knex instance is cloned since instances share the
   // connection pool while having their own client instances.
-  async acquireConnection() {
-    const connection = await super.acquireConnection();
+  async acquireConnection(hookContext) {
+    const connection = await super.acquireConnection(hookContext);
     this.checkVersion(connection);
     return connection;
   }

--- a/lib/dialects/oracledb/transaction.js
+++ b/lib/dialects/oracledb/transaction.js
@@ -72,9 +72,8 @@ module.exports = class Oracle_Transaction extends Transaction {
 
   async acquireConnection(config, cb) {
     const configConnection = config && config.connection;
-
     const connection =
-      configConnection || (await this.client.acquireConnection());
+      configConnection || (await this.client.acquireConnection(this.hookContext()));
     try {
       connection.__knexTxId = this.txid;
       connection.isTransaction = true;
@@ -88,7 +87,7 @@ module.exports = class Oracle_Transaction extends Transaction {
         this._rejecter(err);
       } finally {
         if (!configConnection) {
-          await this.client.releaseConnection(connection);
+          await this.client.releaseConnection(connection, this.hookContext());
         } else {
           debugTx('%s: not releasing external connection', this.txid);
         }

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -31,8 +31,8 @@ class Client_PG extends Client {
     return new Transaction(this, ...arguments);
   }
 
-  queryBuilder() {
-    return new QueryBuilder(this);
+  queryBuilder(userParams) {
+    return new QueryBuilder(this, userParams);
   }
 
   queryCompiler(builder, formatter) {

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -54,8 +54,8 @@ class Client_SQLite3 extends Client {
     return new SqliteQueryCompiler(this, builder, formatter);
   }
 
-  queryBuilder() {
-    return new QueryBuilder(this);
+  queryBuilder(userParams) {
+    return new QueryBuilder(this, userParams);
   }
 
   viewCompiler(builder, formatter) {

--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -61,7 +61,7 @@ class Runner {
     Transform = Transform || require('stream').Transform;
 
     const queryContext = this.builder.queryContext();
-
+    const userParams = this.builder.userParams;
     const stream = new Transform({
       objectMode: true,
       transform: (chunk, _, callback) => {
@@ -69,7 +69,10 @@ class Runner {
       },
     });
     stream.on('close', () => {
-      this.client.releaseConnection(this.connection);
+      this.client.releaseConnection(
+        this.connection,
+        this.builder.hookContext()
+      );
     });
 
     // If the stream is manually destroyed, the close event is not
@@ -302,7 +305,9 @@ class Runner {
 
     let acquiredConnection;
     try {
-      acquiredConnection = await this.client.acquireConnection();
+      acquiredConnection = await this.client.acquireConnection(
+        this.builder.hookContext()
+      );
     } catch (error) {
       if (!(error instanceof KnexTimeoutError)) {
         return Promise.reject(error);
@@ -317,7 +322,10 @@ class Runner {
       this.connection = acquiredConnection;
       return await cb(this, cbParams);
     } finally {
-      await this.client.releaseConnection(acquiredConnection);
+      await this.client.releaseConnection(
+        acquiredConnection,
+        this.builder.hookContext()
+      );
     }
   }
 }

--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -8,7 +8,7 @@ const { callbackify } = require('util');
 const makeKnex = require('../knex-builder/make-knex');
 const { timeout, KnexTimeoutError } = require('../util/timeout');
 const finallyMixin = require('../util/finally-mixin');
-
+const helpers = require('../util/helpers');
 const debug = Debug('knex:tx');
 
 // FYI: This is defined as a function instead of a constant so that
@@ -44,6 +44,7 @@ class Transaction extends EventEmitter {
   constructor(client, container, config = DEFAULT_CONFIG(), outerTx = null) {
     super();
     this.userParams = config.userParams;
+    this.txnContext = config.txnContext;
     this.doNotRejectOnRollback = config.doNotRejectOnRollback;
 
     const txid = (this.txid = uniqueId('trx'));
@@ -259,7 +260,8 @@ class Transaction extends EventEmitter {
   async acquireConnection(config, cb) {
     const configConnection = config && config.connection;
     const connection =
-      configConnection || (await this.client.acquireConnection());
+      configConnection ||
+      (await this.client.acquireConnection(this.hookContext()));
 
     try {
       connection.__knexTxId = this.txid;
@@ -267,7 +269,7 @@ class Transaction extends EventEmitter {
     } finally {
       if (!configConnection) {
         debug('%s: releasing connection', this.txid);
-        this.client.releaseConnection(connection);
+        this.client.releaseConnection(connection, this.hookContext());
       } else {
         debug('%s: not releasing external connection', this.txid);
       }
@@ -339,6 +341,7 @@ function makeTxClient(trx, client, connection) {
   trxClient.version = client.version;
   trxClient.config = client.config;
   trxClient.driver = client.driver;
+  trxClient.hooks = client.hooks;
   trxClient.connectionSettings = client.connectionSettings;
   trxClient.transacting = true;
   trxClient.valueForUndefined = client.valueForUndefined;
@@ -409,5 +412,7 @@ function completedError(trx, obj) {
     'Transaction query already complete, run with DEBUG=knex:tx for more info'
   );
 }
+
+helpers.addHookContext(Transaction);
 
 module.exports = Transaction;

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,0 +1,46 @@
+class Hooks {
+  constructor(client) {
+    this.client = client;
+    this.hooks = {
+      // Fires before requesting connection from pool
+      beforeAcquire: [],
+      // Fires after connection acquired
+      afterAcquire: [],
+      // Fires before releasing connection back to pool
+      beforeRelease: [],
+      // Fires after connection released
+      afterRelease: [],
+      // Fires during compilation phase
+      // Can modify builder before SQL generation
+      beforeCompile: [],
+      // Fires after SQL generated but before execution
+      // Can modify SQL/bindings if needed
+      afterCompile: [],
+      // Final point before database execution
+      // Cannot modify SQL but can track/validate
+      beforeExecute: [],
+      // Fires after successful execution
+      afterExecute: [],
+    };
+  }
+
+  register(event, callback) {
+    if (!this.hooks[event]) {
+      throw new Error(`Unknown hook type: ${event}`);
+    }
+    this.hooks[event].push(callback);
+  }
+
+  async run(name, ...args) {
+    const list = this.hooks[name];
+    if (!list || list.length === 0) return;
+    for (const fn of list) {
+      const result = fn(...args);
+      if (result && result.then && typeof result.then === 'function') {
+         await result;
+      }
+    }
+  }
+}
+
+module.exports = Hooks;

--- a/lib/knex-builder/make-knex.js
+++ b/lib/knex-builder/make-knex.js
@@ -29,6 +29,16 @@ const KNEX_PROPERTY_DEFINITIONS = {
     configurable: true,
   },
 
+  hooks: {
+    get() {
+      return this.client.hooks;
+    },
+    set(hooks) {
+      this.client.hooks = hooks;
+    },
+    configurable: true,
+  },
+
   userParams: {
     get() {
       return this.context.userParams;
@@ -107,9 +117,10 @@ function makeKnex(client) {
 
 function initContext(knexFn) {
   const knexContext = knexFn.context || {};
+  this.client
   Object.assign(knexContext, {
     queryBuilder() {
-      return this.client.queryBuilder();
+      return this.client.queryBuilder(this.userParams || {});
     },
 
     raw() {

--- a/lib/query/querybuilder.js
+++ b/lib/query/querybuilder.js
@@ -12,7 +12,7 @@ const reject = require('lodash/reject');
 const tail = require('lodash/tail');
 const toArray = require('lodash/toArray');
 
-const { addQueryContext, normalizeArr } = require('../util/helpers');
+const { addQueryContext, addHookContext, normalizeArr } = require('../util/helpers');
 const JoinClause = require('./joinclause');
 const Analytic = require('./analytic');
 const saveAsyncStack = require('../util/save-async-stack');
@@ -56,9 +56,10 @@ const LOCK_MODES = new Set([
 // Typically called from `knex.builder`,
 // start a new query building chain.
 class Builder extends EventEmitter {
-  constructor(client) {
+  constructor(client, userParams) {
     super();
     this.client = client;
+    this.userParams = userParams;
     this.and = this;
     this._single = {};
     this._comments = [];
@@ -1750,6 +1751,7 @@ Builder.prototype.del = Builder.prototype.delete;
 // Attach all of the top level promise methods that should be chainable.
 augmentWithBuilderInterface(Builder);
 addQueryContext(Builder);
+addHookContext(Builder);
 
 Builder.extend = (methodName, fn) => {
   if (Object.prototype.hasOwnProperty.call(Builder.prototype, methodName)) {

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -75,6 +75,25 @@ function addQueryContext(Target) {
   };
 }
 
+function addHookContext(Target) {
+  // Stores or returns (if called with no arguments) context passed to
+  // wrapIdentifier and postProcessResponse hooks
+  Target.prototype.hookContext = function (context) {
+    if (context === undefined) {
+      if (!this._hookContext) {
+        this._hookContext = {
+          userParams: this.userParams,
+          txnContext: this.txnContext,
+          queryContext: this._queryContext,
+        };
+      }
+      return this._hookContext;
+    }
+    this._hookContext = context;
+    return this;
+  };
+}
+
 function resolveClientNameWithAliases(clientName) {
   return CLIENT_ALIASES[clientName] || clientName;
 }
@@ -87,6 +106,7 @@ function toNumber(val, fallback) {
 
 module.exports = {
   addQueryContext,
+  addHookContext,
   containsUndefined,
   getUndefinedIndices,
   normalizeArr,

--- a/test/db-less-test-suite.js
+++ b/test/db-less-test-suite.js
@@ -32,6 +32,7 @@ describe('Query Building Tests', function () {
   require('./unit/migrations/migrate/migration-list-resolver');
   require('./unit/migrations/seed/seeder');
   // require('./unit/interface'); ToDo Uncomment after fixed
+  require('./unit/hooks');
   require('./unit/knex');
 });
 

--- a/test/unit/hooks.js
+++ b/test/unit/hooks.js
@@ -1,0 +1,377 @@
+const Knex = require('../../lib/index');
+const { expect } = require('chai');
+const sqliteConfig = require('../knexfile').sqlite3;
+const sqlite3 = require('sqlite3');
+const sinon = require('sinon');
+
+describe('hooks', () => {
+  let connection;
+  beforeEach(() => {
+    connection = new sqlite3.Database(':memory:');
+  });
+
+  afterEach(() => {
+    connection.close();
+  });
+
+  describe('register', () => {
+    it('throws if the hook type is unknown', () => {
+      const knex = Knex({ client: 'sqlite3', useNullAsDefault: true });
+      expect(() => {
+        knex.client.hooks.register('unknownHook', () => {});
+      }).to.throw('Unknown hook type: unknownHook');
+    });
+  });
+
+  describe('beforeAcquire', () => {
+    it('is called before acquiring a connection from the pool', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+        userParams,
+      });
+      const acquireConnectionSpy = sinon.spy(knex.client.pool, 'acquire');
+      const beforeAcquireHook = sinon.spy();
+      knex.hooks.register('beforeAcquire', beforeAcquireHook);
+      const queryContext = { user_id: 123 };
+      await knex.select(knex.raw('1+1 as result')).queryContext(queryContext);
+      expect(beforeAcquireHook.calledOnce).to.be.true;
+      expect(beforeAcquireHook.args[0][0].userParams).to.equal(userParams);
+      expect(beforeAcquireHook.args[0][0].queryContext).to.equal(queryContext);
+      expect(beforeAcquireHook.calledBefore(acquireConnectionSpy)).to.be.true;
+    });
+
+    it('is called before acquiring a connection from the pool while using a transaction', async () => {
+      const userParams = { user_id: 1 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+        userParams,
+      });
+      const acquireConnectionSpy = sinon.spy(knex.client.pool, 'acquire');
+      const beforeAcquireHook = sinon.spy();
+      knex.hooks.register('beforeAcquire', beforeAcquireHook);
+      const queryContext = { user_id: 2 };
+      const txnContext = { user_id: 3 };
+      await knex.transaction(
+        async (trx) => {
+          await trx.select(trx.raw('1+1 as result')).queryContext(queryContext);
+        },
+        { txnContext }
+      );
+      expect(beforeAcquireHook.calledOnce).to.be.true;
+      expect(beforeAcquireHook.args[0][0].userParams).to.equal(userParams);
+      expect(beforeAcquireHook.args[0][0].txnContext).to.equal(txnContext);
+      expect(beforeAcquireHook.calledBefore(acquireConnectionSpy)).to.be.true;
+    });
+
+    it('is called from withUserParams clone', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+      }).withUserParams(userParams);
+      const acquireConnectionSpy = sinon.spy(knex.client.pool, 'acquire');
+      const beforeAcquireHook = sinon.spy();
+      knex.hooks.register('beforeAcquire', beforeAcquireHook);
+      const queryContext = { user_id: 123 };
+      await knex.select(knex.raw('1+1 as result')).queryContext(queryContext);
+      expect(beforeAcquireHook.calledOnce).to.be.true;
+      expect(beforeAcquireHook.args[0][0].userParams).to.equal(userParams);
+      expect(beforeAcquireHook.args[0][0].queryContext).to.equal(queryContext);
+      expect(beforeAcquireHook.calledBefore(acquireConnectionSpy)).to.be.true;
+    });
+
+    it('is called from withUserParams clone while using a transaction', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+      }).withUserParams(userParams);
+      const acquireConnectionSpy = sinon.spy(knex.client.pool, 'acquire');
+      const beforeAcquireHook = sinon.spy();
+      knex.hooks.register('beforeAcquire', beforeAcquireHook);
+      const queryContext = { user_id: 123 };
+      const txnContext = { user_id: 123 };
+      await knex.transaction(
+        async (trx) => {
+          await trx.select(trx.raw('1+1 as result')).queryContext(queryContext);
+        },
+        { txnContext }
+      );
+      expect(beforeAcquireHook.calledOnce).to.be.true;
+      expect(beforeAcquireHook.args[0][0].userParams).to.equal(userParams);
+      expect(beforeAcquireHook.args[0][0].txnContext).to.equal(txnContext);
+      expect(beforeAcquireHook.calledBefore(acquireConnectionSpy)).to.be.true;
+    });
+  });
+
+  describe('afterAcquire', () => {
+    it('is called after acquiring a connection from the pool', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+        userParams,
+      });
+      const acquireConnectionSpy = sinon.spy(knex.client.pool, 'acquire');
+      const afterAcquireHook = sinon.spy();
+      knex.hooks.register('afterAcquire', afterAcquireHook);
+      const queryContext = { user_id: 123 };
+      await knex.select(knex.raw('1+1 as result')).queryContext(queryContext);
+      const connection = await acquireConnectionSpy.returnValues[0].promise;
+      expect(afterAcquireHook.calledOnce).to.be.true;
+      expect(afterAcquireHook.args[0][0].userParams).to.equal(userParams);
+      expect(afterAcquireHook.args[0][0].queryContext).to.equal(queryContext);
+      expect(afterAcquireHook.args[0][1]).to.equal(connection);
+      expect(afterAcquireHook.calledAfter(acquireConnectionSpy)).to.be.true;
+    });
+
+    it('is called after acquiring a connection from the pool while using a transaction', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+        userParams,
+      });
+      const acquireConnectionSpy = sinon.spy(knex.client.pool, 'acquire');
+      const afterAcquireHook = sinon.spy();
+      knex.hooks.register('afterAcquire', afterAcquireHook);
+      const queryContext = { user_id: 123 };
+      const txnContext = { user_id: 123 };
+      await knex.transaction(
+        async (trx) => {
+          await trx.select(trx.raw('1+1 as result')).queryContext(queryContext);
+        },
+        { txnContext }
+      );
+      const connection = await acquireConnectionSpy.returnValues[0].promise;
+      expect(afterAcquireHook.calledOnce).to.be.true;
+      expect(afterAcquireHook.args[0][0].userParams).to.equal(userParams);
+      expect(afterAcquireHook.args[0][0].txnContext).to.equal(txnContext);
+      expect(afterAcquireHook.args[0][1]).to.equal(connection);
+      expect(afterAcquireHook.calledAfter(acquireConnectionSpy)).to.be.true;
+    });
+
+    it('is called from withUserParams', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+      }).withUserParams(userParams);
+      const acquireConnectionSpy = sinon.spy(knex.client.pool, 'acquire');
+      const afterAcquireHook = sinon.spy();
+      knex.hooks.register('afterAcquire', afterAcquireHook);
+      const queryContext = { user_id: 123 };
+      await knex.select(knex.raw('1+1 as result')).queryContext(queryContext);
+      const connection = await acquireConnectionSpy.returnValues[0].promise;
+      expect(afterAcquireHook.calledOnce).to.be.true;
+      expect(afterAcquireHook.args[0][0].userParams).to.equal(userParams);
+      expect(afterAcquireHook.args[0][0].queryContext).to.equal(queryContext);
+      expect(afterAcquireHook.args[0][1]).to.equal(connection);
+      expect(afterAcquireHook.calledAfter(acquireConnectionSpy)).to.be.true;
+    });
+
+    it('is called from withUserParams clone while using a transaction', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+      }).withUserParams(userParams);
+      const acquireConnectionSpy = sinon.spy(knex.client.pool, 'acquire');
+      const afterAcquireHook = sinon.spy();
+      knex.hooks.register('afterAcquire', afterAcquireHook);
+      const queryContext = { user_id: 123 };
+      const txnContext = { user_id: 123 };
+      await knex.transaction(
+        async (trx) => {
+          await trx.select(trx.raw('1+1 as result')).queryContext(queryContext);
+        },
+        { txnContext }
+      );
+      const connection = await acquireConnectionSpy.returnValues[0].promise;
+      expect(afterAcquireHook.calledOnce).to.be.true;
+      expect(afterAcquireHook.args[0][0].userParams).to.equal(userParams);
+      expect(afterAcquireHook.args[0][0].txnContext).to.equal(txnContext);
+      expect(afterAcquireHook.args[0][1]).to.equal(connection);
+      expect(afterAcquireHook.calledAfter(acquireConnectionSpy)).to.be.true;
+    });
+  });
+
+  describe('beforeRelease', () => {
+    it('is called before releasing a connection back to the pool', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+        userParams,
+      });
+      const releaseConnectionSpy = sinon.spy(knex.client.pool, 'release');
+      const beforeReleaseHook = sinon.spy();
+      knex.hooks.register('beforeRelease', beforeReleaseHook);
+      const queryContext = { user_id: 123 };
+      await knex.select(knex.raw('1+1 as result')).queryContext(queryContext);
+      const connection = releaseConnectionSpy.args[0][0];
+      expect(beforeReleaseHook.calledOnce).to.be.true;
+      expect(beforeReleaseHook.args[0][0].userParams).to.equal(userParams);
+      expect(beforeReleaseHook.args[0][0].queryContext).to.equal(queryContext);
+      expect(beforeReleaseHook.args[0][1]).to.equal(connection);
+      expect(beforeReleaseHook.calledBefore(releaseConnectionSpy)).to.be.true;
+    });
+
+    it('is called before releasing a connection back to the pool while using a transaction', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+        userParams,
+      });
+      const releaseConnectionSpy = sinon.spy(knex.client.pool, 'release');
+      const beforeReleaseHook = sinon.spy();
+      knex.hooks.register('beforeRelease', beforeReleaseHook);
+      const queryContext = { user_id: 123 };
+      const txnContext = { user_id: 123 };
+      await knex.transaction(
+        async (trx) => {
+          await trx.select(trx.raw('1+1 as result')).queryContext(queryContext);
+        },
+        { txnContext }
+      );
+      const connection = releaseConnectionSpy.args[0][0];
+      expect(beforeReleaseHook.calledOnce).to.be.true;
+      expect(beforeReleaseHook.args[0][0].userParams).to.equal(userParams);
+      expect(beforeReleaseHook.args[0][0].txnContext).to.equal(txnContext);
+      expect(beforeReleaseHook.args[0][1]).to.equal(connection);
+      expect(beforeReleaseHook.calledBefore(releaseConnectionSpy)).to.be.true;
+    });
+
+    it('is called from withUserParams', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+      }).withUserParams(userParams);
+      const releaseConnectionSpy = sinon.spy(knex.client.pool, 'release');
+      const beforeReleaseHook = sinon.spy();
+      knex.hooks.register('beforeRelease', beforeReleaseHook);
+      const queryContext = { user_id: 123 };
+      await knex.select(knex.raw('1+1 as result')).queryContext(queryContext);
+      const connection = releaseConnectionSpy.args[0][0];
+      expect(beforeReleaseHook.calledOnce).to.be.true;
+      expect(beforeReleaseHook.args[0][0].userParams).to.equal(userParams);
+      expect(beforeReleaseHook.args[0][0].queryContext).to.equal(queryContext);
+      expect(beforeReleaseHook.args[0][1]).to.equal(connection);
+      expect(beforeReleaseHook.calledBefore(releaseConnectionSpy)).to.be.true;
+    });
+
+    it('is called from withUserParams clone while using a transaction', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+      }).withUserParams(userParams);
+      const releaseConnectionSpy = sinon.spy(knex.client.pool, 'release');
+      const beforeReleaseHook = sinon.spy();
+      knex.hooks.register('beforeRelease', beforeReleaseHook);
+      const queryContext = { user_id: 123 };
+      const txnContext = { user_id: 123 };
+      await knex.transaction(
+        async (trx) => {
+          await trx.select(trx.raw('1+1 as result')).queryContext(queryContext);
+        },
+        { txnContext }
+      );
+      const connection = releaseConnectionSpy.args[0][0];
+      expect(beforeReleaseHook.calledOnce).to.be.true;
+      expect(beforeReleaseHook.args[0][0].userParams).to.equal(userParams);
+      expect(beforeReleaseHook.args[0][0].txnContext).to.equal(txnContext);
+      expect(beforeReleaseHook.args[0][1]).to.equal(connection);
+      expect(beforeReleaseHook.calledBefore(releaseConnectionSpy)).to.be.true;
+    });
+  });
+
+  describe('afterRelease', () => {
+    it('is called after releasing a connection back to the pool', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+        userParams,
+      });
+      const releaseConnectionSpy = sinon.spy(knex.client.pool, 'release');
+      const afterReleaseHook = sinon.spy();
+      knex.hooks.register('afterRelease', afterReleaseHook);
+      const queryContext = { user_id: 123 };
+      await knex.select(knex.raw('1+1 as result')).queryContext(queryContext);
+      expect(afterReleaseHook.calledOnce).to.be.true;
+      expect(afterReleaseHook.args[0][0].userParams).to.equal(userParams);
+      expect(afterReleaseHook.args[0][0].queryContext).to.equal(queryContext);
+      expect(afterReleaseHook.calledAfter(releaseConnectionSpy)).to.be.true;
+    });
+
+    it('is called after releasing a connection back to the pool while using a transaction', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+        userParams,
+      });
+      const releaseConnectionSpy = sinon.spy(knex.client.pool, 'release');
+      const afterReleaseHook = sinon.spy();
+      knex.hooks.register('afterRelease', afterReleaseHook);
+      const queryContext = { user_id: 123 };
+      const txnContext = { user_id: 123 };
+      await knex.transaction(
+        async (trx) => {
+          await trx.select(trx.raw('1+1 as result')).queryContext(queryContext);
+        },
+        { txnContext }
+      );
+      expect(afterReleaseHook.calledOnce).to.be.true;
+      expect(afterReleaseHook.args[0][0].userParams).to.equal(userParams);
+      expect(afterReleaseHook.args[0][0].txnContext).to.equal(txnContext);
+      expect(afterReleaseHook.calledAfter(releaseConnectionSpy)).to.be.true;
+    });
+
+    it('is called from withUserParams', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+      }).withUserParams(userParams);
+      const releaseConnectionSpy = sinon.spy(knex.client.pool, 'release');
+      const afterReleaseHook = sinon.spy();
+      knex.hooks.register('afterRelease', afterReleaseHook);
+      const queryContext = { user_id: 123 };
+      await knex.select(knex.raw('1+1 as result')).queryContext(queryContext);
+      expect(afterReleaseHook.calledOnce).to.be.true;
+      expect(afterReleaseHook.args[0][0].userParams).to.equal(userParams);
+      expect(afterReleaseHook.args[0][0].queryContext).to.equal(queryContext);
+      expect(afterReleaseHook.calledAfter(releaseConnectionSpy)).to.be.true;
+    });
+
+    it('is called from withUserParams clone while using a transaction', async () => {
+      const userParams = { user_id: 123 };
+      const knex = Knex({
+        ...sqliteConfig,
+        useNullAsDefault: true,
+      }).withUserParams(userParams);
+      const releaseConnectionSpy = sinon.spy(knex.client.pool, 'release');
+      const afterReleaseHook = sinon.spy();
+      knex.hooks.register('afterRelease', afterReleaseHook);
+      const queryContext = { user_id: 123 };
+      const txnContext = { user_id: 123 };
+      await knex.transaction(
+        async (trx) => {
+          await trx.select(trx.raw('1+1 as result')).queryContext(queryContext);
+        },
+        { txnContext }
+      );
+      expect(afterReleaseHook.calledOnce).to.be.true;
+      expect(afterReleaseHook.args[0][0].userParams).to.equal(userParams);
+      expect(afterReleaseHook.args[0][0].txnContext).to.equal(txnContext);
+      expect(afterReleaseHook.calledAfter(releaseConnectionSpy)).to.be.true;
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -427,6 +427,7 @@ interface Knex<TRecord extends {} = any, TResult = any[]>
   >(): Knex.QueryBuilder<TRecord2, TResult2>;
 
   client: any;
+  hooks: Knex.Hooks;
   migrate: Knex.Migrator;
   seed: Knex.Seeder;
   fn: Knex.FunctionHelper;
@@ -3125,6 +3126,11 @@ declare namespace Knex {
     deprecate?: (method: string, alternative: string) => void;
   }
 
+  type HooksEvents = 'beforeAcquire' | 'afterAcquire' | 'beforeRelease' | 'afterRelease' | 'beforeCompile' | 'afterCompile' | 'beforeExecute' | 'afterExecute';
+  interface Hooks {
+    register(event: HooksEvents, callback: Function): void;
+  }
+
   interface Migration {
     up: (knex: Knex) => PromiseLike<any>;
     down?: (knex: Knex) => PromiseLike<any>;
@@ -3177,6 +3183,10 @@ declare namespace Knex {
     up(config?: MigratorConfigWithLifecycleHooks): Promise<any>;
     down(config?: MigratorConfigWithLifecycleHooks): Promise<any>;
     forceFreeMigrationsLock(config?: MigratorConfig): Promise<any>;
+  }
+
+  interface Hooks {
+    register(event: string, callback: (...args: any[]) => Promise<void>): void;
   }
 
   interface Seed {
@@ -3233,7 +3243,7 @@ declare namespace Knex {
     dialect: string;
     driverName: string;
     connectionSettings: object;
-
+    hooks: Hooks;
     acquireRawConnection(): Promise<any>;
     destroyRawConnection(connection: any): Promise<void>;
     validateConnection(connection: any): Promise<boolean>;


### PR DESCRIPTION
I’m working on adding asynchronous hooks to Knex.js to allow setting connection session parameters when acquiring a connection from the pool.

I followed the approach described in [knex/knex#6270](https://github.com/knex/knex/issues/6270). My first draft introduces the following hooks:
- beforeAcquire
- afterAcquire
- beforeRelease
- afterRelease

These are the hooks I’m most interested in for my use case.
Before going any further, I’d really appreciate any feedback or comments to make sure I’m heading in the right direction.