### PR TITLE
DRI assignment logic in workflow

### DIFF
--- a/.github/workflows/assign-dri.yml
+++ b/.github/workflows/assign-dri.yml
@@ -35,9 +35,18 @@ jobs:
               .replace(/^@+/, '');
             core.info(`Found DRI label: ${labelMatch} -> ${driUser}`);
 
+            const driUserLower = driUser.toLowerCase();
+            const assignees = (pr.assignees || [])
+              .map((assignee) => assignee.login?.toLowerCase())
+              .filter(Boolean);
+            if (assignees.includes(driUserLower)) {
+              core.info('DRI already assigned; skipping assignment.');
+              return;
+            }
+
             if (context.payload.action === 'synchronize') {
               const sender = context.payload.sender?.login || '';
-              if (sender.toLowerCase() === driUser.toLowerCase()) {
+              if (sender.toLowerCase() === driUserLower) {
                 core.info('Latest commit by DRI; skipping assignment.');
                 return;
               }


### PR DESCRIPTION
@kibertoad This is the workflow script that will automatically bounce back a PR to the DRI once somebody commits something. I *think* this is what we want, although we might have to refine this later.

DRI:@mercmobily