### PR TITLE
Update to non-screamy versions of dependencies that have npm audit failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "source-map-support": "^0.5.21",
     "sqlite3": "^5.0.11",
     "tape": "^5.6.0",
-    "tedious": "^19.1.3",
+    "tedious": "^18.2.1",
     "toxiproxy-node-client": "^4.0.0",
     "ts-node": "^10.9.1",
     "tsd": "^0.28.1",


### PR DESCRIPTION
All the audit warnings were on dev dependencies, so I updated most of them to latest where applicable. `tap-spec` doesn't have a non-vulnerable version, so I switched to `faucet`, which doesn't look the same but still enumerates the names of each test for CI.

`node-toxiproxy-client` is only used by the stress testing infrastructure, and that code is broken anyway. I am working on an update/replacement so that they at least work, else we should ditch the dependency entirely.

I removed the `coveralls` dependency entirely, it does not appear to be used. Instead, the github actions use a coveralls github container to publish coverage stats.

r? @mercmobily 