### PR TITLE
fix(redshift): whereJsonPath throws because it reads statement.path instead of jsonPath (#6351)

### DIFF
--- a/lib/dialects/redshift/query/redshift-querycompiler.js
+++ b/lib/dialects/redshift/query/redshift-querycompiler.js
@@ -6,6 +6,7 @@ const QueryCompiler_PG = require('../../postgres/query/pg-querycompiler');
 const identity = require('lodash/identity');
 const {
   columnize: columnize_,
+  operator: operator_,
 } = require('../../../formatter/wrappingFormatter');
 
 class QueryCompiler_Redshift extends QueryCompiler_PG {
@@ -139,12 +140,18 @@ class QueryCompiler_Redshift extends QueryCompiler_PG {
   }
 
   whereJsonPath(statement) {
-    return this._whereJsonPath(
-      'json_extract_path_text',
-      Object.assign({}, statement, {
-        path: this.client.toPathForJson(statement.path),
-      })
-    );
+    return `json_extract_path_text(${this._columnClause(
+      statement
+    )}, ${this.client.toPathForJson(
+      statement.jsonPath,
+      this.builder,
+      this.bindingsHolder
+    )}) ${operator_(
+      statement.operator,
+      this.builder,
+      this.client,
+      this.bindingsHolder
+    )} ${this._jsonValueClause(statement)}`;
   }
 
   whereJsonSupersetOf(statement) {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -11965,6 +11965,10 @@ describe('QueryBuilder', () => {
               sql: 'select * from "users" where json_extract_path("address", ?, ?)::int > ? or json_extract_path("address", ?, ?)::int < ?',
               bindings: ['street', 'number', 5, 'street', 'number', 8],
             },
+            'pg-redshift': {
+              sql: 'select * from "users" where json_extract_path_text("address", ?, ?) > ? or json_extract_path_text("address", ?, ?) < ?',
+              bindings: ['street', 'number', 5, 'street', 'number', 8],
+            },
           }
         );
       });


### PR DESCRIPTION
## Fixes #6351

`whereJsonPath()` throws a `TypeError` on the **redshift** client:

```js
knex({ client: 'redshift' })('users')
  .whereJsonPath('json_col', '$.age', '>', 18)
  .toSQL();
// TypeError: Cannot read properties of undefined (reading 'replace')
```

### Root cause

The query builder stores the JSON path under `statement.jsonPath` (see `Builder.prototype._whereJsonWrappedValue` → `whereJsonClause.jsonPath = ...`), and the base `_whereJsonPath` reads `statement.jsonPath`. The Postgres compiler does the same.

The Redshift compiler, however, read `statement.path` (which is `undefined`):

```js
whereJsonPath(statement) {
  return this._whereJsonPath(
    'json_extract_path_text',
    Object.assign({}, statement, {
      path: this.client.toPathForJson(statement.path), // statement.path === undefined
    })
  );
}
```

So `toPathForJson(undefined)` calls `.replace(...)` on `undefined` and throws. (As noted in the issue, this also breaks generating the docs for the `whereJsonPath` snippet under Redshift.)

There were two further problems with delegating to the base `_whereJsonPath`:
- Redshift's `toPathForJson(jsonPath, builder, bindingsHolder)` needs the `builder`/`bindingsHolder` to bind each path segment — they were not passed.
- The base `_whereJsonPath` re-parameterizes the path via `_jsonPathWrap`, which would re-wrap the already-segmented path string.

### Fix

Build the `json_extract_path_text(...)` clause directly, mirroring the already-correct **CockroachDB** compiler (`crdb-querycompiler.js`), reading `statement.jsonPath` and forwarding `this.builder` / `this.bindingsHolder` to `toPathForJson` so the path segments are parameterized correctly.

Resulting SQL (now consistent with the other dialects' segmented output, e.g. cockroachdb):

```sql
select * from "users"
where json_extract_path_text("address", ?, ?) > ?
   or json_extract_path_text("address", ?, ?) < ?
-- bindings: ['street', 'number', 5, 'street', 'number', 8]
```

### Tests

Added a `pg-redshift` expectation to the existing `whereJsonPath` unit test (`test/unit/query/builder.js`, "where json column is equals to the value returned by a json path"). The test fails without the fix (the exact `TypeError` above) and passes with it. The full `test/unit/query/builder.js` suite (470 tests) passes, and eslint + prettier are clean.