### PR TITLE
chore: fixes for release-drafter workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,9 @@ permissions:
 
 jobs:
   build:
+    # PRs labeled `skip-tests` skip this matrix. used for changes that
+    # can't affect runtime behaviour (docs, CI scripts, release tooling).
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-tests') }}
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     permissions:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -117,6 +117,9 @@ jobs:
         if: matrix.database-type != 'sqlite3' && matrix.database-type != 'better-sqlite3'
 
   user_experience:
+    # PRs labeled `skip-tests` skip this matrix. used for changes that
+    # can't affect runtime behaviour (docs, CI scripts, release tooling).
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-tests') }}
     runs-on: ${{ matrix.os }}
     name: Test user experience
     strategy:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,6 +14,9 @@ permissions:
 
 jobs:
   build:
+    # PRs labeled `skip-tests` skip this matrix. used for changes that
+    # can't affect runtime behaviour (docs, CI scripts, release tooling).
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-tests') }}
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     runs-on: ubuntu-latest

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,6 +19,10 @@ jobs:
     outputs:
       release_id: ${{ steps.drafter.outputs.id }}
       version: ${{ steps.drafter.outputs.resolved_version }}
+      # final body after splicing in New Contributors + Full Changelog;
+      # consumed by verify_release_build so it doesn't need API access
+      # to the draft (drafts return 403 to contents:read tokens).
+      body: ${{ steps.splice.outputs.body }}
     steps:
       - id: drafter
         uses: release-drafter/release-drafter@v6
@@ -31,7 +35,8 @@ jobs:
       # GitHub's generate-notes API does, so call it for the same range
       # and splice the New Contributors block + Full Changelog link into
       # the draft body.
-      - name: Splice in New Contributors and Full Changelog
+      - id: splice
+        name: Splice in New Contributors and Full Changelog
         if: steps.drafter.outputs.id != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,6 +79,17 @@ jobs:
           jq -nc --arg body "$body" '{body: $body}' \
             | gh api -X PATCH "/repos/$REPO/releases/$RELEASE_ID" --input -
 
+          # also surface the final body as a step output so the next job
+          # can use it without needing draft-read permission. multi-line
+          # outputs use a heredoc with a random delimiter to avoid
+          # collisions with body content.
+          delim="EOF_$(uuidgen | tr -d -)"
+          {
+            printf 'body<<%s\n' "$delim"
+            printf '%s\n' "$body"
+            printf '%s\n' "$delim"
+          } >> "$GITHUB_OUTPUT"
+
   # dry-run the release pipeline against the just-updated draft so we
   # catch breakage that would only show up at release time. specifically:
   # apply the projected changelog entry to the working tree, then run
@@ -98,15 +114,14 @@ jobs:
 
       # apply the changelog generation that release.yml will run at
       # publish time. modifies CHANGELOG.md and docs/src/changelog.md
-      # in-place; nothing is committed.
+      # in-place; nothing is committed. body is passed via env (from the
+      # previous job's output) so we don't need read access to the
+      # draft release via the API.
       - name: Apply projected changelog entry
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          node ./scripts/update-changelog.mjs \
-            "${{ needs.update_release_draft.outputs.version }}" \
-            "${{ needs.update_release_draft.outputs.release_id }}"
+          RELEASE_BODY: ${{ needs.update_release_draft.outputs.body }}
+        run: node ./scripts/update-changelog.mjs "${{ needs.update_release_draft.outputs.version }}"
 
       - name: Restore cached docs dependencies
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,19 +136,16 @@ jobs:
           fi
           echo "version=$TAG" >> "$GITHUB_OUTPUT"
 
-      # generate changelog entries by fetching the validated release body
-      # and transforming it into the changelog formats. runs BEFORE the
-      # build so prettier (inside `npm run format`) can format the
-      # inserted content, and so the npm tarball includes the updated
-      # CHANGELOG.md.
+      # generate changelog entries from the validated release body. runs
+      # BEFORE the build so prettier (inside `npm run format`) can format
+      # the inserted content, and so the npm tarball includes the
+      # updated CHANGELOG.md. body is passed via env so the script
+      # doesn't need to round-trip through the GitHub API.
       - name: Update changelog
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          node ./scripts/update-changelog.mjs \
-            "${{ steps.version.outputs.version }}" \
-            "${{ github.event.release.id }}"
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: node ./scripts/update-changelog.mjs "${{ steps.version.outputs.version }}"
 
       - name: Build for release
         id: build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,6 +14,9 @@ permissions:
 
 jobs:
   build:
+    # PRs labeled `skip-tests` skip this matrix. used for changes that
+    # can't affect runtime behaviour (docs, CI scripts, release tooling).
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-tests') }}
     runs-on: ubuntu-latest
     name: Unit Tests
 

--- a/scripts/update-changelog.mjs
+++ b/scripts/update-changelog.mjs
@@ -1,26 +1,27 @@
 #!/usr/bin/env node
 // Inserts a new release section into both CHANGELOG.md (root, shipped on
 // npm) and docs/src/changelog.md (rendered on knexjs.org), taking the
-// content from the published GitHub release body. The release body's
-// structure is enforced by the validate job in release.yml (categories
-// must be from a known set, bullets must match the change-template
-// format), so the transformations here are straightforward.
+// content from $RELEASE_BODY (the GitHub release body). The release
+// body's structure is enforced by the validate job in release.yml
+// (categories must be from a known set, bullets must match the
+// change-template format), so the transformations here are
+// straightforward.
 //
-// Usage:  node scripts/update-changelog.mjs <version> <release-id>
-// Requires: gh CLI authenticated (GH_TOKEN/GITHUB_TOKEN).
+// Usage:  RELEASE_BODY="..." node scripts/update-changelog.mjs <version>
+//
+// Body is passed via env (not stdin or argv) so the workflow can hand it
+// off without needing read access to draft releases via the GitHub API.
 
 import { readFileSync, writeFileSync } from 'node:fs';
-import { execFileSync } from 'node:child_process';
 
 const VERSION = process.argv[2];
-const RELEASE_ID = process.argv[3];
 
 if (!/^\d+\.\d+\.\d+(-[\w.-]+)?$/.test(VERSION || '')) {
-  console.error('Usage: update-changelog.mjs <version> <release-id>');
+  console.error('Usage: RELEASE_BODY="..." update-changelog.mjs <version>');
   process.exit(1);
 }
-if (!/^\d+$/.test(RELEASE_ID || '')) {
-  console.error('Usage: update-changelog.mjs <version> <release-id>');
+if (process.env.RELEASE_BODY == null) {
+  console.error('RELEASE_BODY env var is required');
   process.exit(1);
 }
 
@@ -28,14 +29,7 @@ const REPO = process.env.GITHUB_REPOSITORY || 'knex/knex';
 const ROOT_PATH = 'CHANGELOG.md';
 const DOCS_PATH = 'docs/src/changelog.md';
 
-const release = JSON.parse(
-  execFileSync('gh', ['api', `/repos/${REPO}/releases/${RELEASE_ID}`], {
-    encoding: 'utf8',
-    maxBuffer: 16 * 1024 * 1024,
-  })
-);
-
-let body = release.body || '';
+let body = process.env.RELEASE_BODY;
 
 // strip the trailing "## New Contributors" section and the
 // "**Full Changelog**" line; neither changelog file carries these.


### PR DESCRIPTION
- Fixes [failure here](https://github.com/knex/knex/actions/runs/25225489645/job/73967935369) due to attempting to pull an unpublished release
- Allows for a `skip-tests` label to be assigned for skipping the full test matrix, if we know we're only making docs/CI changes. Full tests will always run on `master`