### PR TITLE
use ecr for mysql/pg images to reduce docker rate limiting

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - 'until /opt/mssql-tools/bin/sqlcmd -S mssql -U sa -P S0meVeryHardPassword -d master -Q "CREATE DATABASE knex_test; ALTER DATABASE knex_test SET ALLOW_SNAPSHOT_ISOLATION ON; ALTER DATABASE knex_test SET DELAYED_DURABILITY = FORCED"; do sleep 5; done'
 
   mysql:
-    image: mysql:8.0.40
+    image: public.ecr.aws/docker/library/mysql:8.0.40
     # https://dev.mysql.com/doc/refman/8.0/en/mysql-acid.html
     # https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_flush_method
     # nosync only for unix, edit for local start on other systems
@@ -51,7 +51,7 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
   waitmysql:
-    image: mysql:8.0.40
+    image: public.ecr.aws/docker/library/mysql:8.0.40
     links:
       - mysql
     depends_on:
@@ -62,7 +62,7 @@ services:
       - 'until /usr/bin/mysql -hmysql -utestuser -ptestpassword -e "SELECT 1"; do sleep 5; done'
 
   postgres:
-    image: postgres:17-alpine
+    image: public.ecr.aws/docker/library/postgres:17-alpine
     # see https://www.postgresql.org/docs/current/non-durability.html
     command: '-c full_page_writes=off -c fsync=off -c synchronous_commit=off'
     ports:
@@ -72,7 +72,7 @@ services:
       - POSTGRES_PASSWORD=knextest
       - POSTGRES_DB=knex_test
   waitpostgres:
-    image: postgres:17-alpine
+    image: public.ecr.aws/docker/library/postgres:17-alpine
     links:
       - postgres
     depends_on:
@@ -103,7 +103,7 @@ services:
       - cockroachdb
 
   pgnative:
-    image: postgres:17-alpine
+    image: public.ecr.aws/docker/library/postgres:17-alpine
     # see https://www.postgresql.org/docs/current/non-durability.html
     command: '-c full_page_writes=off -c fsync=off -c synchronous_commit=off'
     ports:
@@ -113,7 +113,7 @@ services:
       - POSTGRES_PASSWORD=knextest
       - POSTGRES_DB=knex_test
   waitpgnative:
-    image: postgres:17-alpine
+    image: public.ecr.aws/docker/library/postgres:17-alpine
     links:
       - pgnative
     depends_on:


### PR DESCRIPTION
Seeing if we can avoid some of the docker rate limiting on our integration tests