### PR TITLE
Centralize query-specific response handling into Runner.query()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -167,6 +167,15 @@ class Client extends EventEmitter {
     return sql;
   }
 
+  /**
+   * @abstract
+   * @param {import('../../query/querycompiler').ProcessResponseQueryObject} query
+   * @returns {any}
+   */
+  processResponse(query) {
+    throw new Error('not implemented');
+  }
+
   postProcessResponse(resp, queryContext) {
     if (this.config.postProcessResponse) {
       return this.config.postProcessResponse(resp, queryContext);

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -19,6 +19,48 @@ const debug = require('debug')('knex:mssql');
 const SQL_INT4 = { MIN: -2147483648, MAX: 2147483647 };
 const SQL_BIGINT_SAFE = { MIN: -9007199254740991, MAX: 9007199254740991 };
 
+/**
+ * @typedef {Object} Column
+ * @property {{colName: string}} metadata
+ * @property {any} value
+ *
+ * @typedef {Column[][]} TediousResponse
+ *
+ * @typedef {never} TediousContext
+ *
+ * @typedef {import('../../query/querycompiler').ProcessResponseQueryObject<TediousResponse, TediousContext>} QueryObject
+ */
+
+/**
+ * @param {Column[]} cols
+ * @returns {Record<string, any>}
+ */
+const colsToObjects = (cols) =>
+  cols.reduce(
+    /**
+     * @param {Record<string, any>} obj
+     * @param {Column} col
+     * @returns {Record<string, any>}
+     */
+    (obj, col) => {
+      const colName = col.metadata.colName;
+
+      // __proto__ risk
+      if (obj[colName]) {
+        if (!Array.isArray(obj[colName])) {
+          obj[colName] = [obj[colName]];
+        }
+
+        obj[colName].push(col.value);
+      } else {
+        obj[colName] = col.value;
+      }
+
+      return obj;
+    },
+    {}
+  );
+
 // Always initialize with the "QueryBuilder" and "QueryCompiler" objects, which
 // extend the base 'lib/query/builder' and 'lib/query/compiler', respectively.
 class Client_MSSQL extends Client {
@@ -437,35 +479,17 @@ class Client_MSSQL extends Client {
     req.addParameter(bindingName, tediousType, binding, options);
   }
 
-  // Process the response as returned from the query.
-  processResponse(query, runner) {
-    if (query == null) return;
-    let { response } = query;
+  /**
+   * Ensures the response is returned in the same format as other clients.
+   *
+   * @param {QueryObject} query
+   * @returns {any}
+   */
+  processResponse(query) {
     const { method } = query;
 
-    if (query.output) {
-      return query.output.call(runner, response);
-    }
+    const response = query.response.map(colsToObjects);
 
-    response = response.map((row) =>
-      row.reduce((columns, r) => {
-        const colName = r.metadata.colName;
-
-        if (columns[colName]) {
-          if (!Array.isArray(columns[colName])) {
-            columns[colName] = [columns[colName]];
-          }
-
-          columns[colName].push(r.value);
-        } else {
-          columns[colName] = r.value;
-        }
-
-        return columns;
-      }, {})
-    );
-
-    if (query.output) return query.output.call(runner, response);
     switch (method) {
       case 'select':
         return response;

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -16,6 +16,26 @@ const { makeEscape } = require('../../util/string');
 const ViewCompiler = require('./schema/mysql-viewcompiler');
 const ViewBuilder = require('./schema/mysql-viewbuilder');
 
+/**
+ * @typedef {any[]} MySQLSelectResponse
+ * @property {'select'|'first'|'pluck'} method
+ *
+ * @typedef {Object} MySQLInsertResponse
+ * @property {'insert'|'del'|'update'|'counter'} method
+ * @property {number} insertId
+ * @property {number} affectedRows
+ *
+ * @typedef {MySQLSelectResponse|MySQLInsertResponse} MySQLRawResponse
+ * @property {'raw'} method
+ *
+ * @typedef {MySQLSelectResponse|MySQLInsertResponse|MySQLRawResponse} MySQLResponse
+ *
+ * @typedef {Object} MySQLContext
+ * @property {any[]} fields
+ *
+ * @typedef {import('../../query/querycompiler').ProcessResponseQueryObject<MySQLResponse, MySQLContext>} QueryObject
+ */
+
 // Always initialize with the "QueryBuilder" and "QueryCompiler"
 // objects, which extend the base 'lib/query/builder' and
 // 'lib/query/compiler', respectively.
@@ -137,36 +157,56 @@ class Client_MySQL extends Client {
       connection.query(
         queryOptions,
         obj.bindings,
-        function (err, rows, fields) {
+        function (err, response, fields) {
           if (err) return rejecter(err);
-          obj.response = [rows, fields];
+
+          obj.context = { fields };
+          obj.response = response;
+
           resolver(obj);
         }
       );
     });
   }
 
-  // Process the response as returned from the query.
-  processResponse(obj, runner) {
-    if (obj == null) return;
-    const { response } = obj;
-    const { method } = obj;
-    const rows = response[0];
-    const fields = response[1];
-    if (obj.output) return obj.output.call(runner, rows, fields);
+  /**
+   * Ensures the response is returned in the same format as other clients.
+   *
+   * @param {QueryObject} query
+   * @returns {any}
+   */
+  processResponse(query) {
+    const { response } = query;
+    const { method } = query;
+
     switch (method) {
       case 'select':
-        return rows;
+        return response;
       case 'first':
-        return rows[0];
+        return response[0];
       case 'pluck':
-        return map(rows, obj.pluck);
+        return map(response, query.pluck);
       case 'insert':
-        return [rows.insertId];
+        return [response.insertId];
       case 'del':
       case 'update':
       case 'counter':
-        return rows.affectedRows;
+        return response.affectedRows;
+      case 'upsert':
+        // this is a problem. the internal implementation details leaked
+        // into the public-facing api. i'm not sure if upsert was expecting
+        // to return an array of things-representing-inserted-rows, but probably?
+        // and then, the test just happened to work because the tuple of [rows, fields]
+        // is indistinguishable from an array of row[]
+        //
+        // i'll have to research deeply what the correct solution is here
+        //
+        // is this only a breaking change for knex.raw() ?
+
+        // mysql doesn't return multiple insert ids, but to conform to the
+        // normal shape of api responses, we need to make our results an array here
+        // as we did in the 'insert' case above
+        return [response];
       default:
         return response;
     }

--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -83,7 +83,7 @@ class TableCompiler_MySQL extends TableCompiler {
       output(resp) {
         const column = resp[0];
         const runner = this;
-        return compiler.getFKRefs(runner).then(([refs]) =>
+        return compiler.getFKRefs(runner).then((refs) =>
           new Promise((resolve, reject) => {
             try {
               if (!refs.length) {

--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -22,6 +22,16 @@ const { isString } = require('../../util/is');
 const { outputQuery, unwrapRaw } = require('../../formatter/wrappingFormatter');
 const { compileCallback } = require('../../formatter/formatterUtils');
 
+/**
+ * @typedef {any[]} OracleResponse
+ * @typedef {never} OracleContext
+ * @typedef {Object} OracleExtra
+ * @property {() => string} [returningSql]
+ * @property {number} rowsAffected
+ *
+ * @typedef {import('../../query/querycompiler').ProcessResponseQueryObject<OracleResponse, OracleContext> & OracleExtra} QueryObject
+ */
+
 class Client_Oracledb extends Client_Oracle {
   constructor(config) {
     super(config);
@@ -307,27 +317,32 @@ class Client_Oracledb extends Client_Oracle {
       });
   }
 
-  // Process the response as returned from the query.
-  processResponse(obj, runner) {
-    const { response } = obj;
-    if (obj.output) {
-      return obj.output.call(runner, response);
-    }
-    switch (obj.method) {
+  /**
+   * Ensures the response is returned in the same format as other clients.
+   *
+   * @param {QueryObject} query
+   * @returns {any}
+   */
+  processResponse(query) {
+    const { response } = query;
+    switch (query.method) {
       case 'select':
         return response;
       case 'first':
         return response[0];
       case 'pluck':
-        return map(response, obj.pluck);
+        return map(response, query.pluck);
       case 'insert':
       case 'del':
       case 'update':
       case 'counter':
-        if ((obj.returning && !isEmpty(obj.returning)) || obj.returningSql) {
+        if (
+          (query.returning && !isEmpty(query.returning)) ||
+          query.returningSql
+        ) {
           return response;
-        } else if (obj.rowsAffected !== undefined) {
-          return obj.rowsAffected;
+        } else if (query.rowsAffected !== undefined) {
+          return query.rowsAffected;
         } else {
           return 1;
         }

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -16,6 +16,17 @@ const SchemaCompiler = require('./schema/pg-compiler');
 const { makeEscape } = require('../../util/string');
 const { isString } = require('../../util/is');
 
+/**
+ * @typedef {Object} PostgresResponse
+ * @property {string} command
+ * @property {any[]} rows
+ * @property {number} rowCount
+ *
+ * @typedef {never} PostgresContext
+ *
+ * @typedef {import('../../query/querycompiler').ProcessResponseQueryObject<PostgresResponse, PostgresContext>} QueryObject
+ */
+
 class Client_PG extends Client {
   constructor(config) {
     super(config);
@@ -234,15 +245,19 @@ class Client_PG extends Client {
     });
   }
 
-  // Ensures the response is returned in the same format as other clients.
-  processResponse(obj, runner) {
-    const resp = obj.response;
-    if (obj.output) return obj.output.call(runner, resp);
-    if (obj.method === 'raw') return resp;
-    const { returning } = obj;
+  /**
+   * Ensures the response is returned in the same format as other clients.
+   *
+   * @param {QueryObject} query
+   * @returns {any}
+   */
+  processResponse(query) {
+    const resp = query.response;
+    if (query.method === 'raw') return resp;
+    const { returning } = query;
     if (resp.command === 'SELECT') {
-      if (obj.method === 'first') return resp.rows[0];
-      if (obj.method === 'pluck') return map(resp.rows, obj.pluck);
+      if (query.method === 'first') return resp.rows[0];
+      if (query.method === 'pluck') return map(resp.rows, query.pluck);
       return resp.rows;
     }
     if (returning) {

--- a/lib/dialects/redshift/index.js
+++ b/lib/dialects/redshift/index.js
@@ -11,6 +11,17 @@ const TableCompiler = require('./schema/redshift-tablecompiler');
 const SchemaCompiler = require('./schema/redshift-compiler');
 const ViewCompiler = require('./schema/redshift-viewcompiler');
 
+/**
+ * @typedef {Object} RedshiftResponse
+ * @property {string} command
+ * @property {any[]} rows
+ * @property {number} rowCount
+ *
+ * @typedef {never} RedshiftContext
+ *
+ * @typedef {import('../../query/querycompiler').ProcessResponseQueryObject<RedshiftResponse, RedshiftContext>} QueryObject
+ */
+
 class Client_Redshift extends Client_PG {
   transaction() {
     return new Transaction(this, ...arguments);
@@ -44,14 +55,18 @@ class Client_Redshift extends Client_PG {
     return require('pg');
   }
 
-  // Ensures the response is returned in the same format as other clients.
-  processResponse(obj, runner) {
-    const resp = obj.response;
-    if (obj.output) return obj.output.call(runner, resp);
-    if (obj.method === 'raw') return resp;
+  /**
+   * Ensures the response is returned in the same format as other clients.
+   *
+   * @param {QueryObject} query
+   * @returns {any}
+   */
+  processResponse(query) {
+    const resp = query.response;
+    if (query.method === 'raw') return resp;
     if (resp.command === 'SELECT') {
-      if (obj.method === 'first') return resp.rows[0];
-      if (obj.method === 'pluck') return map(resp.rows, obj.pluck);
+      if (query.method === 'first') return resp.rows[0];
+      if (query.method === 'pluck') return map(resp.rows, query.pluck);
       return resp.rows;
     }
     if (

--- a/lib/dialects/sqlite3/index.js
+++ b/lib/dialects/sqlite3/index.js
@@ -17,6 +17,16 @@ const SQLite3_DDL = require('./schema/ddl');
 const Formatter = require('../../formatter');
 const QueryBuilder = require('./query/sqlite-querybuilder');
 
+/**
+ * @typedef {object[]} Sqlite3Response
+ *
+ * @typedef {Object} Sqlite3Context
+ * @property {number} lastID
+ * @property {number} changes
+ *
+ * @typedef {import('../../query/querycompiler').ProcessResponseQueryObject<Sqlite3Response, Sqlite3Context>} QueryObject
+ */
+
 class Client_SQLite3 extends Client {
   constructor(config) {
     super(config);
@@ -176,17 +186,21 @@ class Client_SQLite3 extends Client {
   }
 
   // Ensures the response is returned in the same format as other clients.
-  processResponse(obj, runner) {
-    const ctx = obj.context;
-    const { response, returning } = obj;
-    if (obj.output) return obj.output.call(runner, response);
-    switch (obj.method) {
+  /**
+   * @param {QueryObject} query
+   * @returns {any}
+   */
+  processResponse(query) {
+    const ctx = query.context;
+    const { response, returning } = query;
+
+    switch (query.method) {
       case 'select':
         return response;
       case 'first':
         return response[0];
       case 'pluck':
-        return map(response, obj.pluck);
+        return map(response, query.pluck);
       case 'insert': {
         if (returning) {
           if (response) {

--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -138,6 +138,10 @@ class Runner {
     if (obj !== null && typeof obj === 'object') {
       obj.queryContext = queryContext;
     }
+
+    /**
+     * @type {Promise<import('../query/querycompiler').QueryObject>}
+     */
     let queryPromise = this.client.query(this.connection, obj);
 
     if (obj.timeout) {
@@ -148,8 +152,20 @@ class Runner {
     // dropColumn()/renameColumn(), it will be a Promise for the transaction
     // containing the complete rename procedure.
     return queryPromise
-      .then((resp) => this.client.processResponse(resp, runner))
-      .then((processedResponse) => {
+      .then(async (query) => {
+        let processedResponse;
+
+        if (query.output) {
+          // query.output is a hook to interpret the result of specific queries
+          // (e.g. `columnInfo` or `hasTable`)
+          processedResponse = await query.output.call(runner, query.response);
+        } else {
+          // most queries go through the client's `processResponse` implementation,
+          // which transforms the driver-specific response format into something
+          // consistent that the rest of the code can rely on
+          processedResponse = this.client.processResponse(query, runner);
+        }
+
         const postProcessedResponse = this.client.postProcessResponse(
           processedResponse,
           queryContext

--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -42,6 +42,21 @@ const components = [
   'waitMode',
 ];
 
+/**
+ * @typedef {'select'|'first'|'insert'|'update'|'del'|'counter'|'truncate'|'pluck'|'raw'} QueryMethod
+ */
+
+/**
+ * @template {object} Res Response
+ * @template {object} Ctx Dialect context
+ * @typedef {Object} ProcessResponseQueryObject
+ * @property {Res} response
+ * @property {Ctx} context Dialect call context
+ * @property {QueryMethod} method
+ * @property {string|string[]} [returning] Returning columns
+ * @property {(any) => any} [pluck] Pluck function
+ */
+
 // The "QueryCompiler" takes all of the query statements which
 // have been gathered in the "QueryBuilder" and turns them into a
 // properly formatted / bound query string.

--- a/test/integration2/dialects/mysql2.spec.js
+++ b/test/integration2/dialects/mysql2.spec.js
@@ -79,7 +79,7 @@ describe('MySQL dialect', () => {
             const result = await knex.schema.raw(
               "SHOW STATUS LIKE 'Ssl_cipher'"
             );
-            expect(result[0][0].Value).not.to.be.empty;
+            expect(result[0].Value).not.to.be.empty;
           });
         });
       });

--- a/test/integration2/query/misc/additional.spec.js
+++ b/test/integration2/query/misc/additional.spec.js
@@ -624,7 +624,7 @@ describe('Additional', function () {
           if (isMysql(knex)) {
             const metadata = await knex.raw('SHOW FULL COLUMNS FROM accounts');
             // Store the column metadata
-            aboutCol = metadata[0].filter((t) => t.Field === 'about')[0];
+            aboutCol = metadata.filter((t) => t.Field === 'about')[0];
             delete aboutCol.Field;
           }
 
@@ -660,7 +660,7 @@ describe('Additional', function () {
 
           if (isMysql(knex)) {
             const values = await knex.raw('SHOW FULL COLUMNS FROM accounts');
-            const newAboutCol = values[0].filter(
+            const newAboutCol = values.filter(
               (t) => t.Field === 'about_col'
             )[0];
             // Check if all metadata excepted the Field name (DEFAULT, COLLATION, EXTRA, etc.) are preserved after rename.
@@ -1130,11 +1130,11 @@ describe('Additional', function () {
             },
             [drivers.MySQL]: async () => {
               const results = await knex.raw('SHOW PROCESSLIST');
-              return _.map(results[0], 'Info');
+              return _.map(results, 'Info');
             },
             [drivers.MySQL2]: async () => {
               const results = await knex.raw('SHOW PROCESSLIST');
-              return _.map(results[0], 'Info');
+              return _.map(results, 'Info');
             },
           };
 

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -586,7 +586,7 @@ describe('Schema (misc)', () => {
             return knex
               .raw(query, [table_name, expected_column])
               .then((res) => {
-                const comment = res[0][0].COLUMN_COMMENT;
+                const comment = res[0].COLUMN_COMMENT;
                 expect(comment).to.equal(expected_comment);
               });
           });
@@ -610,7 +610,7 @@ describe('Schema (misc)', () => {
             return knex
               .raw(query, [table_name, expected_column])
               .then((res) => {
-                const comment = res[0][0].COLUMN_COMMENT;
+                const comment = res[0].COLUMN_COMMENT;
                 expect(comment).to.equal(expected_comment);
               });
           });
@@ -1848,7 +1848,7 @@ describe('Schema (misc)', () => {
               .raw('SHOW CREATE TABLE `add_column_test_mysql`')
               .then((schema) => {
                 // .columnInfo() keys does not guaranteed fields order.
-                const fields = schema[0][0]['Create Table']
+                const fields = schema[0]['Create Table']
                   .split('\n')
                   .filter((e) => e.trim().indexOf('`field_') === 0)
                   .map((e) => e.trim())
@@ -1862,7 +1862,7 @@ describe('Schema (misc)', () => {
                 expect(fields[4]).to.equal('field_nondefault_increments');
 
                 // .columnInfo() does not included fields comment.
-                const comments = schema[0][0]['Create Table']
+                const comments = schema[0]['Create Table']
                   .split('\n')
                   .filter((e) => e.trim().indexOf('`field_') === 0)
                   .map((e) => e.slice(e.indexOf("'")).trim())
@@ -1982,7 +1982,7 @@ describe('Schema (misc)', () => {
               expect(autoinc).to.equal(1);
             } else if (isMysql(knex)) {
               const res = await knex.raw(`show fields from ${tableName}`);
-              const autoinc = res[0][0].Extra;
+              const autoinc = res[0].Extra;
               expect(autoinc).to.equal('auto_increment');
             } else if (isPostgreSQL(knex)) {
               const res = await knex.raw(


### PR DESCRIPTION
Part 1 of (2? 3?) of adding casting support to query columns in service of `bigint` support (and other datatypes). This is pre-work to centralize the query-response handling logic, in order to enable consistent treatment of column value casting.

Draft notes:

I need to understand clearly what `.upsert()` is expected to return from the MySQL client. Some tests may have been succeeding by accident since `processResponse` defaults to returning the result of `_query`, which used to be a tuple of `[rows, fields]` and now is just `rows` directly. The internal implementation details were probably leaking and this may become a breaking external api surface change as a consequence.

I _think_ `upsert()` should be like `insert()` where it returns a single-item array, since MySQL doesn't return a list of affected rows, just a summary object. We can keep it from becoming a breaking change by hacking the return value of upsert to return the same thing it would have returned before, but should definitely clean that up at next opportunity for breaking changes.

Also: how do we verify Redshift? (and any other clients that aren't run by CI?)

--

Before this change, every `Client.processRequest()` call independently called something like:

```js
if (obj.output) return obj.output.call(runner, response);
```

This was the only reason to pass `runner` into `processResponse`, but due to differing implementations of `Client._query` and `Client.processResponse`, lifting this logic out of the client required some changes to the client implementations. Most meaningfully, MySQL was returning a tuple of [rows, fields] as its response data, rather than using query.context like e.g. sqlite3.

After this change, calling `response.output` is the responsibility of the runner, and happens before calling `processResponse` on the clients.

Most clients don't account for `columnInfo` calls in their processResponse implementation, but some now have to.

I also added some JSDoc types to help sort out and understand the data flow here.

DRI:@myndzi