### PR TITLE
fix: sqlite DDL operations failing inside transactions #6402

### DIFF
--- a/lib/dialects/sqlite3/execution/sqlite-transaction.js
+++ b/lib/dialects/sqlite3/execution/sqlite-transaction.js
@@ -88,7 +88,7 @@ class Transaction_Sqlite extends Transaction {
       if (
         strictForeignKeyPragma &&
         hasOuterTransaction &&
-        restoreForeignCheck !== undefined
+        restoreForeignCheck != null
       ) {
         throw new Error(
           `Refusing to create transaction: unable to change \`foreign_keys\` pragma inside a nested transaction`

--- a/lib/dialects/sqlite3/schema/ddl.js
+++ b/lib/dialects/sqlite3/schema/ddl.js
@@ -334,6 +334,10 @@ class SQLite3_DDL {
   }
 
   async alter(newSql, createIndices, columns) {
+    // When already inside a transaction, we cannot change the foreign_keys
+    // pragma (SQLite silently ignores pragma changes within transactions).
+    // Use `null` to leave it as-is and avoid the nested-transaction guard.
+    const enforceForeignCheck = this.client.transacting ? null : false;
     await this.client.transaction(
       async (trx) => {
         await trx.raw(newSql);
@@ -345,7 +349,7 @@ class SQLite3_DDL {
           await trx.raw(createIndex);
         }
       },
-      { connection: this.connection, enforceForeignCheck: false }
+      { connection: this.connection, enforceForeignCheck }
     );
   }
 

--- a/test/integration2/dialects/sqlite.spec.js
+++ b/test/integration2/dialects/sqlite.spec.js
@@ -160,6 +160,49 @@ for (const { driver, factory } of configs) {
         );
       });
 
+      it('should allow DDL operations inside a transaction (issue #6402)', async () => {
+        const knex = factory(true);
+        try {
+          await knex.schema.createTable('issue_6402_users', (t) => {
+            t.increments('id');
+          });
+          await knex.schema.createTable('issue_6402_accounts', (t) => {
+            t.increments('id');
+            t.integer('user_id').unsigned().references('issue_6402_users.id');
+          });
+          const colsBefore = await knex.raw(
+            "PRAGMA table_info('issue_6402_accounts')"
+          );
+          const colNamesBefore = colsBefore.map((c) => c.name);
+          expect(colNamesBefore).to.deep.equal(['id', 'user_id']);
+
+          const trx = await knex.transaction();
+          try {
+            await trx.schema.table('issue_6402_accounts', (t) => {
+              t.dropForeign(['user_id']);
+            });
+            await trx.schema.table('issue_6402_accounts', (t) => {
+              t.dropColumn('user_id');
+            });
+            await trx.commit();
+          } catch (e) {
+            await trx.rollback();
+            throw e;
+          }
+
+          // verify the column was actually dropped
+          const cols = await knex.raw(
+            "PRAGMA table_info('issue_6402_accounts')"
+          );
+          const colNamesAfter = cols.map((c) => c.name);
+          expect(colNamesAfter).to.deep.equal(['id']);
+        } finally {
+          await knex.schema.dropTableIfExists('issue_6402_accounts');
+          await knex.schema.dropTableIfExists('issue_6402_users');
+          await knex.destroy();
+        }
+      });
+
       it('should fail a DDL transaction that leaves foreign key violations', async () => {
         const id = 39579; // arbitrarily chosen to be unique to this file
         const parent = `test_parent_${id}`;


### PR DESCRIPTION
Fixes #6402

@thetutlage I added your repro as the test case to make sure it was fixed, it seemed we also needed to also change the behavior in `alter` to fully fix it.