### PR TITLE
Fix pg-query-stream 4.13.0 incompatibility

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -212,7 +212,9 @@ class Client_PG extends Client {
       const queryStream = connection.query(
         new PGQueryStream(sql, obj.bindings, options),
         (err) => {
-          rejecter(err);
+          if (err) {
+            rejecter(err);
+          }
         }
       );
 


### PR DESCRIPTION
pg-query-stream 4.13.0 updates its query stream handling to invoke its callback under more circumstances. This causes awaiting on a Knex Postgres stream to return early.

See https://github.com/brianc/node-postgres/pull/2810

This is reproducible with the current Knex test suite, if run against pg-query-stream 4.13.0 instead of an older version.