### PR TITLE
chore: omit `./scripts` from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,7 +245,6 @@
     "!lib/**/*.d.ts",
     "!lib/**/*.js.map",
     "!lib/.gitignore",
-    "scripts/*",
     "types/index.d.ts",
     "types/result.d.ts",
     "types/tables.d.ts",


### PR DESCRIPTION
In https://github.com/knex/knex/pull/1737, the `scripts` directory was added to the published package to fix https://github.com/knex/knex/issues/1736. There was, for a time, a `postinstall` script in `package.json` that relied on running a script in the `scripts` directory.

That postinstall script was removed here with no apparent PR or explanation:
https://github.com/calvinmetcalf/knex/commit/a16639b156b316921696b6b811b9ebabba209dce

As a result, it's safe to no longer include the `scripts` directory; for hygiene's sake, I think it ought to be removed. It contains things that only seem to be relevant to developing knex itself, not consumers of the library.

I double-checked that the original issue would not arise by running `npm pack` and installing the resultant tarball in a fresh project directory; it succeeded as expected.
