### PR TITLE
feat: add dropIndexIfExists

### DIFF
--- a/docs/src/guide/schema-builder.md
+++ b/docs/src/guide/schema-builder.md
@@ -993,7 +993,7 @@ knex.schema.table('users', function (table) {
 
 **table.dropIndexIfExists(columns, [indexName])**
 
-Like dropIndex, but does not error if the index does not exist. Supported in PostgreSQL, CockroachDB, MariaDB, MSSQL, SQLite/better-sqlite3, and Oracle 23ai+ (and the 19.28 backport). Not supported in MySQL or Redshift, nor on Oracle before 23ai/19.28; calling it there throws a “not supported” error.
+Like dropIndex, but does not error if the index does not exist. Supported in PostgreSQL, CockroachDB, MariaDB, MSSQL, SQLite/better-sqlite3, and Oracle 23ai+ (and the 19c LTS backport, from 19.28). Not supported in MySQL or Redshift, nor on Oracle before 23ai/19.28; calling it there throws a “not supported” error.
 
 ```js
 // @sql

--- a/docs/src/guide/schema-builder.md
+++ b/docs/src/guide/schema-builder.md
@@ -989,6 +989,19 @@ knex.schema.table('users', function (table) {
 });
 ```
 
+### dropIndexIfExists
+
+**table.dropIndexIfExists(columns, [indexName])**
+
+Like dropIndex, but does not error if the index does not exist. Supported in PostgreSQL, CockroachDB, MariaDB, MSSQL, and SQLite/better-sqlite3. Not supported in MySQL, Oracle, or Redshift; calling it there throws a “not supported” error.
+
+```js
+// @sql
+knex.schema.table('users', function (table) {
+  table.dropIndexIfExists(['name', 'last_name']);
+});
+```
+
 ### setNullable [~SQ]
 
 **table.setNullable(column)**

--- a/docs/src/guide/schema-builder.md
+++ b/docs/src/guide/schema-builder.md
@@ -993,7 +993,7 @@ knex.schema.table('users', function (table) {
 
 **table.dropIndexIfExists(columns, [indexName])**
 
-Like dropIndex, but does not error if the index does not exist. Supported in PostgreSQL, CockroachDB, MariaDB, MSSQL, and SQLite/better-sqlite3. Not supported in MySQL, Oracle, or Redshift; calling it there throws a “not supported” error.
+Like dropIndex, but does not error if the index does not exist. Supported in PostgreSQL, CockroachDB, MariaDB, MSSQL, SQLite/better-sqlite3, and Oracle 23ai+ (and the 19.28 backport). Not supported in MySQL or Redshift, nor on Oracle before 23ai/19.28; calling it there throws a “not supported” error.
 
 ```js
 // @sql

--- a/lib/dialects/mssql/schema/mssql-tablecompiler.js
+++ b/lib/dialects/mssql/schema/mssql-tablecompiler.js
@@ -339,6 +339,13 @@ class TableCompiler_MSSQL extends TableCompiler {
     this.pushQuery(`DROP INDEX ${indexName} ON ${this.tableName()}`);
   }
 
+  dropIndexIfExists(columns, indexName) {
+    indexName = indexName
+      ? this.formatter.wrap(indexName)
+      : this._indexCommand('index', this.tableNameRaw, columns);
+    this.pushQuery(`DROP INDEX IF EXISTS ${indexName} ON ${this.tableName()}`);
+  }
+
   // Compile a drop foreign key command.
   dropForeign(columns, indexName) {
     indexName = indexName

--- a/lib/dialects/mysql/schema/mysql-tablecompiler.js
+++ b/lib/dialects/mysql/schema/mysql-tablecompiler.js
@@ -390,6 +390,19 @@ class TableCompiler_MySQL extends TableCompiler {
     this.pushQuery(`alter table ${this.tableName()} drop index ${indexName}`);
   }
 
+  dropIndexIfExists(columns, indexName) {
+    if (this.client.isMariaDB) {
+      indexName = indexName
+        ? this.formatter.wrap(indexName)
+        : this._indexCommand('index', this.tableNameRaw, columns);
+      this.pushQuery(
+        `alter table ${this.tableName()} drop index if exists ${indexName}`
+      );
+      return;
+    }
+    throw new Error('.dropIndexIfExists is not supported for mysql.');
+  }
+
   // Compile a drop foreign key command.
   dropForeign(columns, indexName) {
     indexName = indexName

--- a/lib/dialects/oracle/schema/oracle-tablecompiler.js
+++ b/lib/dialects/oracle/schema/oracle-tablecompiler.js
@@ -154,6 +154,10 @@ class TableCompiler_Oracle extends TableCompiler {
     this.pushQuery(`drop index ${indexName}`);
   }
 
+  dropIndexIfExists(columns, indexName) {
+    throw new Error('.dropIndexIfExists() is not supported by oracle');
+  }
+
   unique(columns, indexName) {
     let deferrable;
     if (isObject(indexName)) {

--- a/lib/dialects/oracle/schema/oracle-tablecompiler.js
+++ b/lib/dialects/oracle/schema/oracle-tablecompiler.js
@@ -155,7 +155,21 @@ class TableCompiler_Oracle extends TableCompiler {
   }
 
   dropIndexIfExists(columns, indexName) {
-    throw new Error('.dropIndexIfExists() is not supported by oracle');
+    // Oracle accepts DROP INDEX ... IF EXISTS only since 23ai and the 19.28
+    // backport; 19.0-19.27 and 21c error on the clause, so gate on the version.
+    const [major, minor] = String(this.client.version || '')
+      .split('.')
+      .map((part) => parseInt(part, 10));
+    const supportsIfExists = major >= 23 || (major === 19 && minor >= 28);
+    if (!supportsIfExists) {
+      throw new Error(
+        '.dropIndexIfExists() is not supported by oracle before 23ai (19.28)'
+      );
+    }
+    indexName = indexName
+      ? this.formatter.wrap(indexName)
+      : this._indexCommand('index', this.tableNameRaw, columns);
+    this.pushQuery(`drop index if exists ${indexName}`);
   }
 
   unique(columns, indexName) {

--- a/lib/dialects/postgres/schema/pg-tablecompiler.js
+++ b/lib/dialects/postgres/schema/pg-tablecompiler.js
@@ -291,6 +291,16 @@ class TableCompiler_PG extends TableCompiler {
     this.pushQuery(`drop index ${indexName}`);
   }
 
+  dropIndexIfExists(columns, indexName) {
+    indexName = indexName
+      ? this.formatter.wrap(indexName)
+      : this._indexCommand('index', this.tableNameRaw, columns);
+    indexName = this.schemaNameRaw
+      ? `${this.formatter.wrap(this.schemaNameRaw)}.${indexName}`
+      : indexName;
+    this.pushQuery(`drop index if exists ${indexName}`);
+  }
+
   dropUnique(columns, indexName) {
     indexName = indexName
       ? this.formatter.wrap(indexName)

--- a/lib/dialects/redshift/schema/redshift-tablecompiler.js
+++ b/lib/dialects/redshift/schema/redshift-tablecompiler.js
@@ -23,6 +23,10 @@ class TableCompiler_Redshift extends TableCompiler_PG {
     );
   }
 
+  dropIndexIfExists() {
+    throw new Error('.dropIndexIfExists() is not supported by redshift');
+  }
+
   dropPrimaryIfExists() {
     throw new Error('.dropPrimaryIfExists() is not supported by redshift');
   }

--- a/lib/dialects/redshift/schema/redshift-tablecompiler.js
+++ b/lib/dialects/redshift/schema/redshift-tablecompiler.js
@@ -23,6 +23,9 @@ class TableCompiler_Redshift extends TableCompiler_PG {
     );
   }
 
+  // Throws rather than warn-and-no-op like dropIndex above: the whole
+  // ...IfExists family throws on dialects that can't honor it (see
+  // dropUniqueIfExists below), so Redshift stays consistent with its siblings.
   dropIndexIfExists() {
     throw new Error('.dropIndexIfExists() is not supported by redshift');
   }

--- a/lib/dialects/redshift/schema/redshift-tablecompiler.js
+++ b/lib/dialects/redshift/schema/redshift-tablecompiler.js
@@ -23,10 +23,12 @@ class TableCompiler_Redshift extends TableCompiler_PG {
     );
   }
 
-  // Throws rather than warn-and-no-op like dropIndex above: the whole
-  // ...IfExists family throws on dialects that can't honor it (see
-  // dropUniqueIfExists below), so Redshift stays consistent with its siblings.
   dropIndexIfExists() {
+    // TODO(reviewer): this is stricter than dropIndex above, which only
+    // warns and no-ops. It throws to match dropUnique/dropForeign/dropPrimary
+    // -IfExists below (the whole ...IfExists family throws on dialects that
+    // can't honor it). Confirm you want family-consistency here rather than
+    // the more forgiving warn-and-no-op of dropIndex.
     throw new Error('.dropIndexIfExists() is not supported by redshift');
   }
 

--- a/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
+++ b/lib/dialects/sqlite3/schema/sqlite-tablecompiler.js
@@ -145,6 +145,13 @@ class TableCompiler_SQLite3 extends TableCompiler {
     this.pushQuery(`drop index ${indexName}`);
   }
 
+  dropIndexIfExists(columns, indexName) {
+    indexName = indexName
+      ? this.formatter.wrap(indexName)
+      : this._indexCommand('index', this.tableNameRaw, columns);
+    this.pushQuery(`drop index if exists ${indexName}`);
+  }
+
   // Compile a unique key command.
   unique(columns, indexName) {
     let deferrable;

--- a/lib/schema/tablebuilder.js
+++ b/lib/schema/tablebuilder.js
@@ -170,6 +170,7 @@ class TableBuilder {
   'dropUnique',
   'dropUniqueIfExists',
   'dropIndex',
+  'dropIndexIfExists',
   'dropForeign',
   'dropForeignIfExists',
 ].forEach((method) => {

--- a/lib/schema/tablecompiler.js
+++ b/lib/schema/tablecompiler.js
@@ -283,6 +283,10 @@ class TableCompiler {
     this.pushQuery(`drop index${value}`);
   }
 
+  dropIndexIfExists() {
+    throw new Error('Method implemented in the dialect driver');
+  }
+
   dropUnique() {
     throw new Error('Method implemented in the dialect driver');
   }

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -7,6 +7,7 @@ const { isString, isObject } = require('../../../lib/util/is');
 const {
   isPgBased,
   isMysql,
+  isMariaDB,
   isOracle,
   isSQLite,
   isRedshift,
@@ -1678,9 +1679,9 @@ describe('Schema (misc)', () => {
             t.dropIndex('first_name');
           }));
 
-        describe('dropIndexIfExists, except mysql and oracle', () => {
+        describe('dropIndexIfExists, except mysql and oracle (mariadb supported)', () => {
           it('allows dropping a index if exists', async function () {
-            if (isOracle(knex) || isMysql(knex)) {
+            if (isOracle(knex) || (isMysql(knex) && !isMariaDB(knex))) {
               return this.skip();
             }
             await knex.schema.table('test_table_one', (t) => {
@@ -1692,7 +1693,7 @@ describe('Schema (misc)', () => {
           });
 
           it("allows dropping a index if exists, when it doesn't exist", async function () {
-            if (isOracle(knex) || isMysql(knex)) {
+            if (isOracle(knex) || (isMysql(knex) && !isMariaDB(knex))) {
               return this.skip();
             }
             await knex.schema.table('test_table_one', (t) => {

--- a/test/integration2/schema/misc.spec.js
+++ b/test/integration2/schema/misc.spec.js
@@ -1678,6 +1678,29 @@ describe('Schema (misc)', () => {
             t.dropIndex('first_name');
           }));
 
+        describe('dropIndexIfExists, except mysql and oracle', () => {
+          it('allows dropping a index if exists', async function () {
+            if (isOracle(knex) || isMysql(knex)) {
+              return this.skip();
+            }
+            await knex.schema.table('test_table_one', (t) => {
+              t.index('last_name');
+            });
+            await knex.schema.table('test_table_one', (t) => {
+              t.dropIndexIfExists('last_name');
+            });
+          });
+
+          it("allows dropping a index if exists, when it doesn't exist", async function () {
+            if (isOracle(knex) || isMysql(knex)) {
+              return this.skip();
+            }
+            await knex.schema.table('test_table_one', (t) => {
+              t.dropIndexIfExists('foo');
+            });
+          });
+        });
+
         describe('supports partial indexes - postgres, sqlite, and mssql', function () {
           it('allows creating indexes with predicate', async function () {
             if (!(isPostgreSQL(knex) || isMssql(knex) || isSQLite(knex))) {

--- a/test/tape/crossdb-compatibility.js
+++ b/test/tape/crossdb-compatibility.js
@@ -152,4 +152,44 @@ module.exports = function (knex) {
       }
     }
   );
+
+  tape(
+    driverName +
+      ' - create and drop index works in different cases, with dropIndexIfExists',
+    async (t) => {
+      t.plan(1);
+      if (isMysql(knex) || isOracle(knex)) {
+        t.pass('dropIndexIfExists not supported on mysql/oracle');
+        t.end();
+        return;
+      }
+      try {
+        await knex.schema
+          .dropTableIfExists('test_table_drop_index_if_exists')
+          .createTable('test_table_drop_index_if_exists', (t) => {
+            t.integer('id');
+            t.string('first');
+            t.string('second');
+            t.string('third').index();
+            t.string('fourth');
+            t.index(['first', 'second']);
+            t.index('fourth');
+          })
+          .alterTable('test_table_drop_index_if_exists', (t) => {
+            t.dropIndexIfExists('third');
+            t.dropIndexIfExists('fourth');
+            t.dropIndexIfExists(['first', 'second']);
+            t.dropIndexIfExists('foo');
+          })
+          .alterTable('test_table_drop_index_if_exists', (t) => {
+            t.index(['first', 'second']);
+            t.index('third');
+            t.index('fourth');
+          });
+        t.assert(true, 'Creating / dropping / creating index was a success');
+      } finally {
+        t.end();
+      }
+    }
+  );
 };

--- a/test/tape/crossdb-compatibility.js
+++ b/test/tape/crossdb-compatibility.js
@@ -1,7 +1,7 @@
 'use strict';
 const tape = require('tape');
 const { expect } = require('chai');
-const { isOracle, isMysql } = require('../util/db-helpers');
+const { isOracle, isMysql, isMariaDB } = require('../util/db-helpers');
 
 /**
  * Collection of tests for making sure that certain features are cross database compatible
@@ -158,7 +158,7 @@ module.exports = function (knex) {
       ' - create and drop index works in different cases, with dropIndexIfExists',
     async (t) => {
       t.plan(1);
-      if (isMysql(knex) || isOracle(knex)) {
+      if ((isMysql(knex) && !isMariaDB(knex)) || isOracle(knex)) {
         t.pass('dropIndexIfExists not supported on mysql/oracle');
         t.end();
         return;

--- a/test/unit/schema-builder/better-sqlite3.js
+++ b/test/unit/schema-builder/better-sqlite3.js
@@ -350,6 +350,30 @@ describe('BetterSQLite3 SchemaBuilder', function () {
     equal(tableSql[0].sql, 'drop index `foo`');
   });
 
+  it('drop index if exists', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.dropIndexIfExists('foo');
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    equal(tableSql[0].sql, 'drop index if exists `users_foo_index`');
+  });
+
+  it('drop index if exists, custom', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.dropIndexIfExists(null, 'foo');
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    equal(tableSql[0].sql, 'drop index if exists `foo`');
+  });
+
   it('rename table', function () {
     tableSql = client.schemaBuilder().renameTable('users', 'foo').toSQL();
 

--- a/test/unit/schema-builder/cockroachdb.js
+++ b/test/unit/schema-builder/cockroachdb.js
@@ -47,6 +47,28 @@ describe('CockroachDB SchemaBuilder', function () {
     );
   });
 
+  it('drop index if exists', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.dropIndexIfExists('foo');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index if exists "users_foo_index"');
+  });
+
+  it('drop index if exists, custom', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.dropIndexIfExists(null, 'foo');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index if exists "foo"');
+  });
+
   it('drop foreign if exists', function () {
     tableSql = client
       .schemaBuilder()

--- a/test/unit/schema-builder/mssql.js
+++ b/test/unit/schema-builder/mssql.js
@@ -460,6 +460,32 @@ describe('MSSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('DROP INDEX [foo] ON [users]');
   });
 
+  it('test drop index if exists', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function () {
+        this.dropIndexIfExists('foo');
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'DROP INDEX IF EXISTS [users_foo_index] ON [users]'
+    );
+  });
+
+  it('test drop index if exists, custom', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function () {
+        this.dropIndexIfExists(null, 'foo');
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('DROP INDEX IF EXISTS [foo] ON [users]');
+  });
+
   it('test drop foreign', function () {
     tableSql = client
       .schemaBuilder()

--- a/test/unit/schema-builder/mysql.js
+++ b/test/unit/schema-builder/mysql.js
@@ -466,6 +466,17 @@ module.exports = function (dialect) {
       expect(tableSql[0].sql).to.equal('alter table `users` drop index `foo`');
     });
 
+    it('test drop index if exists', function () {
+      expect(() => {
+        client
+          .schemaBuilder()
+          .table('users', function () {
+            this.dropIndexIfExists('foo');
+          })
+          .toSQL();
+      }).to.throw(/not supported/);
+    });
+
     it('test drop foreign', function () {
       tableSql = client
         .schemaBuilder()
@@ -1436,6 +1447,36 @@ module.exports = function (dialect) {
       equal(1, tableSql.length);
       expect(tableSql[0].sql).to.equal(
         'alter table `users` drop index if exists `users_email_unique`'
+      );
+    });
+
+    it('allows dropping an index if exists on MariaDB', function () {
+      client.isMariaDB = true;
+      tableSql = client
+        .schemaBuilder()
+        .table('users', function (t) {
+          t.dropIndexIfExists('foo');
+        })
+        .toSQL();
+
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'alter table `users` drop index if exists `users_foo_index`'
+      );
+    });
+
+    it('allows dropping an index if exists by name on MariaDB', function () {
+      client.isMariaDB = true;
+      tableSql = client
+        .schemaBuilder()
+        .table('users', function (t) {
+          t.dropIndexIfExists(null, 'foo');
+        })
+        .toSQL();
+
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'alter table `users` drop index if exists `foo`'
       );
     });
 

--- a/test/unit/schema-builder/oracle.js
+++ b/test/unit/schema-builder/oracle.js
@@ -257,7 +257,8 @@ describe('Oracle SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('drop index "foo"');
   });
 
-  it('test drop index if exists', function () {
+  it('test drop index if exists throws on oracle before 23ai/19.28', function () {
+    // default `client` is version 18.0
     expect(() => {
       client
         .schemaBuilder()
@@ -266,6 +267,58 @@ describe('Oracle SchemaBuilder', function () {
         })
         .toSQL();
     }).to.throw(/not supported/);
+
+    const oracle1927 = new Oracle_Client({
+      client: 'oracledb',
+      version: '19.27',
+    });
+    expect(() => {
+      oracle1927
+        .schemaBuilder()
+        .table('users', function () {
+          this.dropIndexIfExists('foo');
+        })
+        .toSQL();
+    }).to.throw(/not supported/);
+  });
+
+  it('test drop index if exists on oracle 23ai', function () {
+    const oracle23 = new Oracle_Client({ client: 'oracledb', version: '23.4' });
+    tableSql = oracle23
+      .schemaBuilder()
+      .table('users', function () {
+        this.dropIndexIfExists('foo');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index if exists "users_foo_index"');
+  });
+
+  it('test drop index if exists, custom, on oracle 23ai', function () {
+    const oracle23 = new Oracle_Client({ client: 'oracledb', version: '23.4' });
+    tableSql = oracle23
+      .schemaBuilder()
+      .table('users', function () {
+        this.dropIndexIfExists(null, 'foo');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index if exists "foo"');
+  });
+
+  it('test drop index if exists on oracle 19.28 backport', function () {
+    const oracle1928 = new Oracle_Client({
+      client: 'oracledb',
+      version: '19.28',
+    });
+    tableSql = oracle1928
+      .schemaBuilder()
+      .table('users', function () {
+        this.dropIndexIfExists('foo');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index if exists "users_foo_index"');
   });
 
   it('test drop foreign', function () {

--- a/test/unit/schema-builder/oracle.js
+++ b/test/unit/schema-builder/oracle.js
@@ -257,6 +257,17 @@ describe('Oracle SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('drop index "foo"');
   });
 
+  it('test drop index if exists', function () {
+    expect(() => {
+      client
+        .schemaBuilder()
+        .table('users', function () {
+          this.dropIndexIfExists('foo');
+        })
+        .toSQL();
+    }).to.throw(/not supported/);
+  });
+
   it('test drop foreign', function () {
     tableSql = client
       .schemaBuilder()

--- a/test/unit/schema-builder/oracledb.js
+++ b/test/unit/schema-builder/oracledb.js
@@ -375,7 +375,8 @@ describe('OracleDb SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('drop index "foo"');
   });
 
-  it('test drop index if exists', function () {
+  it('test drop index if exists throws on oracle before 23ai/19.28', function () {
+    // default `client` is version 18.0
     expect(() => {
       client
         .schemaBuilder()
@@ -384,6 +385,58 @@ describe('OracleDb SchemaBuilder', function () {
         })
         .toSQL();
     }).to.throw(/not supported/);
+
+    const oracle1927 = new Oracle_Client({
+      client: 'oracledb',
+      version: '19.27',
+    });
+    expect(() => {
+      oracle1927
+        .schemaBuilder()
+        .table('users', function () {
+          this.dropIndexIfExists('foo');
+        })
+        .toSQL();
+    }).to.throw(/not supported/);
+  });
+
+  it('test drop index if exists on oracle 23ai', function () {
+    const oracle23 = new Oracle_Client({ client: 'oracledb', version: '23.4' });
+    tableSql = oracle23
+      .schemaBuilder()
+      .table('users', function () {
+        this.dropIndexIfExists('foo');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index if exists "users_foo_index"');
+  });
+
+  it('test drop index if exists, custom, on oracle 23ai', function () {
+    const oracle23 = new Oracle_Client({ client: 'oracledb', version: '23.4' });
+    tableSql = oracle23
+      .schemaBuilder()
+      .table('users', function () {
+        this.dropIndexIfExists(null, 'foo');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index if exists "foo"');
+  });
+
+  it('test drop index if exists on oracle 19.28 backport', function () {
+    const oracle1928 = new Oracle_Client({
+      client: 'oracledb',
+      version: '19.28',
+    });
+    tableSql = oracle1928
+      .schemaBuilder()
+      .table('users', function () {
+        this.dropIndexIfExists('foo');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index if exists "users_foo_index"');
   });
 
   it('test drop foreign', function () {

--- a/test/unit/schema-builder/oracledb.js
+++ b/test/unit/schema-builder/oracledb.js
@@ -375,6 +375,17 @@ describe('OracleDb SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('drop index "foo"');
   });
 
+  it('test drop index if exists', function () {
+    expect(() => {
+      client
+        .schemaBuilder()
+        .table('users', function () {
+          this.dropIndexIfExists('foo');
+        })
+        .toSQL();
+    }).to.throw(/not supported/);
+  });
+
   it('test drop foreign', function () {
     tableSql = client
       .schemaBuilder()

--- a/test/unit/schema-builder/postgres.js
+++ b/test/unit/schema-builder/postgres.js
@@ -721,6 +721,42 @@ describe('PostgreSQL SchemaBuilder', function () {
     expect(tableSql[0].sql).to.equal('drop index "mySchema"."users_foo_index"');
   });
 
+  it('drop index if exists', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.dropIndexIfExists('foo');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index if exists "users_foo_index"');
+  });
+
+  it('drop index if exists, custom', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.dropIndexIfExists(null, 'foo');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal('drop index if exists "foo"');
+  });
+
+  it('drop index if exists, with schema', function () {
+    tableSql = client
+      .schemaBuilder()
+      .withSchema('mySchema')
+      .table('users', function (table) {
+        table.dropIndexIfExists('foo');
+      })
+      .toSQL();
+    equal(1, tableSql.length);
+    expect(tableSql[0].sql).to.equal(
+      'drop index if exists "mySchema"."users_foo_index"'
+    );
+  });
+
   it('drop foreign', function () {
     tableSql = client
       .schemaBuilder()

--- a/test/unit/schema-builder/redshift.js
+++ b/test/unit/schema-builder/redshift.js
@@ -402,6 +402,17 @@ describe('Redshift SchemaBuilder', function () {
     equal(0, tableSql.length);
   });
 
+  it('drop index if exists is not supported', function () {
+    expect(() => {
+      client
+        .schemaBuilder()
+        .table('users', function (table) {
+          table.dropIndexIfExists('foo');
+        })
+        .toSQL();
+    }).to.throw(/not supported/);
+  });
+
   it('drop foreign', function () {
     tableSql = client
       .schemaBuilder()

--- a/test/unit/schema-builder/sqlite3.js
+++ b/test/unit/schema-builder/sqlite3.js
@@ -368,6 +368,30 @@ describe('SQLite SchemaBuilder', function () {
     equal(tableSql[0].sql, 'drop index `foo`');
   });
 
+  it('drop index if exists', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.dropIndexIfExists('foo');
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    equal(tableSql[0].sql, 'drop index if exists `users_foo_index`');
+  });
+
+  it('drop index if exists, custom', function () {
+    tableSql = client
+      .schemaBuilder()
+      .table('users', function (table) {
+        table.dropIndexIfExists(null, 'foo');
+      })
+      .toSQL();
+
+    equal(1, tableSql.length);
+    equal(tableSql[0].sql, 'drop index if exists `foo`');
+  });
+
   it('rename table', function () {
     tableSql = client.schemaBuilder().renameTable('users', 'foo').toSQL();
 

--- a/test/unit/schema/tablecompiler-base.js
+++ b/test/unit/schema/tablecompiler-base.js
@@ -32,6 +32,13 @@ describe('Base TableCompiler', () => {
     );
   });
 
+  it('dropIndexIfExists throws by default', () => {
+    const compiler = createCompiler();
+    expect(() => compiler.dropIndexIfExists()).to.throw(
+      /implemented in the dialect driver/
+    );
+  });
+
   it('dropForeignIfExists throws by default', () => {
     const compiler = createCompiler();
     expect(() => compiler.dropForeignIfExists()).to.throw(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2598,6 +2598,10 @@ declare namespace Knex {
       columnNames: string | readonly (string | Raw)[],
       indexName?: string
     ): TableBuilder;
+    dropIndexIfExists(
+      columnNames: string | readonly (string | Raw)[],
+      indexName?: string
+    ): TableBuilder;
     dropTimestamps(useCamelCase?: boolean): TableBuilder;
     dropChecks(checkConstraintNames: string | string[]): TableBuilder;
     queryContext(context: any): TableBuilder;


### PR DESCRIPTION
`dropIndex` was the only `drop*` schema method without an `IfExists` sibling — `dropUnique`/`dropForeign`/`dropPrimary` all have one. So dropping a maybe-absent plain index couldn't go through the builder; callers hand-rolled per-dialect SQL. This adds `dropIndexIfExists(columns, [indexName])`, mirroring `dropUniqueIfExists` (#6069): emit the dialect's native `DROP INDEX IF EXISTS` where it exists, otherwise throw a "not supported" error. No introspection — consistent with knex's string-builder design.

Closes #6467.

### Support matrix

- **postgres / sqlite / better-sqlite3 / mssql**: native `IF EXISTS`
- **cockroachdb**: inherits the postgres compiler (consistent with its existing `dropIndex`, which also inherits pg — note this is the prefix form, not the `table@index` shape the issue guessed)
- **mariadb**: native, via the shared mysql client's `isMariaDB` branch
- **oracle / oracledb**: native since **23ai**, backported to **19c (19.28)** — version-gated; older releases (19.0–19.27, 21c, <19) and unknown version stay on the throw path
- **mysql / redshift**: throw "not supported"

### Why MySQL throws (and stays that way)

MySQL has no `IF EXISTS` on `DROP INDEX` at any version — it's the only `DROP` statement that never got the clause. Long-standing upstream requests, still unimplemented:

- https://bugs.mysql.com/bug.php?id=23543 — "add feature drop index if exists"
- https://bugs.mysql.com/bug.php?id=35214 — `ALTER TABLE … DROP INDEX … IF EXISTS`
- https://bugs.mysql.com/bug.php?id=15287 / https://bugs.mysql.com/bug.php?id=69259 — broader `IF EXISTS` asks

Only MariaDB forked it in, which is why the `isMariaDB` branch is the one live path on the shared client.

### Verification

Native paths (pg, pgnative, sqlite3, better-sqlite3, mssql, cockroachdb, **and mariadb**) execute real DDL in the integration + crossdb suites — I widened the `isMysql` skip to `(isMysql && !isMariaDB) || isOracle` so MariaDB's native clause is actually exercised against a live server, not just unit-tested. Oracle's two branches (23ai/19.28 emit vs older throw) are unit-tested with version-injected clients; live integration still skips Oracle because the CI image is 18c XE.

### Open questions / out of scope

- The CI Oracle image is **18c XE**, so the Oracle native path has no live coverage — only unit. Bumping the image to 23ai (or a 19.28+ XE) would close that gap; left out of this PR.
- The same MariaDB live-coverage widening could be applied to the existing `dropUniqueIfExists` tests (same `isMysql` skip gap) — not touched here to keep scope tight.
- **Redshift strictness** (flagged with a `TODO(reviewer)` in `redshift-tablecompiler.js`): Redshift has no secondary indexes at all, so `dropIndexIfExists` throws — matching `dropUnique/dropForeign/dropPrimaryIfExists`, the whole `...IfExists` family. But note this is **stricter than the base `dropIndex`**, which only warns and no-ops on Redshift. I chose family-consistency (throw) over mirroring `dropIndex` (warn-and-no-op); a reasonable argument exists that a `dropIfExists` call should be the *most* forgiving and no-op instead. Reviewer's call — happy to flip it.


NB: This work has been mostly done using Claude Opus as it is a simple port of `dropUniqueIfExists` hence is not risky at all. As mentioned above, reviewing it, I realized `MariaDB` wasn't tested live in `dropUniqueIfExists` and `Oracle 19.28+` support wasn't considered in https://github.com/knex/knex/issues/6467

Assisted-by: Claude:claude-opus-4-8[1m]