### PR TITLE
fix(mysql): handle lowercase INFORMATION_SCHEMA keys in columnInfo

### DIFF
--- a/lib/dialects/mysql/query/mysql-querycompiler.js
+++ b/lib/dialects/mysql/query/mysql-querycompiler.js
@@ -151,12 +151,21 @@ class QueryCompiler_MySQL extends QueryCompiler {
       bindings: [table, this.client.database()],
       output(resp) {
         const out = resp.reduce(function (columns, val) {
-          columns[val.COLUMN_NAME] = {
-            defaultValue:
-              val.COLUMN_DEFAULT === 'NULL' ? null : val.COLUMN_DEFAULT,
-            type: val.DATA_TYPE,
-            maxLength: val.CHARACTER_MAXIMUM_LENGTH,
-            nullable: val.IS_NULLABLE === 'YES',
+          // mysql2 can return INFORMATION_SCHEMA column names in lowercase
+          // depending on server configuration, so fall back to lowercase keys.
+          const columnDefault =
+            val.COLUMN_DEFAULT !== undefined
+              ? val.COLUMN_DEFAULT
+              : val.column_default;
+          const maxLength =
+            val.CHARACTER_MAXIMUM_LENGTH !== undefined
+              ? val.CHARACTER_MAXIMUM_LENGTH
+              : val.character_maximum_length;
+          columns[val.COLUMN_NAME || val.column_name] = {
+            defaultValue: columnDefault === 'NULL' ? null : columnDefault,
+            type: val.DATA_TYPE || val.data_type,
+            maxLength,
+            nullable: (val.IS_NULLABLE || val.is_nullable) === 'YES',
           };
           return columns;
         }, {});

--- a/test/unit/dialects/mysql.js
+++ b/test/unit/dialects/mysql.js
@@ -88,4 +88,62 @@ describe('MySQL unit tests', () => {
       );
     }
   });
+
+  it('columnInfo() handles lowercase INFORMATION_SCHEMA keys from mysql2 #6391', () => {
+    const { output } = qb('users').columnInfo().toSQL();
+
+    const expected = {
+      id: {
+        defaultValue: null,
+        type: 'int',
+        maxLength: null,
+        nullable: false,
+      },
+      email: {
+        defaultValue: null,
+        type: 'varchar',
+        maxLength: 255,
+        nullable: true,
+      },
+    };
+
+    // mysql2 may return INFORMATION_SCHEMA column names in lowercase
+    // depending on server configuration.
+    const lowercaseResp = [
+      {
+        column_name: 'id',
+        column_default: null,
+        data_type: 'int',
+        character_maximum_length: null,
+        is_nullable: 'NO',
+      },
+      {
+        column_name: 'email',
+        column_default: 'NULL',
+        data_type: 'varchar',
+        character_maximum_length: 255,
+        is_nullable: 'YES',
+      },
+    ];
+
+    const uppercaseResp = [
+      {
+        COLUMN_NAME: 'id',
+        COLUMN_DEFAULT: null,
+        DATA_TYPE: 'int',
+        CHARACTER_MAXIMUM_LENGTH: null,
+        IS_NULLABLE: 'NO',
+      },
+      {
+        COLUMN_NAME: 'email',
+        COLUMN_DEFAULT: 'NULL',
+        DATA_TYPE: 'varchar',
+        CHARACTER_MAXIMUM_LENGTH: 255,
+        IS_NULLABLE: 'YES',
+      },
+    ];
+
+    expect(output(lowercaseResp)).to.eql(expected);
+    expect(output(uppercaseResp)).to.eql(expected);
+  });
 });


### PR DESCRIPTION
#6407 fixed `renameColumn` / `dropFKRefs` / `createFKRefs` for the case where mysql2 returns `INFORMATION_SCHEMA` column names in lowercase (#6391). `columnInfo()` reads from the same catalog (`select * from information_schema.columns`) but still builds its result map from uppercase keys only:

```js
columns[val.COLUMN_NAME] = {
  defaultValue: val.COLUMN_DEFAULT === 'NULL' ? null : val.COLUMN_DEFAULT,
  type: val.DATA_TYPE,
  maxLength: val.CHARACTER_MAXIMUM_LENGTH,
  nullable: val.IS_NULLABLE === 'YES',
};
```

Under the same server configuration that broke the FK paths, every `val.COLUMN_NAME` is `undefined`, so `columnInfo()` returns `{ undefined: { type: undefined, maxLength: undefined, nullable: false } }` instead of the column map. MariaDB inherits this compiler, so it is affected too.

This applies the same lowercase fallback to that read site.

One deliberate choice: I used `!== undefined` (not `||`) for `COLUMN_DEFAULT` and `CHARACTER_MAXIMUM_LENGTH`. Those are legitimately falsy on the uppercase path (no default, and non-string types report a `null` max length), and a plain `||` would turn an existing `null` into `undefined`. The other three fields are never falsy-meaningful, so `||` is fine there.

Added a unit test in `test/unit/dialects/mysql.js` that drives the compiled `output()` with both lowercase and uppercase responses and asserts they produce the same map. It fails on the current code with `expected { undefined: ... } to deeply equal ...` and passes with the fix; the uppercase result is unchanged.
