### PR TITLE
Update homepage urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [knex.js](https://knex.github.io/documentation/)
+# [knex.js](https://knexjs.org/)
 
 [![npm version](http://img.shields.io/npm/v/knex.svg)](https://npmjs.org/package/knex)
 [![npm downloads](https://img.shields.io/npm/dm/knex.svg)](https://npmjs.org/package/knex)

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "type": "git",
     "url": "git://github.com/knex/knex.git"
   },
-  "homepage": "https://knex.github.io/documentation/",
+  "homepage": "https://knexjs.org/",
   "keywords": [
     "sql",
     "query",


### PR DESCRIPTION
I have just noticed that a couple of links point to the old documentation urls, so minor fix here!