### PR TITLE
fix: capture bindings from parameterized index predicates

### DIFF
--- a/lib/dialects/mssql/schema/mssql-tablecompiler.js
+++ b/lib/dialects/mssql/schema/mssql-tablecompiler.js
@@ -232,9 +232,13 @@ class TableCompiler_MSSQL extends TableCompiler {
     if (isObject(options)) {
       ({ predicate } = options);
     }
-    const predicateQuery = predicate
-      ? ' ' + this.client.queryCompiler(predicate).where()
+    const predicateCompiler = predicate && this.client.queryCompiler(predicate);
+    const predicateQuery = predicateCompiler
+      ? ' ' + predicateCompiler.where()
       : '';
+    if (predicateCompiler && this.bindings !== predicateCompiler.bindings) {
+      this.bindings.push(...predicateCompiler.bindings);
+    }
     this.pushQuery(
       `CREATE INDEX ${indexName} ON ${this.tableName()} (${this.formatter.columnize(
         columns
@@ -317,12 +321,17 @@ class TableCompiler_MSSQL extends TableCompiler {
     } else {
       // default to making unique index that allows null https://stackoverflow.com/a/767702/360060
       // to be more or less compatible with other DBs (if any of the columns is NULL then "duplicates" are allowed)
-      const predicateQuery = predicate
-        ? ' ' + this.client.queryCompiler(predicate).where()
+      const predicateCompiler =
+        predicate && this.client.queryCompiler(predicate);
+      const predicateQuery = predicateCompiler
+        ? ' ' + predicateCompiler.where()
         : ' WHERE ' +
           columns
             .map((column) => this.formatter.columnize(column) + ' IS NOT NULL')
             .join(' AND ');
+      if (predicateCompiler && this.bindings !== predicateCompiler.bindings) {
+        this.bindings.push(...predicateCompiler.bindings);
+      }
       this.pushQuery(
         `CREATE UNIQUE INDEX ${indexName} ON ${this.tableName()} (${this.formatter.columnize(
           columns

--- a/lib/dialects/postgres/schema/pg-tablecompiler.js
+++ b/lib/dialects/postgres/schema/pg-tablecompiler.js
@@ -217,9 +217,14 @@ class TableCompiler_PG extends TableCompiler {
           deferrable
       );
     } else {
-      const predicateQuery = predicate
-        ? ' ' + this.client.queryCompiler(predicate).where()
+      const predicateCompiler =
+        predicate && this.client.queryCompiler(predicate);
+      const predicateQuery = predicateCompiler
+        ? ' ' + predicateCompiler.where()
         : '';
+      if (predicateCompiler && this.bindings !== predicateCompiler.bindings) {
+        this.bindings.push(...predicateCompiler.bindings);
+      }
 
       this.pushQuery(
         `create unique index ${indexName} on ${this.tableName()} (${this.formatter.columnize(
@@ -244,9 +249,13 @@ class TableCompiler_PG extends TableCompiler {
       ({ indexType, storageEngineIndexType, predicate } = options);
     }
 
-    const predicateQuery = predicate
-      ? ' ' + this.client.queryCompiler(predicate).where()
+    const predicateCompiler = predicate && this.client.queryCompiler(predicate);
+    const predicateQuery = predicateCompiler
+      ? ' ' + predicateCompiler.where()
       : '';
+    if (predicateCompiler && this.bindings !== predicateCompiler.bindings) {
+      this.bindings.push(...predicateCompiler.bindings);
+    }
 
     this.pushQuery(
       `create${

--- a/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
@@ -162,9 +162,13 @@ class TableCompiler_SQLite3 extends TableCompiler {
       : this._indexCommand('unique', this.tableNameRaw, columns);
     columns = this.formatter.columnize(columns);
 
-    const predicateQuery = predicate
-      ? ' ' + this.client.queryCompiler(predicate).where()
+    const predicateCompiler = predicate && this.client.queryCompiler(predicate);
+    const predicateQuery = predicateCompiler
+      ? ' ' + predicateCompiler.where()
       : '';
+    if (predicateCompiler && this.bindings !== predicateCompiler.bindings) {
+      this.bindings.push(...predicateCompiler.bindings);
+    }
 
     this.pushQuery(
       `create unique index ${indexName} on ${this.tableName()} (${columns})${predicateQuery}`
@@ -182,9 +186,13 @@ class TableCompiler_SQLite3 extends TableCompiler {
     if (isObject(options)) {
       ({ predicate } = options);
     }
-    const predicateQuery = predicate
-      ? ' ' + this.client.queryCompiler(predicate).where()
+    const predicateCompiler = predicate && this.client.queryCompiler(predicate);
+    const predicateQuery = predicateCompiler
+      ? ' ' + predicateCompiler.where()
       : '';
+    if (predicateCompiler && this.bindings !== predicateCompiler.bindings) {
+      this.bindings.push(...predicateCompiler.bindings);
+    }
     this.pushQuery(
       `create index ${indexName} on ${this.tableName()} (${columns})${predicateQuery}`
     );

--- a/test/unit/schema-builder/mssql.js
+++ b/test/unit/schema-builder/mssql.js
@@ -677,6 +677,22 @@ describe('MSSQL SchemaBuilder', function () {
     );
   });
 
+  it('test adding index with a parameterized predicate captures its bindings', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.index(['foo', 'bar'], 'baz', {
+          predicate: client.queryBuilder().where('email', '=', 'foo@bar'),
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'CREATE INDEX [baz] ON [users] ([foo], [bar]) where [email] = ?'
+    );
+    expect(tableSql[0].bindings).to.deep.equal(['foo@bar']);
+  });
+
   it('test adding unique index with a predicate', function () {
     tableSql = client
       .schemaBuilder()
@@ -707,6 +723,23 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal(
       'CREATE UNIQUE INDEX [baz] ON [users] ([foo], [bar]) where [email] is not null'
     );
+  });
+
+  it('test adding unique index with a parameterized predicate captures its bindings', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.unique(['foo', 'bar'], {
+          indexName: 'baz',
+          predicate: client.queryBuilder().where('email', '=', 'foo@bar'),
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'CREATE UNIQUE INDEX [baz] ON [users] ([foo], [bar]) where [email] = ?'
+    );
+    expect(tableSql[0].bindings).to.deep.equal(['foo@bar']);
   });
 
   it('throws when adding unique constraint with predicate', function () {

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -1111,6 +1111,22 @@ describe('PostgreSQL SchemaBuilder', function () {
     );
   });
 
+  it('adding index with a parameterized predicate captures its bindings', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.index(['foo', 'bar'], 'baz', {
+          predicate: client.queryBuilder().where('email', '=', 'foo@bar'),
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'create index "baz" on "users" ("foo", "bar") where "email" = ?'
+    );
+    expect(tableSql[0].bindings).to.deep.equal(['foo@bar']);
+  });
+
   it('adding unique index using index method', function () {
     tableSql = client
       .schemaBuilder()
@@ -1187,6 +1203,23 @@ describe('PostgreSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal(
       'create unique index "baz" on "users" ("foo", "bar") where "email" is not null'
     );
+  });
+
+  it('adding unique index with a parameterized predicate captures its bindings', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.unique(['foo', 'bar'], {
+          indexName: 'baz',
+          predicate: client.queryBuilder().where('email', '=', 'foo@bar'),
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'create unique index "baz" on "users" ("foo", "bar") where "email" = ?'
+    );
+    expect(tableSql[0].bindings).to.deep.equal(['foo@bar']);
   });
 
   it('throws when adding unique constraint with a predicate', function () {

--- a/test/unit/schema-builder/sqlite3.js
+++ b/test/unit/schema-builder/sqlite3.js
@@ -593,6 +593,22 @@ describe('SQLite SchemaBuilder', function () {
     );
   });
 
+  it('adding index with a parameterized predicate captures its bindings', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.index(['foo', 'bar'], 'baz', {
+          predicate: client.queryBuilder().where('email', '=', 'foo@bar'),
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'create index `baz` on `users` (`foo`, `bar`) where `email` = ?'
+    );
+    expect(tableSql[0].bindings).to.deep.equal(['foo@bar']);
+  });
+
   it('adding unique index with a predicate', function () {
     tableSql = client
       .schemaBuilder()
@@ -623,6 +639,23 @@ describe('SQLite SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal(
       'create unique index `baz` on `users` (`foo`, `bar`) where `email` is not null'
     );
+  });
+
+  it('adding unique index with a parameterized predicate captures its bindings', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.unique(['foo', 'bar'], {
+          indexName: 'baz',
+          predicate: client.queryBuilder().where('email', '=', 'foo@bar'),
+        });
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'create unique index `baz` on `users` (`foo`, `bar`) where `email` = ?'
+    );
+    expect(tableSql[0].bindings).to.deep.equal(['foo@bar']);
   });
 
   it('adding incrementing id', function () {


### PR DESCRIPTION
Closes #6354.

When creating a partial/filtered index through the table builder with a **parameterized** predicate, the generated SQL contained a `?` placeholder but the corresponding binding was silently dropped:

```js
table.index(['foo', 'bar'], 'baz', {
  predicate: knex.queryBuilder().where('email', '=', 'foo@bar'),
});
// sql:      ... where "email" = ?
// bindings: []          <-- the value never makes it in
```

## Cause

`this.client.queryCompiler(predicate)` constructs a **new** `QueryCompiler` whose constructor does `this.bindings = bindings || []` — a fresh array, since no bindings array is passed in. Calling `.where()` populates that separate array, so the predicate's bindings never reach the table compiler's bindings that `pushQuery` reads. The defect went unnoticed because the existing tests only used `whereRaw('email = "foo@bar"')` / `whereNotNull('email')` predicates, which carry no bindings.

## Fix

Keep the predicate's query compiler and merge its bindings into the table compiler's bindings (this is the fix the reporter suggested). Applied to both `unique()` and `index()` in the three dialects that support index predicates — **postgres**, **mssql** and **sqlite3**:

```js
const predicateCompiler = predicate && this.client.queryCompiler(predicate);
const predicateQuery = predicateCompiler ? ' ' + predicateCompiler.where() : '';
if (predicateCompiler && this.bindings !== predicateCompiler.bindings) {
  this.bindings.push(...predicateCompiler.bindings);
}
```

Existing binding-free predicates (`whereRaw`, `whereNotNull`) are unaffected — their bindings array is empty, so the merge is a no-op.

## Tests

Adds a parameterized-predicate regression test to each dialect's schema-builder unit suite (`test/unit/schema-builder/{postgres,mssql,sqlite3}.js`), for both `index()` and `unique()`, asserting `tableSql[0].bindings` deep-equals `['foo@bar']`. Verified each new test **fails** on the current code (`expected [] to deeply equal [ 'foo@bar' ]`) and **passes** with this change; the full unit suite (1847 tests) stays green and ESLint/Prettier are clean.

These are `.toSQL()`-based unit tests (no database), matching the existing predicate tests and the reporter's own repro. The fix lives entirely in query compilation — it corrects an internally inconsistent `{ sql, bindings }` pair — so a unit test is the right level to verify it.
