### PR TITLE
chore: skip re-running tests on automated release commit

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,11 @@ permissions:
 
 jobs:
   analyze:
+    # skip the auto-generated "release X.Y.Z" commit pushed by the
+    # release workflow (lib/** is rebuilt from unchanged source; the
+    # parent commit was already analysed). security analysis still runs
+    # on `skip-tests` PRs — it's orthogonal to test coverage.
+    if: ${{ !(github.actor == 'github-actions[bot]' && startsWith(github.event.head_commit.message, 'release ')) }}
     permissions:
       actions: read # for github/codeql-action/init to get workflow details
       contents: read # for actions/checkout to fetch code

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,9 +14,17 @@ permissions:
 
 jobs:
   build:
-    # PRs labeled `skip-tests` skip this matrix. used for changes that
-    # can't affect runtime behaviour (docs, CI scripts, release tooling).
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-tests') }}
+    # skip on:
+    #   - PRs labeled `skip-tests` (changes that can't affect runtime
+    #     behaviour: docs, CI scripts, release tooling)
+    #   - the auto-generated "release X.Y.Z" commit pushed by the
+    #     release workflow (only changes lib/**, package.json, and
+    #     changelogs; same source already tested on the parent commit)
+    if: >-
+      ${{
+        !contains(github.event.pull_request.labels.*.name, 'skip-tests') &&
+        !(github.actor == 'github-actions[bot]' && startsWith(github.event.head_commit.message, 'release '))
+      }}
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     permissions:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,9 +14,17 @@ permissions:
 
 jobs:
   build:
-    # PRs labeled `skip-tests` skip this matrix. used for changes that
-    # can't affect runtime behaviour (docs, CI scripts, release tooling).
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-tests') }}
+    # skip on:
+    #   - PRs labeled `skip-tests` (changes that can't affect runtime
+    #     behaviour: docs, CI scripts, release tooling)
+    #   - the auto-generated "release X.Y.Z" commit pushed by the
+    #     release workflow (only changes lib/**, package.json, and
+    #     changelogs; same source already tested on the parent commit)
+    if: >-
+      ${{
+        !contains(github.event.pull_request.labels.*.name, 'skip-tests') &&
+        !(github.actor == 'github-actions[bot]' && startsWith(github.event.head_commit.message, 'release '))
+      }}
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     runs-on: ubuntu-latest
@@ -117,9 +125,17 @@ jobs:
         if: matrix.database-type != 'sqlite3' && matrix.database-type != 'better-sqlite3'
 
   user_experience:
-    # PRs labeled `skip-tests` skip this matrix. used for changes that
-    # can't affect runtime behaviour (docs, CI scripts, release tooling).
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-tests') }}
+    # skip on:
+    #   - PRs labeled `skip-tests` (changes that can't affect runtime
+    #     behaviour: docs, CI scripts, release tooling)
+    #   - the auto-generated "release X.Y.Z" commit pushed by the
+    #     release workflow (only changes lib/**, package.json, and
+    #     changelogs; same source already tested on the parent commit)
+    if: >-
+      ${{
+        !contains(github.event.pull_request.labels.*.name, 'skip-tests') &&
+        !(github.actor == 'github-actions[bot]' && startsWith(github.event.head_commit.message, 'release '))
+      }}
     runs-on: ${{ matrix.os }}
     name: Test user experience
     strategy:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,6 +14,17 @@ permissions:
 
 jobs:
   build:
+    # skip on:
+    #   - PRs labeled `skip-tests` (changes that can't affect lint
+    #     output: external assets, etc.)
+    #   - the auto-generated "release X.Y.Z" commit pushed by the
+    #     release workflow (lib/** is rebuilt + prettier-formatted by
+    #     the release flow itself; source files unchanged)
+    if: >-
+      ${{
+        !contains(github.event.pull_request.labels.*.name, 'skip-tests') &&
+        !(github.actor == 'github-actions[bot]' && startsWith(github.event.head_commit.message, 'release '))
+      }}
     runs-on: ubuntu-latest
     name: Linting and Types
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,13 @@ permissions:
 
 jobs:
   update_release_draft:
+    # skip the auto-generated "release X.Y.Z" commit pushed by the
+    # release workflow itself — that commit doesn't introduce new PRs to
+    # draft, and updating the draft against it would just re-render the
+    # already-published release notes. matched on actor + message so a
+    # human-authored commit that happens to start with "release " (e.g.
+    # "release unused connection") still triggers normally.
+    if: ${{ !(github.actor == 'github-actions[bot]' && startsWith(github.event.head_commit.message, 'release ')) }}
     permissions:
       # write permission required to create a draft release
       contents: write

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,9 +14,17 @@ permissions:
 
 jobs:
   build:
-    # PRs labeled `skip-tests` skip this matrix. used for changes that
-    # can't affect runtime behaviour (docs, CI scripts, release tooling).
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-tests') }}
+    # skip on:
+    #   - PRs labeled `skip-tests` (changes that can't affect runtime
+    #     behaviour: docs, CI scripts, release tooling)
+    #   - the auto-generated "release X.Y.Z" commit pushed by the
+    #     release workflow (only changes lib/**, package.json, and
+    #     changelogs; same source already tested on the parent commit)
+    if: >-
+      ${{
+        !contains(github.event.pull_request.labels.*.name, 'skip-tests') &&
+        !(github.actor == 'github-actions[bot]' && startsWith(github.event.head_commit.message, 'release '))
+      }}
     runs-on: ubuntu-latest
     name: Unit Tests
 


### PR DESCRIPTION
Skips re-running tests when the GH Bot cuts the `release x.x.x` commit to `master`