### PR TITLE
fix(types): add `modify` callback args inferance.

### DIFF
--- a/test-tsd/tsd-tests8.test-d.ts
+++ b/test-tsd/tsd-tests8.test-d.ts
@@ -1,5 +1,5 @@
 import { knex, Knex } from '../types';
-import { expectType } from 'tsd';
+import { expectType, expectError } from 'tsd';
 
 const clientConfig = {
   client: 'sqlite3',
@@ -425,6 +425,45 @@ const main = async () => {
       .modify<User, Pick<User, 'id' | 'age'>>(withAge);
 
     expectType<Pick<User, 'id' | 'age'>>(r);
+  }
+
+  {
+    const withAsAge = (
+      queryBuilder: Knex.QueryBuilder<User, any[]>,
+      { as }: { as: string }
+    ) => queryBuilder.select({ age: as });
+
+    // $ExpectType Pick<User, "id" | "age">
+    const r = await knexInstance
+      .table<User>('users')
+      .select('id')
+      .modify<User, Pick<User, 'id' | 'age'>>(withAsAge, { as: 'userAge' });
+
+    expectType<Pick<User, 'id' | 'age'>>(r);
+  }
+
+  {
+    const withAsAge = (
+      queryBuilder: Knex.QueryBuilder<User, any[]>,
+      { as }: { as: string }
+    ) => queryBuilder.select({ age: as });
+
+    const r = await knexInstance
+      .table<User>('users')
+      .select('id')
+      // No explicit type params → TRecord2/TResult2 default to any, args inferred
+      .modify(withAsAge, { as: 'userAge' });
+
+    expectType<any>(r);
+    expectError(
+      knexInstance
+        .table<User>('users')
+        .select('id')
+        .modify(withAsAge, { as: 123 })
+    );
+    expectError(
+      knexInstance.table<User>('users').select('id').modify(withAsAge)
+    );
   }
 
   // With:

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -998,9 +998,19 @@ declare namespace Knex {
         : DbRecordArr<TRecord> | ReadonlyArray<DbRecordArr<TRecord>>
     ): QueryBuilder<TRecord, TResult2>;
 
-    modify<TRecord2 extends {} = any, TResult2 extends {} = any>(
-      callback: QueryCallbackWithArgs<TRecord, any>,
-      ...args: any[]
+    modify<
+      TRecord2 extends {} = any,
+      TResult2 extends {} = any,
+      TCallback extends (...args: any[]) => any = any
+    >(
+      callback: TCallback,
+      ...args: TCallback extends (
+        this: any,
+        builder: any,
+        ...args: infer TArgs
+      ) => any
+        ? TArgs
+        : []
     ): QueryBuilder<TRecord2, TResult2>;
     update<
       K1 extends StrKey<ResolveTableType<TRecord, 'update'>>,


### PR DESCRIPTION
it allows to auto infer modify callback args type.

<img width="1322" height="458" alt="Screenshot 2026-06-30 at 13-46-02 —" src="https://github.com/user-attachments/assets/2f617f31-2e09-49af-9bf1-bdd8cfe42e19" />


### TS limitation

When the user provides `TRecord2/TResult2`, it won't auto infer the args type.

It keeps the same behaviour as it is now.
<img width="1162" height="232" alt="Screenshot 2026-06-30 at 13-48-38 —" src="https://github.com/user-attachments/assets/1e8672ad-f1a9-4e8f-8559-cd304f69e7ce" />
