### PR TITLE
fix(pg): whereJsonPath: use proper cast type for numbers

### DIFF
--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -348,15 +348,21 @@ class QueryCompiler_PG extends QueryCompiler {
       : jsonCol;
   }
 
+  static castType(value){
+    if (typeof value === 'bigint') return '::bigint'
+    if (value===null||value===undefined || !['number','string'].includes(typeof value)) return " #>> '{}'"
+    let isString=typeof value === 'string'
+    if (isString && value.trim()==='') return " #>> '{}'"
+    if (isNaN(value)) return " #>> '{}'"
+    if (isString && value.includes('.'))
+        return '::numeric'
+    let num=Number(value)
+    if (Number.isSafeInteger(num)) return '::bigint'
+    return '::numeric'
+  }
+
   whereJsonPath(statement) {
-    let castValue = '';
-    if (!isNaN(statement.value) && parseInt(statement.value)) {
-      castValue = '::int';
-    } else if (!isNaN(statement.value) && parseFloat(statement.value)) {
-      castValue = '::float';
-    } else {
-      castValue = " #>> '{}'";
-    }
+    let castValue = QueryCompiler_PG.castType(statement.value);
     return `jsonb_path_query_first(${this._columnClause(
       statement
     )}, ${this.client.parameter(

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -11881,7 +11881,7 @@ describe('QueryBuilder', () => {
             .orWhereJsonPath('address', '$.street.number', '<', 8),
           {
             pg: {
-              sql: 'select * from "users" where jsonb_path_query_first("address", ?)::int > ? or jsonb_path_query_first("address", ?)::int < ?',
+              sql: 'select * from "users" where jsonb_path_query_first("address", ?)::bigint > ? or jsonb_path_query_first("address", ?)::bigint < ?',
               bindings: ['$.street.number', 5, '$.street.number', 8],
             },
             mysql: {


### PR DESCRIPTION
- Use `::bigint` for safe integers and native `bigint` values
- Use `::numeric` for numbers with a decimal point

The current implementation doesn’t detect the number types properly: `!isNaN(statement.value) && parseInt(statement.value)` evaluates to `true` even for decimal numbers, causing all numbers to be cast to `int`.

Integer values (those that pass `Number.isSafeInteger`) are now cast to `bigint` to prevent overflow errors with large numbers already in the database.

Strings containing a '.' and numbers that are not safe integers are now cast to `numeric`. This avoids problems where existing numbers in the database can’t safely be cast to ::float or where exact decimal precision must be preserved.



