### PR TITLE
  Fix VitePress build in CI (WebCrypto)

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       # cache node_modules
       - name: Restore cached dependencies

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,16 +1,8 @@
 import { defineConfig } from 'vitepress';
 import fs from 'node:fs';
 import path from 'node:path';
-import { webcrypto } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import KnexDialectsPlugins from './knexDialects';
-
-if (
-  !globalThis.crypto ||
-  typeof globalThis.crypto.getRandomValues !== 'function'
-) {
-  (globalThis as { crypto?: unknown }).crypto = webcrypto;
-}
 
 const HEADING_RE = /^(#{2,3})\s+(.+)$/;
 const FENCE_RE = /^(```|~~~)/;


### PR DESCRIPTION
Local npm run build succeeds, but CI fails with crypto.getRandomValues is not  a function during VitePress build. The CI Node environment doesn’t expose globalThis.crypto, so Vite/VitePress fails while resolving config.

I used a newer version of node as recommended by @myndzi 

This is isolated to the docs config and doesn’t touch the Knex runtime or main   build.