### PR TITLE
Fix SQL injection in MSSQL and Oracle DDL operations

### DIFF
--- a/lib/dialects/mssql/schema/mssql-tablecompiler.js
+++ b/lib/dialects/mssql/schema/mssql-tablecompiler.js
@@ -91,7 +91,21 @@ class TableCompiler_MSSQL extends TableCompiler {
     for (let i = 0, l = colBuilder.length; i < l; i++) {
       const builder = colBuilder[i];
       if (builder.modified.defaultTo) {
-        const schema = this.schemaNameRaw || 'dbo';
+        const schema = this.formatter.escapingStringDelimiters(
+          this.schemaNameRaw || 'dbo'
+        );
+        const tableName = this.formatter.escapingStringDelimiters(
+          this.tableNameRaw
+        );
+        const columnName = this.formatter.escapingStringDelimiters(
+          builder.getColumnName()
+        );
+        // Inside EXEC(), the table name must also be escaped for the
+        // dynamic SQL string (single quotes doubled) since the entire
+        // expression is within an EXEC('...') string literal.
+        const tableNameForExec = this.formatter.escapingStringDelimiters(
+          this.tableNameRaw
+        );
         const baseQuery = `
               DECLARE @constraint varchar(100) = (SELECT default_constraints.name
                                                   FROM sys.all_columns
@@ -102,14 +116,10 @@ class TableCompiler_MSSQL extends TableCompiler {
                                                   INNER JOIN sys.default_constraints
                                                     ON all_columns.default_object_id = default_constraints.object_id
                                                   WHERE schemas.name = '${schema}'
-                                                  AND tables.name = '${
-                                                    this.tableNameRaw
-                                                  }'
-                                                  AND all_columns.name = '${builder.getColumnName()}')
+                                                  AND tables.name = '${tableName}'
+                                                  AND all_columns.name = '${columnName}')
 
-              IF @constraint IS NOT NULL EXEC('ALTER TABLE ${
-                this.tableNameRaw
-              } DROP CONSTRAINT ' + @constraint)`;
+              IF @constraint IS NOT NULL EXEC('ALTER TABLE ${tableNameForExec} DROP CONSTRAINT ' + @constraint)`;
         this.pushQuery(baseQuery);
       }
     }
@@ -135,9 +145,21 @@ class TableCompiler_MSSQL extends TableCompiler {
     const columns = helpers.normalizeArr.apply(null, arguments);
     const columnsArray = Array.isArray(columns) ? columns : [columns];
     const drops = columnsArray.map((column) => _this2.formatter.wrap(column));
-    const schema = this.schemaNameRaw || 'dbo';
+    const schema = this.formatter.escapingStringDelimiters(
+      this.schemaNameRaw || 'dbo'
+    );
+    const tableName = this.formatter.escapingStringDelimiters(
+      this.tableNameRaw
+    );
 
     for (const column of columns) {
+      const columnName = this.formatter.escapingStringDelimiters(column);
+      // Inside EXEC(), the table name must also be escaped for the
+      // dynamic SQL string (single quotes doubled) since the entire
+      // expression is within an EXEC('...') string literal.
+      const tableNameForExec = this.formatter.escapingStringDelimiters(
+        this.tableNameRaw
+      );
       const baseQuery = `
               DECLARE @constraint varchar(100) = (SELECT default_constraints.name
                                                   FROM sys.all_columns
@@ -148,10 +170,10 @@ class TableCompiler_MSSQL extends TableCompiler {
                                                   INNER JOIN sys.default_constraints
                                                     ON all_columns.default_object_id = default_constraints.object_id
                                                   WHERE schemas.name = '${schema}'
-                                                  AND tables.name = '${this.tableNameRaw}'
-                                                  AND all_columns.name = '${column}')
+                                                  AND tables.name = '${tableName}'
+                                                  AND all_columns.name = '${columnName}')
 
-              IF @constraint IS NOT NULL EXEC('ALTER TABLE ${this.tableNameRaw} DROP CONSTRAINT ' + @constraint)`;
+              IF @constraint IS NOT NULL EXEC('ALTER TABLE ${tableNameForExec} DROP CONSTRAINT ' + @constraint)`;
       this.pushQuery(baseQuery);
     }
     this.pushQuery(

--- a/lib/dialects/oracle/query/oracle-querycompiler.js
+++ b/lib/dialects/oracle/query/oracle-querycompiler.js
@@ -239,11 +239,18 @@ class QueryCompiler_Oracle extends QueryCompiler {
     // identifiers otherwise.
     const table = this.client.customWrapIdentifier(this.single.table, identity);
 
+    // Escape single quotes in the table name to prevent SQL injection.
+    // The table name appears inside a double-single-quoted string literal
+    // within dbms_xmlgen.getXMLType('... ''table'' ...'), so a single quote
+    // in the table name must be escaped as two single quotes (which becomes
+    // four single quotes in the outer string context: '''').
+    const escapedTable = (table || '').replace(/'/g, "''");
+
     // Node oracle drivers doesn't support LONG type (which is data_default type)
     const sql = `select * from xmltable( '/ROWSET/ROW'
       passing dbms_xmlgen.getXMLType('
       select char_col_decl_length, column_name, data_type, data_default, nullable
-      from all_tab_columns where table_name = ''${table}'' ')
+      from all_tab_columns where table_name = ''${escapedTable}'' ')
       columns
       CHAR_COL_DECL_LENGTH number, COLUMN_NAME varchar2(200), DATA_TYPE varchar2(106),
       DATA_DEFAULT clob, NULLABLE varchar2(1))`;

--- a/lib/dialects/oracle/query/oracle-querycompiler.js
+++ b/lib/dialects/oracle/query/oracle-querycompiler.js
@@ -240,11 +240,14 @@ class QueryCompiler_Oracle extends QueryCompiler {
     const table = this.client.customWrapIdentifier(this.single.table, identity);
 
     // Escape single quotes in the table name to prevent SQL injection.
-    // The table name appears inside a double-single-quoted string literal
-    // within dbms_xmlgen.getXMLType('... ''table'' ...'), so a single quote
-    // in the table name must be escaped as two single quotes (which becomes
-    // four single quotes in the outer string context: '''').
-    const escapedTable = (table || '').replace(/'/g, "''");
+    // The table name is doubly nested: it sits inside an inner SQL string
+    // literal ('<table>') that is itself passed as text inside the outer
+    // dbms_xmlgen.getXMLType('...') string literal. A single quote must be
+    // escaped for BOTH layers: doubled for the inner literal, then each of
+    // those doubled again for the outer literal -> four single quotes.
+    // Doubling alone is insufficient: "users'; DROP TABLE users--" would
+    // collapse back to a breakout after the outer literal is decoded.
+    const escapedTable = (table || '').replace(/'/g, "''''");
 
     // Node oracle drivers doesn't support LONG type (which is data_default type)
     const sql = `select * from xmltable( '/ROWSET/ROW'

--- a/lib/dialects/oracle/schema/internal/trigger.js
+++ b/lib/dialects/oracle/schema/internal/trigger.js
@@ -1,5 +1,19 @@
 const { NameHelper } = require('../../utils');
 
+// Escape a value for use inside a PL/SQL single-quoted string literal.
+// Doubles any single quotes so that e.g. "it's" becomes "it''s".
+function escapeString(value) {
+  return (value || '').replace(/'/g, "''");
+}
+
+// Escape an identifier for use inside double-quote wrapping ("...")
+// within a PL/SQL single-quoted string literal (EXECUTE IMMEDIATE ('...')).
+// Doubles any double quotes to prevent breaking out of "identifier" quoting,
+// and doubles any single quotes to prevent breaking out of the '...' string.
+function escapeIdentInString(value) {
+  return (value || '').replace(/"/g, '""').replace(/'/g, "''");
+}
+
 class Trigger {
   constructor(oracleVersion) {
     this.nameHelper = new NameHelper(oracleVersion);
@@ -16,32 +30,42 @@ class Trigger {
       'seq',
       tableName
     );
+    // Escape identifiers for use inside EXECUTE IMMEDIATE string literals
+    const tableNameEsc = escapeIdentInString(tableName);
+    const columnNameEsc = escapeIdentInString(columnName);
+    const toEsc = escapeIdentInString(to);
+    const triggerNameEsc = escapeIdentInString(triggerName);
+    const sequenceNameEsc = escapeIdentInString(sequenceName);
+    // Escape values for use inside PL/SQL string literals (WHERE clauses)
+    const triggerNameStr = escapeString(triggerName);
+    const tableNameStr = escapeString(tableName);
+    const toStr = escapeString(to);
     return (
       `DECLARE ` +
       `PK_NAME VARCHAR(200); ` +
       `IS_AUTOINC NUMBER := 0; ` +
       `BEGIN` +
-      `  EXECUTE IMMEDIATE ('ALTER TABLE "${tableName}" RENAME COLUMN "${columnName}" TO "${to}"');` +
-      `  SELECT COUNT(*) INTO IS_AUTOINC from "USER_TRIGGERS" where trigger_name = '${triggerName}';` +
+      `  EXECUTE IMMEDIATE ('ALTER TABLE "${tableNameEsc}" RENAME COLUMN "${columnNameEsc}" TO "${toEsc}"');` +
+      `  SELECT COUNT(*) INTO IS_AUTOINC from "USER_TRIGGERS" where trigger_name = '${triggerNameStr}';` +
       `  IF (IS_AUTOINC > 0) THEN` +
       `    SELECT cols.column_name INTO PK_NAME` +
       `    FROM all_constraints cons, all_cons_columns cols` +
       `    WHERE cons.constraint_type = 'P'` +
       `    AND cons.constraint_name = cols.constraint_name` +
       `    AND cons.owner = cols.owner` +
-      `    AND cols.table_name = '${tableName}';` +
-      `    IF ('${to}' = PK_NAME) THEN` +
-      `      EXECUTE IMMEDIATE ('DROP TRIGGER "${triggerName}"');` +
-      `      EXECUTE IMMEDIATE ('create or replace trigger "${triggerName}"` +
-      `      BEFORE INSERT on "${tableName}" for each row` +
+      `    AND cols.table_name = '${tableNameStr}';` +
+      `    IF ('${toStr}' = PK_NAME) THEN` +
+      `      EXECUTE IMMEDIATE ('DROP TRIGGER "${triggerNameEsc}"');` +
+      `      EXECUTE IMMEDIATE ('create or replace trigger "${triggerNameEsc}"` +
+      `      BEFORE INSERT on "${tableNameEsc}" for each row` +
       `        declare` +
       `        checking number := 1;` +
       `        begin` +
-      `          if (:new."${to}" is null) then` +
+      `          if (:new."${toEsc}" is null) then` +
       `            while checking >= 1 loop` +
-      `              select "${sequenceName}".nextval into :new."${to}" from dual;` +
-      `              select count("${to}") into checking from "${tableName}"` +
-      `              where "${to}" = :new."${to}";` +
+      `              select "${sequenceNameEsc}".nextval into :new."${toEsc}" from dual;` +
+      `              select count("${toEsc}") into checking from "${tableNameEsc}"` +
+      `              where "${toEsc}" = :new."${toEsc}";` +
       `            end loop;` +
       `          end if;` +
       `        end;');` +
@@ -52,10 +76,16 @@ class Trigger {
   }
 
   createAutoIncrementTrigger(logger, tableName, schemaName) {
-    const tableQuoted = `"${tableName}"`;
-    const tableUnquoted = tableName;
-    const schemaQuoted = schemaName ? `"${schemaName}".` : '';
-    const constraintOwner = schemaName ? `'${schemaName}'` : 'cols.owner';
+    // Escape identifiers for use inside EXECUTE IMMEDIATE string literals
+    const tableNameEsc = escapeIdentInString(tableName);
+    const tableQuoted = `"${tableNameEsc}"`;
+    const schemaNameEsc = schemaName ? escapeIdentInString(schemaName) : '';
+    const schemaQuoted = schemaName ? `"${schemaNameEsc}".` : '';
+    // Escape values for use inside PL/SQL string literals
+    const constraintOwner = schemaName
+      ? `'${escapeString(schemaName)}'`
+      : 'cols.owner';
+    const tableNameStr = escapeString(tableName);
     const triggerName = this.nameHelper.generateCombinedName(
       logger,
       'autoinc_trg',
@@ -66,7 +96,9 @@ class Trigger {
       'seq',
       tableName
     );
-    const sequenceNameQuoted = `"${sequenceNameUnquoted}"`;
+    const sequenceNameEsc = escapeIdentInString(sequenceNameUnquoted);
+    const sequenceNameQuoted = `"${sequenceNameEsc}"`;
+    const triggerNameEsc = escapeIdentInString(triggerName);
     return (
       `DECLARE ` +
       `PK_NAME VARCHAR(200); ` +
@@ -77,8 +109,8 @@ class Trigger {
       `  WHERE cons.constraint_type = 'P'` +
       `  AND cons.constraint_name = cols.constraint_name` +
       `  AND cons.owner = ${constraintOwner}` +
-      `  AND cols.table_name = '${tableUnquoted}';` +
-      `  execute immediate ('create or replace trigger ${schemaQuoted}"${triggerName}"` +
+      `  AND cols.table_name = '${tableNameStr}';` +
+      `  execute immediate ('create or replace trigger ${schemaQuoted}"${triggerNameEsc}"` +
       `  BEFORE INSERT on ${schemaQuoted}${tableQuoted}` +
       `  for each row` +
       `  declare` +
@@ -117,31 +149,41 @@ class Trigger {
       'seq',
       to
     );
+    // Escape identifiers for use inside EXECUTE IMMEDIATE string literals
+    const tableNameEsc = escapeIdentInString(tableName);
+    const toEsc = escapeIdentInString(to);
+    const triggerNameEsc = escapeIdentInString(triggerName);
+    const sequenceNameEsc = escapeIdentInString(sequenceName);
+    const toTriggerNameEsc = escapeIdentInString(toTriggerName);
+    const toSequenceNameEsc = escapeIdentInString(toSequenceName);
+    // Escape values for use inside PL/SQL string literals
+    const triggerNameStr = escapeString(triggerName);
+    const toStr = escapeString(to);
     return (
       `DECLARE ` +
       `PK_NAME VARCHAR(200); ` +
       `IS_AUTOINC NUMBER := 0; ` +
       `BEGIN` +
-      `  EXECUTE IMMEDIATE ('RENAME "${tableName}" TO "${to}"');` +
-      `  SELECT COUNT(*) INTO IS_AUTOINC from "USER_TRIGGERS" where trigger_name = '${triggerName}';` +
+      `  EXECUTE IMMEDIATE ('RENAME "${tableNameEsc}" TO "${toEsc}"');` +
+      `  SELECT COUNT(*) INTO IS_AUTOINC from "USER_TRIGGERS" where trigger_name = '${triggerNameStr}';` +
       `  IF (IS_AUTOINC > 0) THEN` +
-      `    EXECUTE IMMEDIATE ('DROP TRIGGER "${triggerName}"');` +
-      `    EXECUTE IMMEDIATE ('RENAME "${sequenceName}" TO "${toSequenceName}"');` +
+      `    EXECUTE IMMEDIATE ('DROP TRIGGER "${triggerNameEsc}"');` +
+      `    EXECUTE IMMEDIATE ('RENAME "${sequenceNameEsc}" TO "${toSequenceNameEsc}"');` +
       `    SELECT cols.column_name INTO PK_NAME` +
       `    FROM all_constraints cons, all_cons_columns cols` +
       `    WHERE cons.constraint_type = 'P'` +
       `    AND cons.constraint_name = cols.constraint_name` +
       `    AND cons.owner = cols.owner` +
-      `    AND cols.table_name = '${to}';` +
-      `    EXECUTE IMMEDIATE ('create or replace trigger "${toTriggerName}"` +
-      `    BEFORE INSERT on "${to}" for each row` +
+      `    AND cols.table_name = '${toStr}';` +
+      `    EXECUTE IMMEDIATE ('create or replace trigger "${toTriggerNameEsc}"` +
+      `    BEFORE INSERT on "${toEsc}" for each row` +
       `      declare` +
       `      checking number := 1;` +
       `      begin` +
       `        if (:new."' || PK_NAME || '" is null) then` +
       `          while checking >= 1 loop` +
-      `            select "${toSequenceName}".nextval into :new."' || PK_NAME || '" from dual;` +
-      `            select count("' || PK_NAME || '") into checking from "${to}"` +
+      `            select "${toSequenceNameEsc}".nextval into :new."' || PK_NAME || '" from dual;` +
+      `            select count("' || PK_NAME || '") into checking from "${toEsc}"` +
       `            where "' || PK_NAME || '" = :new."' || PK_NAME || '";` +
       `          end loop;` +
       `        end if;` +

--- a/test/unit/schema-builder/mssql.js
+++ b/test/unit/schema-builder/mssql.js
@@ -1580,4 +1580,54 @@ describe('MSSQL SchemaBuilder', function () {
       });
     });
   });
+
+  describe('SQL injection prevention in DDL operations', function () {
+    it('should escape single quotes in table names for dropColumn', function () {
+      tableSql = client
+        .schemaBuilder()
+        .table("users'; DROP TABLE users--", function () {
+          this.dropColumn('foo');
+        })
+        .toSQL();
+
+      // The constraint lookup query should have escaped single quotes
+      expect(tableSql[0].sql).to.include(
+        "tables.name = 'users''; DROP TABLE users--'"
+      );
+      // The EXEC dynamic SQL should also have escaped single quotes
+      expect(tableSql[0].sql).to.include(
+        "EXEC('ALTER TABLE users''; DROP TABLE users-- DROP CONSTRAINT ' + @constraint)"
+      );
+    });
+
+    it('should escape single quotes in column names for dropColumn', function () {
+      tableSql = client
+        .schemaBuilder()
+        .table('users', function () {
+          this.dropColumn("col'; DROP TABLE users--");
+        })
+        .toSQL();
+
+      expect(tableSql[0].sql).to.include(
+        "all_columns.name = 'col''; DROP TABLE users--'"
+      );
+    });
+
+    it('should escape single quotes in table names for alterColumns with defaultTo', function () {
+      tableSql = client
+        .schemaBuilder()
+        .table("users'; DROP TABLE users--", function () {
+          this.string('foo').defaultTo('test').alter();
+        })
+        .toSQL();
+
+      // The constraint lookup query should have escaped single quotes
+      expect(tableSql[0].sql).to.include(
+        "tables.name = 'users''; DROP TABLE users--'"
+      );
+      expect(tableSql[0].sql).to.include(
+        "EXEC('ALTER TABLE users''; DROP TABLE users-- DROP CONSTRAINT ' + @constraint)"
+      );
+    });
+  });
 });

--- a/test/unit/schema-builder/oracle.js
+++ b/test/unit/schema-builder/oracle.js
@@ -1118,4 +1118,52 @@ describe('Oracle SchemaBuilder', function () {
       'begin execute immediate \'drop table "book"\'; exception when others then if sqlcode != -942 then raise; end if; end;\nbegin execute immediate \'drop sequence "book_seq"\'; exception when others then if sqlcode != -2289 then raise; end if; end;'
     );
   });
+
+  describe('SQL injection prevention in DDL operations', function () {
+    it('should escape single quotes in table names for renameColumn trigger', function () {
+      tableSql = client
+        .schemaBuilder()
+        .table("users'; EXECUTE IMMEDIATE 'DROP TABLE x", function () {
+          this.renameColumn('foo', 'bar');
+        })
+        .toSQL();
+
+      // The EXECUTE IMMEDIATE string should have escaped single quotes
+      expect(tableSql[0].sql).to.include(
+        "EXECUTE IMMEDIATE ('ALTER TABLE \"users''; EXECUTE IMMEDIATE ''DROP TABLE x\" RENAME COLUMN \"foo\" TO \"bar\"')"
+      );
+      // The PL/SQL string literal for trigger_name should have escaped single quotes
+      expect(tableSql[0].sql).to.include(
+        "trigger_name = 'users''; execute immediate ''drop table x_autoinc_trg'"
+      );
+    });
+
+    it('should escape double quotes in table names for renameColumn trigger', function () {
+      tableSql = client
+        .schemaBuilder()
+        .table('users" OR 1=1--', function () {
+          this.renameColumn('foo', 'bar');
+        })
+        .toSQL();
+
+      // Inside EXECUTE IMMEDIATE ('...'), double quotes in identifiers are doubled
+      // for identifier escaping, then each of those is doubled again for the
+      // single-quoted string context, resulting in 4 double-quote chars.
+      expect(tableSql[0].sql).to.include(
+        'ALTER TABLE "users"""" OR 1=1--" RENAME COLUMN "foo" TO "bar"'
+      );
+    });
+
+    it('should escape single quotes in table names for renameTable trigger', function () {
+      tableSql = client
+        .schemaBuilder()
+        .renameTable("users'; DROP TABLE x--", 'foo')
+        .toSQL();
+
+      // The EXECUTE IMMEDIATE string should have escaped single quotes
+      expect(tableSql[0].sql).to.include(
+        "EXECUTE IMMEDIATE ('RENAME \"users''; DROP TABLE x--\" TO \"foo\"')"
+      );
+    });
+  });
 });

--- a/test/unit/schema-builder/oracle.js
+++ b/test/unit/schema-builder/oracle.js
@@ -1130,7 +1130,7 @@ describe('Oracle SchemaBuilder', function () {
 
       // The EXECUTE IMMEDIATE string should have escaped single quotes
       expect(tableSql[0].sql).to.include(
-        "EXECUTE IMMEDIATE ('ALTER TABLE \"users''; EXECUTE IMMEDIATE ''DROP TABLE x\" RENAME COLUMN \"foo\" TO \"bar\"')"
+        'EXECUTE IMMEDIATE (\'ALTER TABLE "users\'\'; EXECUTE IMMEDIATE \'\'DROP TABLE x" RENAME COLUMN "foo" TO "bar"\')'
       );
       // The PL/SQL string literal for trigger_name should have escaped single quotes
       expect(tableSql[0].sql).to.include(
@@ -1162,7 +1162,7 @@ describe('Oracle SchemaBuilder', function () {
 
       // The EXECUTE IMMEDIATE string should have escaped single quotes
       expect(tableSql[0].sql).to.include(
-        "EXECUTE IMMEDIATE ('RENAME \"users''; DROP TABLE x--\" TO \"foo\"')"
+        'EXECUTE IMMEDIATE (\'RENAME "users\'\'; DROP TABLE x--" TO "foo"\')'
       );
     });
   });

--- a/test/unit/schema-builder/oracledb.js
+++ b/test/unit/schema-builder/oracledb.js
@@ -1433,4 +1433,19 @@ describe('OracleDb SchemaBuilder', function () {
       );
     });
   });
+
+  describe('SQL injection prevention in DDL operations', function () {
+    it('should escape single quotes in table names for columnInfo', function () {
+      const compiledQuery = client
+        .queryBuilder()
+        .from("users'; DROP TABLE users--")
+        .columnInfo()
+        .toSQL();
+
+      // The table name in dbms_xmlgen.getXMLType should have escaped single quotes
+      expect(compiledQuery.sql).to.include(
+        "table_name = ''users''; DROP TABLE users--''"
+      );
+    });
+  });
 });

--- a/test/unit/schema-builder/oracledb.js
+++ b/test/unit/schema-builder/oracledb.js
@@ -1435,15 +1435,22 @@ describe('OracleDb SchemaBuilder', function () {
   });
 
   describe('SQL injection prevention in DDL operations', function () {
-    it('should escape single quotes in table names for columnInfo', function () {
+    it('should escape single quotes in table names for columnInfo (doubly-nested breakout)', function () {
       const compiledQuery = client
         .queryBuilder()
         .from("users'; DROP TABLE users--")
         .columnInfo()
         .toSQL();
 
-      // The table name in dbms_xmlgen.getXMLType should have escaped single quotes
+      // table_name is doubly nested: inside an inner SQL string literal that is
+      // itself inside the outer dbms_xmlgen.getXMLType('...') literal. A single
+      // quote must be quadrupled; merely doubling it collapses back to a
+      // breakout once the outer literal is decoded.
       expect(compiledQuery.sql).to.include(
+        "table_name = ''users''''; DROP TABLE users--''"
+      );
+      // Regression guard: the previously-vulnerable doubled form must NOT appear.
+      expect(compiledQuery.sql).to.not.include(
         "table_name = ''users''; DROP TABLE users--''"
       );
     });


### PR DESCRIPTION
## Summary

Fixes #6432

The core `raw()` binding system in knex is well-implemented, but three DDL/schema code paths string-interpolate user-supplied identifiers into dynamically-constructed SQL without escaping, creating SQL injection vectors:

1. **MSSQL `alterColumns`/`dropColumn`** (`lib/dialects/mssql/schema/mssql-tablecompiler.js`) — Table names, schema names, and column names were interpolated directly into `EXEC()` dynamic SQL strings and `WHERE` clause string literals. Fixed by applying `this.formatter.escapingStringDelimiters()` to all interpolated values.

2. **Oracle trigger generation** (`lib/dialects/oracle/schema/internal/trigger.js`) — Table names, column names, trigger names, and sequence names were interpolated directly into `EXECUTE IMMEDIATE` PL/SQL string literals. Fixed by escaping both double quotes (for identifier quoting within `"..."`) and single quotes (for the enclosing `'...'` string literal context).

3. **Oracle `columnInfo`** (`lib/dialects/oracle/query/oracle-querycompiler.js`) — Table name was interpolated directly into the double-single-quoted string inside `dbms_xmlgen.getXMLType()`. Fixed by escaping single quotes before interpolation.

## Test plan

- [x] Added unit tests for MSSQL `dropColumn` with single-quote injection in table and column names
- [x] Added unit tests for MSSQL `alterColumns` with single-quote injection in table names
- [x] Added unit tests for Oracle `renameColumn` trigger with single-quote and double-quote injection in table names
- [x] Added unit tests for Oracle `renameTable` trigger with single-quote injection in table names
- [x] Added unit tests for Oracle `columnInfo` with single-quote injection in table names
- [x] All 554 existing schema builder unit tests continue to pass