### PR TITLE
feat: add TracingChannel support for APM instrumentation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,4 +36,25 @@ module.exports = {
     mocha: true,
     es6: true,
   },
+  overrides: [
+    {
+      files: ['lib/tracing.js', 'test/unit/tracing.js'],
+      rules: {
+        'n/no-unsupported-features/node-builtins': [
+          ERR_IN_CI,
+          {
+            allowExperimental: true,
+            ignores: [
+              'process.getBuiltinModule',
+              'diagnostics_channel',
+              'diagnostics_channel.tracingChannel',
+              'diagnostics_channel.channel',
+              'diagnostics_channel.Channel',
+              'diagnostics_channel.TracingChannel',
+            ],
+          },
+        ],
+      },
+    },
+  ],
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -457,9 +457,9 @@ class Client extends EventEmitter {
 
     if (!didRelease) {
       debug('pool refused connection: %s', connection.__knexUid);
+    } else {
+      publishPoolRelease(getConnectionInfo(this.connectionSettings));
     }
-
-    publishPoolRelease(getConnectionInfo(this.connectionSettings));
 
     return Promise.resolve();
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -32,6 +32,11 @@ const ViewBuilder = require('./schema/viewbuilder.js');
 const ViewCompiler = require('./schema/viewcompiler.js');
 const isPlainObject = require('lodash/isPlainObject');
 const { setHiddenProperty } = require('./util/security.js');
+const {
+  tracePoolAcquire,
+  publishPoolRelease,
+  getConnectionInfo,
+} = require('./tracing');
 
 const debug = require('debug')('knex:client');
 
@@ -403,43 +408,45 @@ class Client extends EventEmitter {
     if (!this.pool) {
       throw new Error('Unable to acquire a connection');
     }
-    try {
-      const connection = await this.pool.acquire().promise;
-      debug('acquired connection from pool: %s', connection.__knexUid);
-      if (connection.config) {
-        if (connection.config.password) {
-          setHiddenProperty(connection.config);
-        }
-        if (
-          connection.config.authentication &&
-          connection.config.authentication.options &&
-          connection.config.authentication.options.password
-        ) {
-          setHiddenProperty(connection.config.authentication.options);
-        }
-      }
-      return connection;
-    } catch (error) {
-      // Tarn only gives us the propagated error's message, not its stack. However, for the "original"
-      // promise that rejected, the stack will be present when Tarn passes us the error directly (not
-      // as a timeout). The stack is likely of little use, but let's give all the information we can.
-      const withStack =
-        error instanceof Error ? error.stack ?? error.message : String(error);
+    return tracePoolAcquire(
+      async () => {
+        try {
+          const connection = await this.pool.acquire().promise;
+          debug('acquired connection from pool: %s', connection.__knexUid);
+          if (connection.config) {
+            if (connection.config.password) {
+              setHiddenProperty(connection.config);
+            }
+            if (
+              connection.config.authentication &&
+              connection.config.authentication.options &&
+              connection.config.authentication.options.password
+            ) {
+              setHiddenProperty(connection.config.authentication.options);
+            }
+          }
+          return connection;
+        } catch (error) {
+          const withStack =
+            error instanceof Error
+              ? error.stack ?? error.message
+              : String(error);
 
-      // Errors like this can be noisy; use logger.warn to make it easier for operators to opt out of
-      // noise but still surface more critical problems
-      this.logger.warn(`Acquire connection error: ${withStack}`);
+          this.logger.warn(`Acquire connection error: ${withStack}`);
 
-      let convertedError = error;
-      if (error instanceof TimeoutError) {
-        convertedError = new KnexTimeoutError(
-          'Knex: Timeout acquiring a connection. The pool is probably full. ' +
-            'Are you missing a .transacting(trx) call?'
-        );
-        convertedError.cause = error;
-      }
-      throw convertedError;
-    }
+          let convertedError = error;
+          if (error instanceof TimeoutError) {
+            convertedError = new KnexTimeoutError(
+              'Knex: Timeout acquiring a connection. The pool is probably full. ' +
+                'Are you missing a .transacting(trx) call?'
+            );
+            convertedError.cause = error;
+          }
+          throw convertedError;
+        }
+      },
+      () => getConnectionInfo(this.connectionSettings)
+    );
   }
 
   // Releases a connection back to the connection pool,
@@ -451,6 +458,8 @@ class Client extends EventEmitter {
     if (!didRelease) {
       debug('pool refused connection: %s', connection.__knexUid);
     }
+
+    publishPoolRelease(getConnectionInfo(this.connectionSettings));
 
     return Promise.resolve();
   }

--- a/lib/execution/runner.js
+++ b/lib/execution/runner.js
@@ -4,6 +4,7 @@ const {
   ensureConnectionCallback,
   ensureConnectionStreamCallback,
 } = require('./internal/ensure-connection-callback');
+const { traceQuery, getConnectionInfo } = require('../tracing');
 
 let Transform;
 
@@ -138,91 +139,106 @@ class Runner {
     if (obj !== null && typeof obj === 'object') {
       obj.queryContext = queryContext;
     }
-    let queryPromise = this.client.query(this.connection, obj);
 
-    if (obj.timeout) {
-      queryPromise = timeout(queryPromise, obj.timeout);
-    }
+    return traceQuery(
+      () => {
+        let queryPromise = this.client.query(this.connection, obj);
 
-    // Await the return value of client.processResponse; in the case of sqlite3's
-    // dropColumn()/renameColumn(), it will be a Promise for the transaction
-    // containing the complete rename procedure.
-    return queryPromise
-      .then((resp) => this.client.processResponse(resp, runner))
-      .then((processedResponse) => {
-        const postProcessedResponse = this.client.postProcessResponse(
-          processedResponse,
-          queryContext
-        );
-
-        this.builder.emit(
-          'query-response',
-          postProcessedResponse,
-          Object.assign({ __knexUid, __knexTxId }, obj),
-          this.builder
-        );
-
-        this.client.emit(
-          'query-response',
-          postProcessedResponse,
-          Object.assign({ __knexUid, __knexTxId }, obj),
-          this.builder
-        );
-
-        return postProcessedResponse;
-      })
-      .catch((error) => {
-        if (!(error instanceof KnexTimeoutError)) {
-          return Promise.reject(error);
-        }
-        const { timeout, sql, bindings } = obj;
-
-        let cancelQuery;
-        if (obj.cancelOnTimeout) {
-          cancelQuery = this.client.cancelQuery(this.connection);
-        } else {
-          // If we don't cancel the query, we need to mark the connection as disposed so that
-          // it gets destroyed by the pool and is never used again. If we don't do this and
-          // return the connection to the pool, it will be useless until the current operation
-          // that timed out, finally finishes.
-          this.connection.__knex__disposed = error;
-          cancelQuery = Promise.resolve();
+        if (obj.timeout) {
+          queryPromise = timeout(queryPromise, obj.timeout);
         }
 
-        return cancelQuery
-          .catch((cancelError) => {
-            // If the cancellation failed, we need to mark the connection as disposed so that
-            // it gets destroyed by the pool and is never used again. If we don't do this and
-            // return the connection to the pool, it will be useless until the current operation
-            // that timed out, finally finishes.
-            this.connection.__knex__disposed = error;
+        // Await the return value of client.processResponse; in the case of sqlite3's
+        // dropColumn()/renameColumn(), it will be a Promise for the transaction
+        // containing the complete rename procedure.
+        return queryPromise
+          .then((resp) => this.client.processResponse(resp, runner))
+          .then((processedResponse) => {
+            const postProcessedResponse = this.client.postProcessResponse(
+              processedResponse,
+              queryContext
+            );
 
-            // cancellation failed
-            throw Object.assign(cancelError, {
-              message: `After query timeout of ${timeout}ms exceeded, cancelling of query failed.`,
-              sql,
-              bindings,
-              timeout,
-            });
+            this.builder.emit(
+              'query-response',
+              postProcessedResponse,
+              Object.assign({ __knexUid, __knexTxId }, obj),
+              this.builder
+            );
+
+            this.client.emit(
+              'query-response',
+              postProcessedResponse,
+              Object.assign({ __knexUid, __knexTxId }, obj),
+              this.builder
+            );
+
+            return postProcessedResponse;
           })
-          .then(() => {
-            // cancellation succeeded, rethrow timeout error
-            throw Object.assign(error, {
-              message: `Defined query timeout of ${timeout}ms exceeded when running query.`,
-              sql,
-              bindings,
-              timeout,
-            });
+          .catch((error) => {
+            if (!(error instanceof KnexTimeoutError)) {
+              return Promise.reject(error);
+            }
+            const { timeout, sql, bindings } = obj;
+
+            let cancelQuery;
+            if (obj.cancelOnTimeout) {
+              cancelQuery = this.client.cancelQuery(this.connection);
+            } else {
+              // If we don't cancel the query, we need to mark the connection as disposed so that
+              // it gets destroyed by the pool and is never used again. If we don't do this and
+              // return the connection to the pool, it will be useless until the current operation
+              // that timed out, finally finishes.
+              this.connection.__knex__disposed = error;
+              cancelQuery = Promise.resolve();
+            }
+
+            return cancelQuery
+              .catch((cancelError) => {
+                // If the cancellation failed, we need to mark the connection as disposed so that
+                // it gets destroyed by the pool and is never used again. If we don't do this and
+                // return the connection to the pool, it will be useless until the current operation
+                // that timed out, finally finishes.
+                this.connection.__knex__disposed = error;
+
+                // cancellation failed
+                throw Object.assign(cancelError, {
+                  message: `After query timeout of ${timeout}ms exceeded, cancelling of query failed.`,
+                  sql,
+                  bindings,
+                  timeout,
+                });
+              })
+              .then(() => {
+                // cancellation succeeded, rethrow timeout error
+                throw Object.assign(error, {
+                  message: `Defined query timeout of ${timeout}ms exceeded when running query.`,
+                  sql,
+                  bindings,
+                  timeout,
+                });
+              });
+          })
+          .catch((error) => {
+            this.builder.emit(
+              'query-error',
+              error,
+              Object.assign({ __knexUid, __knexTxId, queryContext }, obj)
+            );
+            throw error;
           });
-      })
-      .catch((error) => {
-        this.builder.emit(
-          'query-error',
-          error,
-          Object.assign({ __knexUid, __knexTxId, queryContext }, obj)
-        );
-        throw error;
-      });
+      },
+      () => {
+        const connInfo = getConnectionInfo(this.client.connectionSettings);
+        return {
+          query: obj.sql,
+          bindings: obj.bindings,
+          method: this.builder._method,
+          table: this.builder._single && this.builder._single.table,
+          ...connInfo,
+        };
+      }
+    );
   }
 
   // In the case of the "schema builder" we call `queryArray`, which runs each

--- a/lib/execution/transaction.js
+++ b/lib/execution/transaction.js
@@ -8,6 +8,7 @@ const { callbackify } = require('util');
 const makeKnex = require('../knex-builder/make-knex');
 const { timeout, KnexTimeoutError } = require('../util/timeout');
 const finallyMixin = require('../util/finally-mixin');
+const { traceTransaction, getConnectionInfo } = require('../tracing');
 
 const debug = Debug('knex:tx');
 
@@ -200,6 +201,19 @@ class Transaction extends EventEmitter {
   }
 
   async _onAcquire(container, connection) {
+    return traceTransaction(
+      () => this._executeTransaction(container, connection),
+      () => {
+        const connInfo = getConnectionInfo(this.client.connectionSettings);
+        return {
+          transactionId: this.txid,
+          ...connInfo,
+        };
+      }
+    );
+  }
+
+  async _executeTransaction(container, connection) {
     const trxClient = (this.trxClient = makeTxClient(
       this,
       this.client,

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -1,0 +1,117 @@
+// Tracing support via node:diagnostics_channel TracingChannel.
+// Zero-cost when no APM subscribers are attached.
+
+const dc = (() => {
+  try {
+    return 'getBuiltinModule' in process
+      ? process.getBuiltinModule('node:diagnostics_channel')
+      : require('node:diagnostics_channel');
+  } catch {
+    return undefined;
+  }
+})();
+
+const hasTracingChannel = typeof (dc && dc.tracingChannel) === 'function';
+
+// Check explicitly for `false` rather than truthiness because `hasSubscribers`
+// is not available on all Node.js versions that support TracingChannel.
+// When `hasSubscribers` is `undefined` (older Node), we assume there are
+// subscribers and trace unconditionally, keeping the zero-cost optimization
+// only for versions where we can reliably check.
+function shouldTrace(channel) {
+  return !!channel && channel.hasSubscribers !== false;
+}
+
+const noop = () => {};
+
+// --- Channels ---
+
+const queryChannel = hasTracingChannel
+  ? dc.tracingChannel('knex:query')
+  : undefined;
+
+const transactionChannel = hasTracingChannel
+  ? dc.tracingChannel('knex:transaction')
+  : undefined;
+
+const poolAcquireChannel = hasTracingChannel
+  ? dc.tracingChannel('knex:pool:acquire')
+  : undefined;
+
+// Plain channel (fire-and-forget) for pool release — no async lifecycle needed.
+const poolReleaseChannel = dc ? dc.channel('knex:pool:release') : undefined;
+
+// --- Trace helpers ---
+
+function traceQuery(fn, contextFactory) {
+  if (!shouldTrace(queryChannel)) {
+    return fn();
+  }
+  const traced = queryChannel.tracePromise(fn, contextFactory());
+  traced.catch(noop);
+  return traced;
+}
+
+function traceTransaction(fn, contextFactory) {
+  if (!shouldTrace(transactionChannel)) {
+    return fn();
+  }
+  const traced = transactionChannel.tracePromise(fn, contextFactory());
+  traced.catch(noop);
+  return traced;
+}
+
+function tracePoolAcquire(fn, contextFactory) {
+  if (!shouldTrace(poolAcquireChannel)) {
+    return fn();
+  }
+  const traced = poolAcquireChannel.tracePromise(fn, contextFactory());
+  traced.catch(noop);
+  return traced;
+}
+
+function publishPoolRelease(context) {
+  if (!poolReleaseChannel || !poolReleaseChannel.hasSubscribers) {
+    return;
+  }
+  poolReleaseChannel.publish(context);
+}
+
+// --- Connection info helper ---
+
+function getConnectionInfo(connectionSettings) {
+  if (!connectionSettings) {
+    return {
+      database: undefined,
+      serverAddress: undefined,
+      serverPort: undefined,
+    };
+  }
+
+  // Handle Unix socket / Windows named pipe
+  if (connectionSettings.socketPath || connectionSettings.path) {
+    return {
+      database: connectionSettings.database,
+      serverAddress: connectionSettings.socketPath || connectionSettings.path,
+      serverPort: undefined,
+    };
+  }
+
+  return {
+    database: connectionSettings.database,
+    serverAddress: connectionSettings.host,
+    serverPort: connectionSettings.port,
+  };
+}
+
+module.exports = {
+  queryChannel,
+  transactionChannel,
+  poolAcquireChannel,
+  poolReleaseChannel,
+  traceQuery,
+  traceTransaction,
+  tracePoolAcquire,
+  publishPoolRelease,
+  getConnectionInfo,
+};

--- a/test/db-less-test-suite.js
+++ b/test/db-less-test-suite.js
@@ -64,4 +64,8 @@ if (config['better-sqlite3']) {
   require('./unit/dialects/better-sqlite3');
 }
 
+describe('Tracing Tests', function () {
+  require('./unit/tracing');
+});
+
 require('./cli-tests-suite');

--- a/test/unit/tracing.js
+++ b/test/unit/tracing.js
@@ -1,0 +1,285 @@
+'use strict';
+
+const { expect } = require('chai');
+
+let dc;
+try {
+  dc =
+    'getBuiltinModule' in process
+      ? process.getBuiltinModule('node:diagnostics_channel')
+      : require('node:diagnostics_channel');
+} catch {
+  dc = undefined;
+}
+
+const hasTracingChannel = typeof (dc && dc.tracingChannel) === 'function';
+
+(hasTracingChannel ? describe : describe.skip)(
+  'TracingChannel support',
+  function () {
+    this.timeout(process.env.KNEX_TEST_TIMEOUT || 10000);
+
+    let knex;
+
+    before(function () {
+      knex = require('../../lib/index')({
+        client: 'better-sqlite3',
+        connection: {
+          filename: ':memory:',
+        },
+        useNullAsDefault: true,
+        pool: { min: 0, max: 2 },
+      });
+
+      return knex.schema.createTable('test_tracing', (table) => {
+        table.increments('id');
+        table.string('name');
+      });
+    });
+
+    after(function () {
+      return knex.destroy();
+    });
+
+    describe('knex:query channel', function () {
+      let queryChannel;
+
+      before(function () {
+        queryChannel = dc.tracingChannel('knex:query');
+      });
+
+      it('emits start and asyncEnd for a select query', async function () {
+        const events = [];
+
+        const handlers = {
+          start(ctx) {
+            events.push({ event: 'start', ...ctx });
+          },
+          end(ctx) {
+            events.push({ event: 'end' });
+          },
+          asyncStart(ctx) {
+            events.push({ event: 'asyncStart' });
+          },
+          asyncEnd(ctx) {
+            events.push({ event: 'asyncEnd' });
+          },
+          error(ctx) {
+            events.push({ event: 'error', error: ctx.error });
+          },
+        };
+
+        queryChannel.subscribe(handlers);
+        try {
+          await knex('test_tracing').select('*');
+
+          expect(events.length).to.be.greaterThan(0);
+          const startEvent = events.find((e) => e.event === 'start');
+          expect(startEvent).to.exist;
+          expect(startEvent.query).to.be.a('string');
+          expect(startEvent.query).to.match(/select/i);
+          expect(startEvent.method).to.equal('select');
+          expect(startEvent.table).to.equal('test_tracing');
+        } finally {
+          queryChannel.unsubscribe(handlers);
+        }
+      });
+
+      it('emits start for an insert query with correct method', async function () {
+        const events = [];
+
+        const handlers = {
+          start(ctx) {
+            events.push({ event: 'start', ...ctx });
+          },
+          end() {},
+          asyncStart() {},
+          asyncEnd() {},
+          error() {},
+        };
+
+        queryChannel.subscribe(handlers);
+        try {
+          await knex('test_tracing').insert({ name: 'test' });
+
+          const startEvent = events.find((e) => e.event === 'start');
+          expect(startEvent).to.exist;
+          expect(startEvent.method).to.equal('insert');
+          expect(startEvent.table).to.equal('test_tracing');
+          expect(startEvent.bindings).to.be.an('array');
+        } finally {
+          queryChannel.unsubscribe(handlers);
+        }
+      });
+
+      it('emits error event on query failure', async function () {
+        const events = [];
+
+        const handlers = {
+          start(ctx) {
+            events.push({ event: 'start' });
+          },
+          end() {},
+          asyncStart() {},
+          asyncEnd() {},
+          error(ctx) {
+            events.push({ event: 'error', error: ctx.error });
+          },
+        };
+
+        queryChannel.subscribe(handlers);
+        try {
+          await knex('nonexistent_table')
+            .select('*')
+            .catch(() => {});
+
+          const errorEvent = events.find((e) => e.event === 'error');
+          expect(errorEvent).to.exist;
+          expect(errorEvent.error).to.be.an.instanceOf(Error);
+        } finally {
+          queryChannel.unsubscribe(handlers);
+        }
+      });
+    });
+
+    describe('knex:transaction channel', function () {
+      let transactionChannel;
+
+      before(function () {
+        transactionChannel = dc.tracingChannel('knex:transaction');
+      });
+
+      it('emits start and asyncEnd for a successful transaction', async function () {
+        const events = [];
+
+        const handlers = {
+          start(ctx) {
+            events.push({
+              event: 'start',
+              transactionId: ctx.transactionId,
+            });
+          },
+          end() {},
+          asyncStart() {},
+          asyncEnd(ctx) {
+            events.push({ event: 'asyncEnd' });
+          },
+          error() {},
+        };
+
+        transactionChannel.subscribe(handlers);
+        try {
+          await knex.transaction(async (trx) => {
+            await trx('test_tracing').insert({ name: 'trx_test' });
+          });
+
+          const startEvent = events.find((e) => e.event === 'start');
+          expect(startEvent).to.exist;
+          expect(startEvent.transactionId).to.be.a('string');
+          expect(startEvent.transactionId).to.match(/^trx/);
+
+          const asyncEndEvent = events.find((e) => e.event === 'asyncEnd');
+          expect(asyncEndEvent).to.exist;
+        } finally {
+          transactionChannel.unsubscribe(handlers);
+        }
+      });
+
+      it('emits error on transaction rollback', async function () {
+        const events = [];
+
+        const handlers = {
+          start(ctx) {
+            events.push({ event: 'start' });
+          },
+          end() {},
+          asyncStart() {},
+          asyncEnd() {},
+          error(ctx) {
+            events.push({ event: 'error', error: ctx.error });
+          },
+        };
+
+        transactionChannel.subscribe(handlers);
+        try {
+          await knex
+            .transaction(async (trx) => {
+              throw new Error('deliberate rollback');
+            })
+            .catch(() => {});
+
+          const errorEvent = events.find((e) => e.event === 'error');
+          expect(errorEvent).to.exist;
+        } finally {
+          transactionChannel.unsubscribe(handlers);
+        }
+      });
+    });
+
+    describe('knex:pool:acquire channel', function () {
+      let poolAcquireChannel;
+
+      before(function () {
+        poolAcquireChannel = dc.tracingChannel('knex:pool:acquire');
+      });
+
+      it('emits start and asyncEnd when acquiring a connection', async function () {
+        const events = [];
+
+        const handlers = {
+          start(ctx) {
+            events.push({ event: 'start', ...ctx });
+          },
+          end() {},
+          asyncStart() {},
+          asyncEnd(ctx) {
+            events.push({ event: 'asyncEnd' });
+          },
+          error() {},
+        };
+
+        poolAcquireChannel.subscribe(handlers);
+        try {
+          await knex('test_tracing').select('*');
+
+          const startEvent = events.find((e) => e.event === 'start');
+          expect(startEvent).to.exist;
+
+          const asyncEndEvent = events.find((e) => e.event === 'asyncEnd');
+          expect(asyncEndEvent).to.exist;
+        } finally {
+          poolAcquireChannel.unsubscribe(handlers);
+        }
+      });
+    });
+
+    describe('knex:pool:release channel', function () {
+      it('publishes when a connection is released', async function () {
+        const events = [];
+        const releaseChannel = dc.channel('knex:pool:release');
+
+        const handler = (ctx) => {
+          events.push(ctx);
+        };
+
+        releaseChannel.subscribe(handler);
+        try {
+          await knex('test_tracing').select('*');
+
+          expect(events.length).to.be.greaterThan(0);
+          // The context should contain connection info fields
+          expect(events[0]).to.have.property('database');
+        } finally {
+          releaseChannel.unsubscribe(handler);
+        }
+      });
+    });
+
+    describe('no subscribers', function () {
+      it('works without errors when no subscribers are attached', async function () {
+        const result = await knex('test_tracing').select('*');
+        expect(result).to.be.an('array');
+      });
+    });
+  }
+);


### PR DESCRIPTION
Add first-class `node:diagnostics_channel` TracingChannel support so APM tools (OpenTelemetry, Sentry, Datadog) can instrument knex without monkey-patching.

Channels:
- `knex:query` — query lifecycle with method, table, sql, bindings
- `knex:transaction` — transaction lifecycle with transactionId
- `knex:pool:acquire` — pool connection acquisition (TracingChannel)
- `knex:pool:release` — pool connection release (plain channel)

Zero-cost when no subscribers are attached. Gracefully skipped on Node.js versions without TracingChannel support.

 ### Channels

  | Channel | Type | Tracks |
  |---|---|---|
  | `knex:query` | TracingChannel | Query lifecycle method, table, sql, bindings, connection info |
  | `knex:transaction` | TracingChannel | Transaction lifecycle — BEGIN through COMMIT/ROLLBACK |              
  | `knex:pool:acquire` | TracingChannel | Connection acquisition from tarn.js pool |                          
  | `knex:pool:release` | Plain channel | Connection returned to pool (fire-and-forget) |                     

  ### How APM tools use this

  ```js
  const dc = require('node:diagnostics_channel');

dc.tracingChannel('knex:query').subscribe({
  start(ctx) {
    ctx.span = tracer.startSpan(`${ctx.method} ${ctx.table}`, {
      attributes: {
        'db.operation.name': ctx.method,
        'db.collection.name': ctx.table,
        'db.query.text': ctx.query,
        'db.namespace': ctx.database,
        'server.address': ctx.serverAddress,
        'server.port': ctx.serverPort,
      },
    });
  },
  asyncEnd(ctx) { ctx.span?.end(); },
  error(ctx) { ctx.span?.setStatus({ code: SpanStatusCode.ERROR }); },
});
```

closes #6394