### PR TITLE
Fix: orderby nulls now sorting on column values

### DIFF
--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -1452,7 +1452,7 @@ class QueryCompiler {
   }
 
   _basicGroupOrder(item, type) {
-    const column = this._formatGroupsItemValue(item.value, item.nulls);
+    const column = this._formatGroupsItemValue(item.value);
     const direction =
       type === 'order' && item.type !== 'orderByRaw'
         ? ` ${direction_(
@@ -1462,6 +1462,19 @@ class QueryCompiler {
             this.bindingsHolder
           )}`
         : '';
+
+    if (
+      type === 'order' &&
+      item.type !== 'orderByRaw' &&
+      (item.nulls === 'first' || item.nulls === 'last') &&
+      !(item.value instanceof Raw)
+    ) {
+      return (
+        this._formatGroupsItemValue(item.value, item.nulls) +
+        ` asc, ${column}${direction}`
+      );
+    }
+
     return column + direction;
   }
 

--- a/test/integration2/query/select/selects.spec.js
+++ b/test/integration2/query/select/selects.spec.js
@@ -609,7 +609,7 @@ describe('Selects', function () {
 
         await knex('OrderByNullTest').insert([
           {
-            null_col: 'test',
+            null_col: 'test2',
             string_col: 'a',
           },
           {
@@ -617,7 +617,7 @@ describe('Selects', function () {
             string_col: 'b',
           },
           {
-            null_col: 'test2',
+            null_col: 'test',
             string_col: 'c',
           },
           {
@@ -635,45 +635,51 @@ describe('Selects', function () {
           .testSql(function (tester) {
             tester(
               'mysql',
-              'select `id` from `OrderByNullTest` order by (`null_col` is not null) asc, `string_col` asc',
+              'select `id` from `OrderByNullTest` order by (`null_col` is not null) asc, `null_col` asc, `string_col` asc',
               [],
-              [2, 4, 1, 3]
+              [2, 4, 3, 1]
             );
             tester(
               'pg',
               'select "id" from "OrderByNullTest" order by "null_col" asc nulls first, "string_col" asc',
               [],
-              [2, 4, 1, 3]
+              [2, 4, 3, 1]
             );
             tester(
               'pgnative',
               'select "id" from "OrderByNullTest" order by "null_col" asc nulls first, "string_col" asc',
               [],
-              [2, 4, 1, 3]
+              [2, 4, 3, 1]
             );
             tester(
               'pg-redshift',
               'select "id" from "OrderByNullTest" order by "null_col" asc nulls first, "string_col" asc',
               [],
-              ['2', '4', '1', '3']
+              ['2', '4', '3', '1']
             );
             tester(
               'sqlite3',
-              'select `id` from `OrderByNullTest` order by (`null_col` is not null) asc, `string_col` asc',
+              'select `id` from `OrderByNullTest` order by (`null_col` is not null) asc, `null_col` asc, `string_col` asc',
               [],
-              [2, 4, 1, 3]
+              [2, 4, 3, 1]
+            );
+            tester(
+              'better-sqlite3',
+              'select `id` from `OrderByNullTest` order by (`null_col` is not null) asc, `null_col` asc, `string_col` asc',
+              [],
+              [2, 4, 3, 1]
             );
             tester(
               'oracledb',
               'select "id" from "OrderByNullTest" order by "null_col" asc nulls first, "string_col" asc',
               [],
-              [2, 4, 1, 3]
+              [2, 4, 3, 1]
             );
             tester(
               'mssql',
-              'select [id] from [OrderByNullTest] order by IIF([null_col] is null,0,1) asc, [string_col] asc',
+              'select [id] from [OrderByNullTest] order by IIF([null_col] is null,0,1) asc, [null_col] asc, [string_col] asc',
               [],
-              [2, 4, 1, 3]
+              [2, 4, 3, 1]
             );
           });
 
@@ -686,45 +692,51 @@ describe('Selects', function () {
           .testSql(function (tester) {
             tester(
               'mysql',
-              'select `id` from `OrderByNullTest` order by (`null_col` is null) asc, `string_col` asc',
+              'select `id` from `OrderByNullTest` order by (`null_col` is null) asc, `null_col` asc, `string_col` asc',
               [],
-              [1, 3, 2, 4]
+              [3, 1, 2, 4]
             );
             tester(
               'pg',
               'select "id" from "OrderByNullTest" order by "null_col" asc nulls last, "string_col" asc',
               [],
-              [1, 3, 2, 4]
+              [3, 1, 2, 4]
             );
             tester(
               'pgnative',
               'select "id" from "OrderByNullTest" order by "null_col" asc nulls last, "string_col" asc',
               [],
-              [1, 3, 2, 4]
+              [3, 1, 2, 4]
             );
             tester(
               'pg-redshift',
               'select "id" from "OrderByNullTest" order by "null_col" asc nulls last, "string_col" asc',
               [],
-              ['1', '3', '2', '4']
+              ['3', '1', '2', '4']
             );
             tester(
               'sqlite3',
-              'select `id` from `OrderByNullTest` order by (`null_col` is null) asc, `string_col` asc',
+              'select `id` from `OrderByNullTest` order by (`null_col` is null) asc, `null_col` asc, `string_col` asc',
               [],
-              [1, 3, 2, 4]
+              [3, 1, 2, 4]
+            );
+            tester(
+              'better-sqlite3',
+              'select `id` from `OrderByNullTest` order by (`null_col` is null) asc, `null_col` asc, `string_col` asc',
+              [],
+              [3, 1, 2, 4]
             );
             tester(
               'oracledb',
               'select "id" from "OrderByNullTest" order by "null_col" asc nulls last, "string_col" asc',
               [],
-              [1, 3, 2, 4]
+              [3, 1, 2, 4]
             );
             tester(
               'mssql',
-              'select [id] from [OrderByNullTest] order by IIF([null_col] is null,1,0) asc, [string_col] asc',
+              'select [id] from [OrderByNullTest] order by IIF([null_col] is null,1,0) asc, [null_col] asc, [string_col] asc',
               [],
-              [1, 3, 2, 4]
+              [3, 1, 2, 4]
             );
           });
         await knex.schema.dropTable('OrderByNullTest');

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -6289,16 +6289,22 @@ describe('QueryBuilder', () => {
   it('order by, null first', () => {
     testsql(qb().from('users').orderBy('foo', 'desc', 'first'), {
       mysql: {
-        sql: 'select * from `users` order by (`foo` is not null) desc',
+        sql: 'select * from `users` order by (`foo` is not null) asc, `foo` desc',
+      },
+      sqlite3: {
+        sql: 'select * from `users` order by (`foo` is not null) asc, `foo` desc',
       },
       mssql: {
-        sql: 'select * from [users] order by IIF([foo] is null,0,1) desc',
+        sql: 'select * from [users] order by IIF([foo] is null,0,1) asc, [foo] desc',
       },
       pg: {
         sql: 'select * from "users" order by "foo" desc nulls first',
       },
       'pg-redshift': {
         sql: 'select * from "users" order by "foo" desc nulls first',
+      },
+      cockroachdb: {
+        sql: 'select * from "users" order by ("foo" is not null) asc, "foo" desc',
       },
     });
   });
@@ -6310,16 +6316,22 @@ describe('QueryBuilder', () => {
         .orderBy([{ column: 'foo', order: 'desc', nulls: 'first' }]),
       {
         mysql: {
-          sql: 'select * from `users` order by (`foo` is not null) desc',
+          sql: 'select * from `users` order by (`foo` is not null) asc, `foo` desc',
+        },
+        sqlite3: {
+          sql: 'select * from `users` order by (`foo` is not null) asc, `foo` desc',
         },
         mssql: {
-          sql: 'select * from [users] order by IIF([foo] is null,0,1) desc',
+          sql: 'select * from [users] order by IIF([foo] is null,0,1) asc, [foo] desc',
         },
         pg: {
           sql: 'select * from "users" order by "foo" desc nulls first',
         },
         'pg-redshift': {
           sql: 'select * from "users" order by "foo" desc nulls first',
+        },
+        cockroachdb: {
+          sql: 'select * from "users" order by ("foo" is not null) asc, "foo" desc',
         },
       }
     );
@@ -6328,16 +6340,22 @@ describe('QueryBuilder', () => {
   it('order by, null last', () => {
     testsql(qb().from('users').orderBy('foo', 'desc', 'last'), {
       mysql: {
-        sql: 'select * from `users` order by (`foo` is null) desc',
+        sql: 'select * from `users` order by (`foo` is null) asc, `foo` desc',
+      },
+      sqlite3: {
+        sql: 'select * from `users` order by (`foo` is null) asc, `foo` desc',
       },
       mssql: {
-        sql: 'select * from [users] order by IIF([foo] is null,1,0) desc',
+        sql: 'select * from [users] order by IIF([foo] is null,1,0) asc, [foo] desc',
       },
       pg: {
         sql: 'select * from "users" order by "foo" desc nulls last',
       },
       'pg-redshift': {
         sql: 'select * from "users" order by "foo" desc nulls last',
+      },
+      cockroachdb: {
+        sql: 'select * from "users" order by ("foo" is null) asc, "foo" desc',
       },
     });
   });
@@ -6349,16 +6367,22 @@ describe('QueryBuilder', () => {
         .orderBy([{ column: 'foo', order: 'desc', nulls: 'last' }]),
       {
         mysql: {
-          sql: 'select * from `users` order by (`foo` is null) desc',
+          sql: 'select * from `users` order by (`foo` is null) asc, `foo` desc',
+        },
+        sqlite3: {
+          sql: 'select * from `users` order by (`foo` is null) asc, `foo` desc',
         },
         mssql: {
-          sql: 'select * from [users] order by IIF([foo] is null,1,0) desc',
+          sql: 'select * from [users] order by IIF([foo] is null,1,0) asc, [foo] desc',
         },
         pg: {
           sql: 'select * from "users" order by "foo" desc nulls last',
         },
         'pg-redshift': {
           sql: 'select * from "users" order by "foo" desc nulls last',
+        },
+        cockroachdb: {
+          sql: 'select * from "users" order by ("foo" is null) asc, "foo" desc',
         },
       }
     );


### PR DESCRIPTION
Fix: sqlite and better-sqlite3 null ordering now applying column ordering as well

The issue was that if we had an invocation of `orderBy`, such as:
```
query.orderBy([{column: "my_column", order: "asc", nulls: "first"}])
```
it would return SQL like:
```
select * from `my_table` where (1 = 1) order by (`my_column` is not null) asc
```
I think it should be something more like: 
```
select * from `my_table` where (1 = 1) order by (`my_column` is not null) asc, `my_column` asc
```
