### PR TITLE
fix(postgres): postgres updateFrom value binding order

### DIFF
--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -49,14 +49,15 @@ class QueryCompiler_PG extends QueryCompiler {
   update() {
     const withSQL = this.with();
     const updateData = this._prepUpdate(this.single.update);
+    const updateFrom = this._updateFrom(this.single.updateFrom);
     const wheres = this.where();
-    const { returning, updateFrom } = this.single;
+    const { returning } = this.single;
     return {
       sql:
         withSQL +
         `update ${this.single.only ? 'only ' : ''}${this.tableName} ` +
         `set ${updateData.join(', ')}` +
-        this._updateFrom(updateFrom) +
+        updateFrom +
         (wheres ? ` ${wheres}` : '') +
         this._returning(returning),
       returning,

--- a/test/integration2/query/update/updates.spec.js
+++ b/test/integration2/query/update/updates.spec.js
@@ -619,7 +619,7 @@ describe('Updates', function () {
         await knex.schema.dropTable('testing');
       });
 
-      it('handle from bindings in the right order #6376', async () => {
+      it('handle from bindings in the right order #6376', async function() {
         if (!isPostgreSQL(knex)) {
           return this.skip();
         }


### PR DESCRIPTION
## Summary
Fixes #6376 

### Issue
`QueryCompiler.where()` was being called prior to `QueryCompiler_PG._updateFrom()`, subsequently confusing parameter binding order when using a `UPDATE ... FROM VALUES` statement in postgres.

### Resolution
Moved order of function calls slightly to avoid problem.