### PR TITLE
fix(pg): preserve updateFrom binding order

### DIFF
--- a/lib/dialects/postgres/query/pg-querycompiler.js
+++ b/lib/dialects/postgres/query/pg-querycompiler.js
@@ -49,14 +49,15 @@ class QueryCompiler_PG extends QueryCompiler {
   update() {
     const withSQL = this.with();
     const updateData = this._prepUpdate(this.single.update);
-    const wheres = this.where();
     const { returning, updateFrom } = this.single;
+    const updateFromSQL = this._updateFrom(updateFrom);
+    const wheres = this.where();
     return {
       sql:
         withSQL +
         `update ${this.single.only ? 'only ' : ''}${this.tableName} ` +
         `set ${updateData.join(', ')}` +
-        this._updateFrom(updateFrom) +
+        updateFromSQL +
         (wheres ? ` ${wheres}` : '') +
         this._returning(returning),
       returning,

--- a/test/integration2/query/update/updates.spec.js
+++ b/test/integration2/query/update/updates.spec.js
@@ -703,6 +703,36 @@ describe('Updates', function () {
           });
         await knex.schema.dropTable('testing');
       });
+
+      it('handle from bindings in the right order #6376', async function () {
+        if (!isPostgreSQL(knex)) {
+          return this.skip();
+        }
+
+        await knex('accounts')
+          .update({ last_name: knex.ref('values.last_name') })
+          .updateFrom(
+            knex.raw('(VALUES (?, ?), (?, ?)) as ?? (??, ??)', [
+              'test1@example.com',
+              'John',
+              'test2@example.com',
+              'Jane',
+              'values',
+              'email',
+              'last_name',
+            ])
+          )
+          .where(knex.raw('?', [1]), '=', 1)
+          .andWhere('accounts.email', knex.ref('values.email'))
+          .testSql(function (tester) {
+            tester(
+              'pg',
+              'update "accounts" set "last_name" = "values"."last_name" from (VALUES (?, ?), (?, ?)) as "values" ("email", "last_name") where ? = ? and "accounts"."email" = "values"."email"',
+              ['test1@example.com', 'John', 'test2@example.com', 'Jane', 1, 1],
+              2
+            );
+          });
+      });
     });
   });
 });

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -6209,6 +6209,24 @@ describe('QueryBuilder', () => {
     );
   });
 
+  it('should produce correct binding order when updating with a subquery updateFrom in pg (#6277)', () => {
+    testsql(
+      qb()
+        .update({ flagged: true })
+        .table('orders')
+        .updateFrom(
+          qb().from('accounts').where('tier', 'gold').as('gold_accounts')
+        )
+        .where('orders.status', 'unpaid'),
+      {
+        pg: {
+          sql: 'update "orders" set "flagged" = ? from (select * from "accounts" where "tier" = ?) as "gold_accounts" where "orders"."status" = ?',
+          bindings: [true, 'gold', 'unpaid'],
+        },
+      }
+    );
+  });
+
   it('should not update columns undefined values', () => {
     testsql(
       qb()


### PR DESCRIPTION
re #6277 #6412 #6438 
fixes #6376

Missed the same binding-order issue in PostgreSQL `updateFrom()` when the `FROM` source has bindings.

`QueryCompiler_PG.update()` compiled `where()` before `_updateFrom(updateFrom)`, but the SQL emits `FROM` before `WHERE`. This caused bindings from the outer `WHERE` to be placed before bindings from an `updateFrom` subquery.

This moves `_updateFrom(updateFrom)` before `where()` so bindings follow SQL placeholder order, without changing the emitted SQL.