### PR TITLE
fix: correct binding order in delete with subquery join

### DIFF
--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -865,8 +865,8 @@ class QueryCompiler {
     // Make sure tableName is processed by the formatter first.
     const { tableName } = this;
     const withSQL = this.with();
-    const wheres = this.where();
     const joins = this.join();
+    const wheres = this.where();
     // When using joins, delete the "from" table values as a default
     const deleteSelector = joins ? tableName + ' ' : '';
     return (

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -11210,6 +11210,27 @@ describe('QueryBuilder', () => {
     });
   });
 
+  it('should produce correct binding order when deleting with a subquery join (#6277)', () => {
+    testsql(
+      qb()
+        .del()
+        .from(raw('tableB'))
+        .innerJoin(
+          qb().from('tableA').where('fieldA', 'valueForFieldA').as('subQuery'),
+          'subQuery.id',
+          '=',
+          'tableB.relatedId'
+        )
+        .where('tableA.fieldB', 'valueForFieldB'),
+      {
+        mysql: {
+          sql: 'delete tableB from tableB inner join (select * from `tableA` where `fieldA` = ?) as `subQuery` on `subQuery`.`id` = `tableB`.`relatedId` where `tableA`.`fieldB` = ?',
+          bindings: ['valueForFieldA', 'valueForFieldB'],
+        },
+      }
+    );
+  });
+
   describe('json functions', () => {
     describe('json manipulation', () => {
       it('should extract json value', () => {


### PR DESCRIPTION
`del()` called `this.where()` before `this.join()`, but the generated SQL places JOIN before WHERE. This caused bindings from a join subquery to appear after the where bindings, producing incorrect queries that could silently delete wrong data.

The fix swaps the two calls so bindings are pushed in SQL order.

Closes #6277