### PR TITLE
docs: replaces broken link in streams section

### DIFF
--- a/docs/src/guide/interfaces.md
+++ b/docs/src/guide/interfaces.md
@@ -107,7 +107,7 @@ knex
 
 ## Streams
 
-Streams are a powerful way of piping data through as it comes in, rather than all at once. You can read more about streams [here at substack's stream handbook](https://github.com/substack/stream-handbook). See the following for example uses of stream & pipe. If you wish to use streams with PostgreSQL, you must also install the [pg-query-stream](https://github.com/brianc/node-pg-query-stream) module. If you wish to use streams with the `pgnative` dialect, please be aware that the results will not be streamed as they are received, but rather streamed after the entire result set has returned. On an HTTP server, make sure to [manually close your streams](https://github.com/knex/knex/wiki/Manually-Closing-Streams) if a request is aborted.
+Streams are a powerful way of piping data through as it comes in, rather than all at once. You can read more about streams [here](https://github.com/JasonGhent/stream-handbook-epub). See the following for example uses of stream & pipe. If you wish to use streams with PostgreSQL, you must also install the [pg-query-stream](https://github.com/brianc/node-pg-query-stream) module. If you wish to use streams with the `pgnative` dialect, please be aware that the results will not be streamed as they are received, but rather streamed after the entire result set has returned. On an HTTP server, make sure to [manually close your streams](https://github.com/knex/knex/wiki/Manually-Closing-Streams) if a request is aborted.
 
 ### stream
 


### PR DESCRIPTION
Substack link doesn't work anymore. Not sure if this is a good enough swap in for it or if we'd rather leave it blank.