### PR TITLE
fix(types): manual commit transaction types

### DIFF
--- a/docs/src/guide/transactions.md
+++ b/docs/src/guide/transactions.md
@@ -135,7 +135,12 @@ try {
 Throwing an error directly from the transaction handler function automatically rolls back the transaction, same as returning a rejected promise.
 
 Notice that if the handler does not return a promise, it is up to you to ensure `trx.commit`, or `trx.rollback` are called, otherwise the transaction connection will hang.
-If the handler does not return a promise, `knex.transaction` will return the transaction `trx`.
+`knex.transaction` returns a thenable transaction object, and awaiting it resolves with the value passed to `trx.commit(value)`.
+If you call `trx.commit(value)` manually inside an async handler, `value` becomes the final transaction result and any later callback return value is ignored at runtime.
+In TypeScript, this manual side-effect pattern cannot be inferred from callback body alone, so prefer either:
+
+- returning a promise and letting knex auto-commit from the resolved callback value, or
+- returning `trx.commit(value)` directly when using explicit commit/rollback control.
 
 Calling `trx.rollback` will return a rejected Promise. If you don't pass any argument to `trx.rollback`, a generic `Error` object will be created and passed in to ensure the Promise always rejects with something.
 

--- a/test-tsd/transaction.test-d.ts
+++ b/test-tsd/transaction.test-d.ts
@@ -63,7 +63,7 @@ const main = async () => {
     })
   );
 
-  expectType<any[]>(
+  expectType<Pick<Article, 'id' | 'subject'>[]>(
     await knexInstance.transaction(async (trx) => {
       const articles: Article[] = [
         { id: 1, subject: 'Canterbury Tales' },
@@ -79,7 +79,7 @@ const main = async () => {
     })
   );
 
-  expectType<any[]>(
+  expectType<Pick<Article, 'id' | 'subject'>[]>(
     await knexInstance.transaction(async (trx) => {
       const articles: ReadonlyArray<Article> = [
         { id: 1, subject: 'Canterbury Tales' },
@@ -114,6 +114,18 @@ const main = async () => {
       }
     )
   );
+
+  expectType<boolean>(
+    await knexInstance.transaction((trx) => {
+      return trx.commit(true);
+    })
+  );
+
+  await knexInstance.transaction(async (trx) => {
+    expectType<Promise<void>>(trx.commit());
+    expectType<Promise<boolean>>(trx.commit(true));
+    expectType<Promise<never>>(trx.rollback(new Error('rollback')));
+  });
 
   const transactionConfig: Knex.TransactionConfig = {
     isolationLevel: 'serializable',

--- a/test/integration/execution/transaction.js
+++ b/test/integration/execution/transaction.js
@@ -145,6 +145,15 @@ module.exports = function (knex) {
         });
     });
 
+    it('should resolve transaction with manually committed value in async callback', async function () {
+      const transactionResult = await knex.transaction(async function (trx) {
+        await trx.commit(true);
+        return 'ignored';
+      });
+
+      expect(transactionResult).to.equal(true);
+    });
+
     it('should be able to rollback transactions', function () {
       let id = null;
       const err = new Error('error message');

--- a/test/integration/execution/transaction.js
+++ b/test/integration/execution/transaction.js
@@ -152,6 +152,7 @@ module.exports = function (knex) {
       });
 
       expect(transactionResult).to.equal(true);
+      expect(typeof transactionResult).to.equal('boolean');
     });
 
     it('should be able to rollback transactions', function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2341,8 +2341,8 @@ declare namespace Knex {
       value: any
     ): QueryBuilder<TRecord, TResult>;
     savepoint<T = any>(transactionScope: (trx: Transaction) => any): Promise<T>;
-    commit(value?: any): QueryBuilder<TRecord, TResult>;
-    rollback(error?: any): QueryBuilder<TRecord, TResult>;
+    commit<T = void>(value?: T): Promise<T>;
+    rollback(error?: any): Promise<never>;
   }
 
   type TransactionProvider = () => Promise<Transaction>;


### PR DESCRIPTION
fixes #6435

 ## Summary

  This PR aligns transaction typing and docs with existing runtime behavior when
  `trx.commit(value)` is called manually inside transaction callbacks.

  At runtime, the transaction resolves with the value passed to `commit(...)`.
  This was already true, but TS typings and docs were not explicit enough.

  ## What Changed

  ### 1) Public Type Definitions
  Updated transaction control methods in `types/index.d.ts`:

  - `commit<T = void>(value?: T): Promise<T>`
  - `rollback(error?: any): Promise<never>`

  This better reflects current behavior and improves type safety for callback-
  style transaction flows.

  ### 2) Runtime Regression Test
  Added integration test in `test/integration/execution/transaction.js`:

  - verifies that manual `await trx.commit(true)` in an async handler resolves
  the transaction result to `true` (even if callback later returns another
  value).

  ### 3) Type Tests
  Extended `test-tsd/transaction.test-d.ts` to assert:

  - `await knex.transaction((trx) => trx.commit(true))` is `boolean`
  - `trx.commit()` is `Promise<void>`
  - `trx.commit(true)` is `Promise<boolean>`
  - `trx.rollback(...)` is `Promise<never>`

  Also tightened two existing expectations to specific `Pick<Article, 'id' | 'subject'>[]` types.

  ### 4) Documentation
  Updated `docs/src/guide/transactions.md` to clarify:

  - `knex.transaction` returns a thenable transaction object
  - awaiting it resolves with the value passed to `trx.commit(value)`
  - manual `trx.commit(value)` in async handlers takes precedence for final result
  - TS cannot infer this side-effect pattern from callback body alone
  - recommended patterns:
    - return a promise and let knex auto-commit, or
    - return `trx.commit(value)` directly when using explicit commit control

  ## Why

  This fixes a mismatch between:
  - runtime transaction resolution behavior,
  - TypeScript definitions,
  - and user-facing docs.