### PR TITLE
Fix renameColumn with composite foreign keys on MySQL

### DIFF
--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -83,24 +83,36 @@ class TableCompiler_MySQL extends TableCompiler {
       output(resp) {
         const column = resp[0];
         const runner = this;
-        return compiler.getFKRefs(runner).then(([refs]) =>
-          new Promise((resolve, reject) => {
-            try {
-              if (!refs.length) {
-                resolve();
-              }
-              resolve(compiler.dropFKRefs(runner, refs));
-            } catch (e) {
-              reject(e);
-            }
-          })
+        return compiler.getFKRefs(runner).then(([refs]) => {
+          const relevantRefs = refs.filter(
+            (ref) =>
+              ref.COLUMN_NAME === from ||
+              ref.REFERENCED_COLUMN_NAME === from
+          );
+
+          const uniqueConstraints = [
+            ...new Set(relevantRefs.map((ref) => ref.CONSTRAINT_NAME)),
+          ];
+
+          return (
+            uniqueConstraints.length
+              ? compiler.dropFKRefs(
+                  runner,
+                  uniqueConstraints.map((name) => ({
+                    CONSTRAINT_NAME: name,
+                    TABLE_NAME: relevantRefs.find(
+                      (r) => r.CONSTRAINT_NAME === name
+                    ).TABLE_NAME,
+                  }))
+                )
+              : Promise.resolve()
+          )
             .then(function () {
               let sql = `alter table ${table} change ${wrapped} ${column.Type}`;
 
               if (String(column.Null).toUpperCase() !== 'YES') {
                 sql += ` NOT NULL`;
               } else {
-                // This doesn't matter for most cases except Timestamp, where this is important
                 sql += ` NULL`;
               }
               if (column.Default !== void 0 && column.Default !== null) {
@@ -109,7 +121,6 @@ class TableCompiler_MySQL extends TableCompiler {
               if (column.Collation !== void 0 && column.Collation !== null) {
                 sql += ` COLLATE '${column.Collation}'`;
               }
-              // Add back the auto increment if the column  it, fix issue #2767
               if (column.Extra == 'auto_increment') {
                 sql += ` AUTO_INCREMENT`;
               }
@@ -119,23 +130,28 @@ class TableCompiler_MySQL extends TableCompiler {
               });
             })
             .then(function () {
-              if (!refs.length) {
+              if (!uniqueConstraints.length) {
                 return;
               }
-              return compiler.createFKRefs(
-                runner,
-                refs.map(function (ref) {
-                  if (ref.REFERENCED_COLUMN_NAME === from) {
-                    ref.REFERENCED_COLUMN_NAME = to;
+
+              const updatedRefs = refs
+                .filter((ref) =>
+                  uniqueConstraints.includes(ref.CONSTRAINT_NAME)
+                )
+                .map(function (ref) {
+                  const clone = Object.assign({}, ref);
+                  if (clone.REFERENCED_COLUMN_NAME === from) {
+                    clone.REFERENCED_COLUMN_NAME = to;
                   }
-                  if (ref.COLUMN_NAME === from) {
-                    ref.COLUMN_NAME = to;
+                  if (clone.COLUMN_NAME === from) {
+                    clone.COLUMN_NAME = to;
                   }
-                  return ref;
-                })
-              );
-            })
-        );
+                  return clone;
+                });
+
+              return compiler.createFKRefs(runner, updatedRefs);
+            });
+        });
       },
     });
   }
@@ -232,21 +248,40 @@ class TableCompiler_MySQL extends TableCompiler {
   createFKRefs(runner, refs) {
     const formatter = this.client.formatter(this.tableBuilder);
 
+    const grouped = new Map();
+    for (const ref of refs) {
+      const key = ref.CONSTRAINT_NAME;
+      if (!grouped.has(key)) {
+        grouped.set(key, {
+          TABLE_NAME: ref.TABLE_NAME,
+          CONSTRAINT_NAME: ref.CONSTRAINT_NAME,
+          REFERENCED_TABLE_NAME: ref.REFERENCED_TABLE_NAME,
+          UPDATE_RULE: ref.UPDATE_RULE,
+          DELETE_RULE: ref.DELETE_RULE,
+          COLUMNS: [],
+          REFERENCED_COLUMNS: [],
+        });
+      }
+      const group = grouped.get(key);
+      group.COLUMNS.push(ref.COLUMN_NAME);
+      group.REFERENCED_COLUMNS.push(ref.REFERENCED_COLUMN_NAME);
+    }
+
     return Promise.all(
-      refs.map(function (ref) {
-        const tableName = formatter.wrap(ref.TABLE_NAME);
-        const keyName = formatter.wrap(ref.CONSTRAINT_NAME);
-        const column = formatter.columnize(ref.COLUMN_NAME);
-        const references = formatter.columnize(ref.REFERENCED_COLUMN_NAME);
-        const inTable = formatter.wrap(ref.REFERENCED_TABLE_NAME);
-        const onUpdate = ` ON UPDATE ${ref.UPDATE_RULE}`;
-        const onDelete = ` ON DELETE ${ref.DELETE_RULE}`;
+      [...grouped.values()].map(function (group) {
+        const tableName = formatter.wrap(group.TABLE_NAME);
+        const keyName = formatter.wrap(group.CONSTRAINT_NAME);
+        const columns = formatter.columnize(group.COLUMNS);
+        const references = formatter.columnize(group.REFERENCED_COLUMNS);
+        const inTable = formatter.wrap(group.REFERENCED_TABLE_NAME);
+        const onUpdate = ` ON UPDATE ${group.UPDATE_RULE}`;
+        const onDelete = ` ON DELETE ${group.DELETE_RULE}`;
 
         return runner.query({
           sql:
             `alter table ${tableName} add constraint ${keyName} ` +
             'foreign key (' +
-            column +
+            columns +
             ') references ' +
             inTable +
             ' (' +


### PR DESCRIPTION
## Problem

When calling `renameColumn` on a MySQL table that has composite foreign keys, three bugs manifest:

1. **All FKs dropped needlessly**: `renameColumn` drops every foreign key referencing the table, even when the FK does not involve the column being renamed. This is unnecessarily disruptive and can cause temporary constraint violations.

2. **Composite FKs dropped multiple times**: `getFKRefs` queries `INFORMATION_SCHEMA.KEY_COLUMN_USAGE` which returns one row per column in a composite FK. For a composite FK on `(id, content_type_id)`, two rows are returned with the same `CONSTRAINT_NAME`. `dropFKRefs` then tries to drop the same constraint twice, causing `ER_CANT_DROP_FIELD_OR_KEY` on the second attempt.

3. **Composite FKs recreated incorrectly**: `createFKRefs` treated each row individually, so a composite FK on `(id, content_type_id)` was recreated as two separate single-column FKs instead of one composite FK.

Reported in #2909.

## Fix

### `renameColumn()`

- Filter `getFKRefs` results to only include rows where `COLUMN_NAME` or `REFERENCED_COLUMN_NAME` matches the column being renamed
- Deduplicate constraints by name before calling `dropFKRefs`
- Clone ref objects before mutation to avoid side effects
- Only drop/recreate constraints that actually involve the renamed column

### `createFKRefs()`

- Group rows by `CONSTRAINT_NAME` before generating SQL
- Emit a single `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY (col1, col2) REFERENCES ...` per constraint instead of one per row

### `dropFKRefs()`

- No changes needed (callers now pass deduplicated refs)

## Tests

6 new unit tests (3 for mysql, 3 for mysql2 since the test module runs for both dialects):
- `dropFKRefs` emits one DROP per unique constraint
- `createFKRefs` groups composite FK columns into a single constraint
- `createFKRefs` handles multiple separate constraints independently

All 1672 existing tests continue to pass.

Made with [Cursor](https://cursor.com)