### PR TITLE
fix(postgres): use global replace in toPathForJson so deep json paths are not corrupted

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -337,8 +337,8 @@ class Client_PG extends Client {
       '{' +
       jsonPath
         .replace(/^(\$\.)/, '') // remove the first dollar
-        .replace('.', ',')
-        .replace(/\[([0-9]+)]/, ',$1') + // transform [number] to ,number
+        .replace(/\./g, ',')
+        .replace(/\[([0-9]+)]/g, ',$1') + // transform [number] to ,number
       '}'
     );
   }

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -11740,6 +11740,32 @@ describe('QueryBuilder', () => {
         );
       });
 
+      it('should set json value with deeply nested path', () => {
+        testsql(qb().jsonSet('address', '$.a.b.c', '5').from('users'), {
+          pg: {
+            sql: 'select jsonb_set("address", ?, ?) from "users"',
+            bindings: ['{a,b,c}', '5'],
+          },
+          cockroachdb: {
+            sql: 'select jsonb_set("address", ?, ?) from "users"',
+            bindings: ['{a,b,c}', '5'],
+          },
+        });
+      });
+
+      it('should set json value with multiple array indices', () => {
+        testsql(qb().jsonSet('address', '$.a[0].b[1]', '5').from('users'), {
+          pg: {
+            sql: 'select jsonb_set("address", ?, ?) from "users"',
+            bindings: ['{a,0,b,1}', '5'],
+          },
+          cockroachdb: {
+            sql: 'select jsonb_set("address", ?, ?) from "users"',
+            bindings: ['{a,0,b,1}', '5'],
+          },
+        });
+      });
+
       it('should set json value with nested function', async function () {
         testsql(
           qb()


### PR DESCRIPTION
## Problem

On PostgreSQL, `jsonSet()` / `jsonInsert()` / `jsonRemove()` silently corrupt the JSON path when it has 3+ levels or 2+ array indices.

`toPathForJson` in `lib/dialects/postgres/index.js` converts a JSONPath like `$.a.b.c` into a PG text-array path like `{a,b,c}`. It did this with two **non-global** replaces, so only the first dot and the first array index were converted:

```js
.replace('.', ',')              // only the FIRST dot
.replace(/\[([0-9]+)]/, ',$1')  // only the FIRST array index
```

Expected vs actual PG path:

| input         | expected    | actual (before fix) |
| ------------- | ----------- | ------------------- |
| `$.a.b.c`     | `{a,b,c}`   | `{a,b.c}`           |
| `$.a[0].b[1]` | `{a,0,b,1}` | `{a,0,b[1]}`        |

Because `jsonb_set` defaults to `create_if_missing = true`, Postgres does not error on the malformed path. Instead the value is written to a bogus literal key. Verified on PostgreSQL 18:

```
jsonSet('j', '$.a.b.c', 'NEW')
-- writes: {"a": {"b": {"c": 1}, "b.c": "NEW"}}
```

The original `{"a":{"b":{"c":...}}}` is untouched and a stray `"b.c"` key appears at the wrong level. The write succeeds, so the corruption is silent.

## Root cause

`String.prototype.replace` with a string first argument, and with a regex that lacks the `g` flag, only replaces the first match. One- and two-level paths happen to have at most one dot and one bracket, so they were correct by accident, which is why existing tests passed.

## Fix

Add the `g` flag to both transforms so every segment is converted:

```js
.replace(/\./g, ',')
.replace(/\[([0-9]+)]/g, ',$1')
```

This is backward compatible: one- and two-level paths (the only depths covered by existing tests) produce byte-identical output. The Redshift sibling dialect already does this correctly by splitting on every `.`, so this aligns the two.

## Tests

Added two SQL-generation assertions for `pg` and `cockroachdb` covering a deep path and multiple array indices.

- Before the fix both fail: `expected [ '{a,b.c}', '5' ]` and `expected [ '{a,0,b[1]}', '5' ]`.
- After the fix both pass.

Offline SQL-generation suites green (`test/unit/query/builder.js` and the dialect schema-builder units), `eslint` and `prettier --check` clean on the changed files.
