### PR TITLE
fix: compile having callbacks with having clauses

### DIFF
--- a/lib/query/querycompiler.js
+++ b/lib/query/querycompiler.js
@@ -688,12 +688,41 @@ class QueryCompiler {
   havingWrapped(statement) {
     const val = rawOrFn_(
       statement.value,
-      'where',
+      'havingWrappedConditions',
       this.builder,
       this.client,
       this.bindingsHolder
     );
-    return (val && this._not(statement, '') + '(' + val.slice(6) + ')') || '';
+    return (val && this._not(statement, '') + '(' + val + ')') || '';
+  }
+
+  havingWrappedConditions() {
+    const sql = [];
+
+    for (const stmt of this.builder._statements) {
+      if (stmt.grouping !== 'where' && stmt.grouping !== 'having') {
+        continue;
+      }
+
+      if (
+        stmt.grouping === 'where' &&
+        Object.prototype.hasOwnProperty.call(stmt, 'value') &&
+        helpers.containsUndefined(stmt.value)
+      ) {
+        this.undefinedBindingsInfo.push(stmt.column);
+        this._undefinedInWhereClause = true;
+      }
+
+      const val = this[stmt.type](stmt);
+      if (val) {
+        if (sql.length > 0) {
+          sql.push(stmt.bool);
+        }
+        sql.push(val);
+      }
+    }
+
+    return sql.join(' ');
   }
 
   havingBasic(statement) {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -3601,6 +3601,26 @@ describe('QueryBuilder', () => {
     );
   });
 
+  it('nested having with having callbacks', () => {
+    testsql(
+      qb()
+        .select('*')
+        .from('users')
+        .having(function () {
+          this.having('email', '>', 10);
+          this.orHaving('email', '=', 7);
+        }),
+      {
+        mysql: 'select * from `users` having (`email` > ? or `email` = ?)',
+        mssql: 'select * from [users] having ([email] > ? or [email] = ?)',
+        pg: 'select * from "users" having ("email" > ? or "email" = ?)',
+        'pg-redshift':
+          'select * from "users" having ("email" > ? or "email" = ?)',
+        oracledb: 'select * from "users" having ("email" > ? or "email" = ?)',
+      }
+    );
+  });
+
   it('nested or havings', () => {
     testsql(
       qb()


### PR DESCRIPTION
## Summary

Fixes #6247.

`having(function () { this.having(...) })` and direct `havingWrapped()` callbacks previously omitted their HAVING clauses because wrapped callbacks were compiled only through the `where` compiler path. This compiles wrapped HAVING callback conditions from both `where` and `having` statements while preserving the existing `.where()` workaround behavior.

## Changes

- Add a wrapped HAVING condition compiler that preserves callback statement order across `where` and `having` groups.
- Add regression coverage for `.having()` and `.orHaving()` inside a HAVING callback.

## Testing

- `npm install --package-lock=false`
- `npx mocha --exit -t 10000 --config test/mocha-unit-config-test.js --grep 'nested having'`
- `npx eslint --cache lib/query/querycompiler.js test/unit/query/builder.js`
- `npx prettier --check lib/query/querycompiler.js test/unit/query/builder.js`
- `npm run test:unit-only -- --grep 'havings|nested having|nested or havings'`

I did not run the full database integration suite because this change is limited to SQL generation and the focused unit coverage covers the affected compiler path.
