### PR TITLE
Fixed error in documentation due to wrong conflict resolution

### DIFF
--- a/docs/src/guide/schema-builder.md
+++ b/docs/src/guide/schema-builder.md
@@ -1115,15 +1115,23 @@ knex.schema.table('users', function (table) {
 
 Drops a foreign key constraint from a table. A default foreign key name using the columns is used unless foreignKeyName is specified (in which case columns is ignored).
 
+```js
+// @sql
+knex.schema.table('users', function (table) {
+  table.dropForeign('companyId');
+});
+```
+
 ### dropForeignIfExists
 
 **table.dropForeignIfExists(columns, [foreignKeyName])**
 
 Like dropForeign, but does not error if the constraint does not exist. Supported on PostgreSQL and other Postgres-based dialects that accept `DROP CONSTRAINT IF EXISTS` (including CockroachDB). For Redshift, MySQL, MSSQL, Oracle, and SQLite (including better-sqlite3) this method throws “not supported” because those engines do not provide an IF EXISTS form.
+
 ```js
 // @sql
 knex.schema.table('users', function (table) {
-  table.dropForeign('companyId');
+  table.dropForeignIfExists('companyId');
 });
 ```
 
@@ -1133,17 +1141,23 @@ knex.schema.table('users', function (table) {
 
 Drops a unique key constraint from a table. A default unique key name using the columns is used unless indexName is specified (in which case columns is ignored).
 
+```js
+// @sql
+knex.schema.table('job', function (table) {
+  table.dropUnique(['account_id', 'program_id'], 'job_composite_index');
+});
+```
+
 ### dropUniqueIfExists
 
 **table.dropUniqueIfExists(columns, [indexName])**
 
 Like dropUnique, but does not error if the constraint does not exist. Supported in PostgreSQL, CockroachDB, MariaDB, MSSQL, and SQLite/better-sqlite3. Not supported in MySQL, Oracle, or Redshift; calling it there throws a “not supported” error.
 
-### dropPrimary
 ```js
 // @sql
 knex.schema.table('job', function (table) {
-  table.dropUnique(['account_id', 'program_id'], 'job_composite_index');
+  table.dropUniqueIfExists(['account_id', 'program_id'], 'job_composite_index');
 });
 ```
 
@@ -1153,15 +1167,23 @@ knex.schema.table('job', function (table) {
 
 Drops the primary key constraint on a table. Defaults to tablename_pkey unless constraintName is specified.
 
+```js
+// @sql
+knex.schema.table('users', function (table) {
+  table.dropPrimary();
+});
+```
+
 ### dropPrimaryIfExists
 
 **table.dropPrimaryIfExists([constraintName])**
 
 Like dropPrimary, but does not error if the constraint does not exist. Supported on PostgreSQL and other Postgres-based dialects that accept `DROP CONSTRAINT IF EXISTS` (including CockroachDB). Not supported in Redshift, MySQL, MSSQL, Oracle, or SQLite (including better-sqlite3); calling it there throws a “not supported” error.
+
 ```js
 // @sql
 knex.schema.table('users', function (table) {
-  table.dropPrimary();
+  table.dropPrimaryIfExists();
 });
 ```
 

--- a/test/unit/dialects/mysql-version.js
+++ b/test/unit/dialects/mysql-version.js
@@ -125,7 +125,7 @@ describe('MySQL/MariaDB version detection', () => {
     expect(warnings).to.have.length(1);
   });
 
-  it('treats configured version \"latest\" as an escape hatch', async () => {
+  it('treats configured version "latest" as an escape hatch', async () => {
     const tracker = { count: 0 };
     const client = new Client_MySQL({
       client: 'mysql',


### PR DESCRIPTION
I made the mistake of merging the docs via the UI; I was even impressed by how easy it was... and of course I didn't realise that I was actually merging it wrong. Apologies. This fixes it.