### PR TITLE
Fix the artifact dirty check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Extract artifact
         run: |
           tar zxf "${{ needs.build.outputs.tarball }}" --strip-components=1 -C .
-          if git diff --name-only HEAD -- ':(exclude)lib/**' ':(exclude)package.json'; then
+          if git diff --name-only HEAD -- ':(exclude)lib/**' ':(exclude)package.json' | grep .; then
             echo "Tarball contained unexpected differences, aborting"
             exit 1
           fi


### PR DESCRIPTION
Use grep to convert the `git diff` exit code to a success when the output is empty. `git diff` will exit with 0 when there are differences, even if the only difference(s) are in files that are excluded from the output.

Piping into `grep .` will exit 0 if the output contains anything, and 1 if the output from `git diff` was empty, which will satisfy the dirty check