### PR TITLE
feat: add validate to PoolConfig

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -278,6 +278,10 @@ class Client extends EventEmitter {
           this.logger.warn(`Connection Error: ${connection.__knex__disposed}`);
           return false;
         }
+        
+        if (poolConfig.validate && !poolConfig.validate(connection)) {
+          return false;
+        }
 
         return this.validateConnection(connection);
       },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3105,6 +3105,7 @@ declare namespace Knex {
     returnToHead?: boolean;
     priorityRange?: number;
     log?: (message: string, logLevel: string) => void;
+    validate?: (connection: any) => boolean;
 
     // tarn configs
     propagateCreateError?: boolean;


### PR DESCRIPTION
This PR exposes the `validate: (connection: any) => boolean` option from tarn.js to the Knex pool configuration. This allows developers to provide a function that validates a connection every time it's acquired from the pool.

It provides more flexible control over connection management. A primary use case is invalidating old connections to ensure the pool can effectively rebalance connections across new database instances. This is especially important when new database instances are added to a cluster, ensuring they start receiving traffic and the load is distributed evenly.

related PR: https://github.com/knex/knex/pull/5120