### PR TITLE
fix: handle lowercase INFORMATION_SCHEMA keys in MySQL renameColumn

### DIFF
--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -125,11 +125,19 @@ class TableCompiler_MySQL extends TableCompiler {
               return compiler.createFKRefs(
                 runner,
                 refs.map(function (ref) {
-                  if (ref.REFERENCED_COLUMN_NAME === from) {
-                    ref.REFERENCED_COLUMN_NAME = to;
+                  const refColKey =
+                    ref.REFERENCED_COLUMN_NAME !== undefined
+                      ? 'REFERENCED_COLUMN_NAME'
+                      : 'referenced_column_name';
+                  const colKey =
+                    ref.COLUMN_NAME !== undefined
+                      ? 'COLUMN_NAME'
+                      : 'column_name';
+                  if (ref[refColKey] === from) {
+                    ref[refColKey] = to;
                   }
-                  if (ref.COLUMN_NAME === from) {
-                    ref.COLUMN_NAME = to;
+                  if (ref[colKey] === from) {
+                    ref[colKey] = to;
                   }
                   return ref;
                 })
@@ -187,7 +195,7 @@ class TableCompiler_MySQL extends TableCompiler {
       '       RC.UPDATE_RULE, RC.DELETE_RULE ' +
       'FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU ' +
       'JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC ' +
-      '       USING(CONSTRAINT_NAME)' +
+      '       USING(CONSTRAINT_NAME) ' +
       'WHERE KCU.REFERENCED_TABLE_NAME = ' +
       this.client.parameter(
         this.tableNameRaw,
@@ -220,8 +228,10 @@ class TableCompiler_MySQL extends TableCompiler {
 
     return Promise.all(
       refs.map(function (ref) {
-        const constraintName = formatter.wrap(ref.CONSTRAINT_NAME);
-        const tableName = formatter.wrap(ref.TABLE_NAME);
+        const constraintName = formatter.wrap(
+          ref.CONSTRAINT_NAME || ref.constraint_name
+        );
+        const tableName = formatter.wrap(ref.TABLE_NAME || ref.table_name);
         return runner.query({
           sql: `alter table ${tableName} drop foreign key ${constraintName}`,
         });
@@ -234,13 +244,19 @@ class TableCompiler_MySQL extends TableCompiler {
 
     return Promise.all(
       refs.map(function (ref) {
-        const tableName = formatter.wrap(ref.TABLE_NAME);
-        const keyName = formatter.wrap(ref.CONSTRAINT_NAME);
-        const column = formatter.columnize(ref.COLUMN_NAME);
-        const references = formatter.columnize(ref.REFERENCED_COLUMN_NAME);
-        const inTable = formatter.wrap(ref.REFERENCED_TABLE_NAME);
-        const onUpdate = ` ON UPDATE ${ref.UPDATE_RULE}`;
-        const onDelete = ` ON DELETE ${ref.DELETE_RULE}`;
+        const tableName = formatter.wrap(ref.TABLE_NAME || ref.table_name);
+        const keyName = formatter.wrap(
+          ref.CONSTRAINT_NAME || ref.constraint_name
+        );
+        const column = formatter.columnize(ref.COLUMN_NAME || ref.column_name);
+        const references = formatter.columnize(
+          ref.REFERENCED_COLUMN_NAME || ref.referenced_column_name
+        );
+        const inTable = formatter.wrap(
+          ref.REFERENCED_TABLE_NAME || ref.referenced_table_name
+        );
+        const onUpdate = ` ON UPDATE ${ref.UPDATE_RULE || ref.update_rule}`;
+        const onDelete = ` ON DELETE ${ref.DELETE_RULE || ref.delete_rule}`;
 
         return runner.query({
           sql:

--- a/test/unit/schema-builder/mysql.js
+++ b/test/unit/schema-builder/mysql.js
@@ -1685,5 +1685,133 @@ module.exports = function (dialect) {
         );
       });
     });
+
+    describe('dropFKRefs and createFKRefs with lowercase column names (#6391)', function () {
+      // mysql2 may return INFORMATION_SCHEMA column names in lowercase,
+      // which caused table names and constraint names to be `undefined`.
+      const TableBuilder = require('../../../lib/schema/tablebuilder');
+      let tableCompiler;
+
+      beforeEach(function () {
+        const tableBuilder = new TableBuilder(
+          client,
+          'alter',
+          'test_table',
+          undefined,
+          function () {}
+        );
+        tableCompiler = client.tableCompiler(tableBuilder);
+      });
+
+      it('dropFKRefs handles lowercase ref keys from mysql2', async function () {
+        const queries = [];
+        const mockRunner = {
+          query(obj) {
+            queries.push(obj.sql);
+            return Promise.resolve();
+          },
+        };
+
+        const refs = [
+          {
+            table_name: 'my_table',
+            constraint_name: 'fk_my_constraint',
+          },
+        ];
+
+        await tableCompiler.dropFKRefs(mockRunner, refs);
+
+        expect(queries).to.have.length(1);
+        expect(queries[0]).to.equal(
+          'alter table `my_table` drop foreign key `fk_my_constraint`'
+        );
+      });
+
+      it('dropFKRefs still works with uppercase ref keys', async function () {
+        const queries = [];
+        const mockRunner = {
+          query(obj) {
+            queries.push(obj.sql);
+            return Promise.resolve();
+          },
+        };
+
+        const refs = [
+          {
+            TABLE_NAME: 'my_table',
+            CONSTRAINT_NAME: 'fk_my_constraint',
+          },
+        ];
+
+        await tableCompiler.dropFKRefs(mockRunner, refs);
+
+        expect(queries).to.have.length(1);
+        expect(queries[0]).to.equal(
+          'alter table `my_table` drop foreign key `fk_my_constraint`'
+        );
+      });
+
+      it('createFKRefs handles lowercase ref keys from mysql2', async function () {
+        const queries = [];
+        const mockRunner = {
+          query(obj) {
+            queries.push(obj.sql);
+            return Promise.resolve();
+          },
+        };
+
+        const refs = [
+          {
+            table_name: 'child_table',
+            constraint_name: 'fk_parent',
+            column_name: 'parent_id',
+            referenced_table_name: 'parent_table',
+            referenced_column_name: 'id',
+            update_rule: 'NO ACTION',
+            delete_rule: 'CASCADE',
+          },
+        ];
+
+        await tableCompiler.createFKRefs(mockRunner, refs);
+
+        expect(queries).to.have.length(1);
+        expect(queries[0]).to.equal(
+          'alter table `child_table` add constraint `fk_parent` ' +
+            'foreign key (`parent_id`) references `parent_table` (`id`) ' +
+            'ON UPDATE NO ACTION ON DELETE CASCADE'
+        );
+      });
+
+      it('createFKRefs still works with uppercase ref keys', async function () {
+        const queries = [];
+        const mockRunner = {
+          query(obj) {
+            queries.push(obj.sql);
+            return Promise.resolve();
+          },
+        };
+
+        const refs = [
+          {
+            TABLE_NAME: 'child_table',
+            CONSTRAINT_NAME: 'fk_parent',
+            COLUMN_NAME: 'parent_id',
+            REFERENCED_TABLE_NAME: 'parent_table',
+            REFERENCED_COLUMN_NAME: 'id',
+            UPDATE_RULE: 'NO ACTION',
+            DELETE_RULE: 'CASCADE',
+          },
+        ];
+
+        await tableCompiler.createFKRefs(mockRunner, refs);
+
+        expect(queries).to.have.length(1);
+        expect(queries[0]).to.equal(
+          'alter table `child_table` add constraint `fk_parent` ' +
+            'foreign key (`parent_id`) references `parent_table` (`id`) ' +
+            'ON UPDATE NO ACTION ON DELETE CASCADE'
+        );
+      });
+    });
   });
 };


### PR DESCRIPTION
## Summary

Fixes #6391.

Problem:
- mysql2 can return INFORMATION_SCHEMA column names in lowercase (`table_name` instead of `TABLE_NAME`) depending on server configuration
- This caused `undefined` table and constraint names when renaming columns with foreign key references, producing invalid SQL: `alter table \`undefined\` drop foreign key \`undefined\``

So fixes:
- `dropFKRefs`, `createFKRefs`, and the `renameColumn` callback now fall back to lowercase keys when uppercase ones are missing
- Fixed a missing space before the `WHERE` clause in the `getFKRefs` query