### PR TITLE
ci: make npm install resilient to transient network failures

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -63,7 +63,17 @@ jobs:
         run: npm run db:start:no-oracle
 
       - name: Run npm install
-        run: npm install
+        run: |
+          n=0
+          until npm install; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "npm install failed after $n attempts"
+              exit 1
+            fi
+            echo "npm install failed, retrying in 15s... (attempt $n)"
+            sleep 15
+          done
 
       - name: Install pg-native
         run: npm i pg-native

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -67,7 +67,17 @@ jobs:
         if: matrix.database-type != 'sqlite3' && matrix.database-type != 'better-sqlite3'
 
       - name: Run npm install
-        run: npm install
+        run: |
+          n=0
+          until npm install; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "npm install failed after $n attempts"
+              exit 1
+            fi
+            echo "npm install failed, retrying in 15s... (attempt $n)"
+            sleep 15
+          done
 
       - name: Initialize Database(s)
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -46,7 +46,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Run npm install
-        run: npm install
+        run: |
+          n=0
+          until npm install; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "npm install failed after $n attempts"
+              exit 1
+            fi
+            echo "npm install failed, retrying in 15s... (attempt $n)"
+            sleep 15
+          done
 
       - name: Run format:check
         run: npm run format:check

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,7 +46,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Run npm install
-        run: npm install
+        run: |
+          n=0
+          until npm install; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "npm install failed after $n attempts"
+              exit 1
+            fi
+            echo "npm install failed, retrying in 15s... (attempt $n)"
+            sleep 15
+          done
 
       - run: npm run build
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# Make dependency installs resilient to transient network failures (e.g.
+# ECONNRESET against the npm registry), which are a common source of flaky
+# CI jobs. npm's defaults (2 retries, short timeouts) are too low.
+fetch-retries=5
+fetch-retry-mintimeout=20000
+fetch-retry-maxtimeout=120000
+fetch-timeout=600000


### PR DESCRIPTION
Transient ECONNRESET errors from the npm registry during `npm install` regularly fail individual CI jobs. On the 32-job integration matrix a single failed job is enough to turn a green PR red, even when nothing is wrong with the change.

Two changes to reduce these false reds:

1. Add a root `.npmrc` that raises npm's fetch retries and timeouts. The defaults (2 retries, short timeouts) are too low for CI. This also benefits local installs.
2. Retry the `npm install` step up to 3 times in every workflow, so an isolated reset no longer fails the whole job.