### PR TITLE
Enable commit of version bump and tag push in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,8 +131,8 @@ jobs:
           git add .
           git commit -m "chore: release v$(node -p "require('./package.json').version")"
           git tag "v$(node -p "require('./package.json').version")"
-          echo :::: git push
-          echo :::: git push --tags
+          git push
+          git push --tags
 
       - uses: actions/attest-build-provenance@v3
         with:


### PR DESCRIPTION
https://github.com/knex/knex/pull/6344 added a workflow to automatically publish new versions of the library, but two key pieces were disabled so that they could be tested separately. This enables the first one - the code that pushes the bumped version back to the repository (and the version tag).

After verifying that this works as expected, we've reached the end of the things we can test without affecting consumers of the library in NPM and the final step is to test actual publication to NPM.

