### PR TITLE
fix(mysql): #3012 - handle case-insensitive text column values

### DIFF
--- a/lib/dialects/mysql/schema/mysql-columncompiler.js
+++ b/lib/dialects/mysql/schema/mysql-columncompiler.js
@@ -40,7 +40,8 @@ class ColumnCompiler_MySQL extends ColumnCompiler {
   }
 
   text(column) {
-    switch (column) {
+    const normalizedText = column ? column.toLowerCase() : column;
+    switch (normalizedText) {
       case 'medium':
       case 'mediumtext':
         return 'mediumtext';

--- a/test/unit/schema-builder/mysql.js
+++ b/test/unit/schema-builder/mysql.js
@@ -904,6 +904,20 @@ module.exports = function (dialect) {
       expect(tableSql[0].sql).to.equal('alter table `users` add `foo` text');
     });
 
+    it('test adding case-insensitive text types', function () {
+      tableSql = client
+        .schemaBuilder()
+        .table('users', function () {
+          this.text('foo', 'MEDIUMTEXT');
+        })
+        .toSQL();
+
+      equal(1, tableSql.length);
+      expect(tableSql[0].sql).to.equal(
+        'alter table `users` add `foo` mediumtext'
+      );
+    });
+
     it('test adding big integer', function () {
       tableSql = client
         .schemaBuilder()


### PR DESCRIPTION
Fixes #3012.

MySQL is case-insensitive for SQL keywords and data types, but Knex only recognised lowercase values correctly in the MySQL column compiler. This means that function calls like 

```js
table.text('foo','MEDIUMTEXT');
```

would incorrectly fall back to `text` instead of `mediumtext`.

*Fix*: Added a ternary operator to normalise the `column` input to lowercase:
```js
const normalisedText = column ? column.toLowerCase() : column;
```
and then run the switch statement with `normalizedText` instead of `column`.

*Testing*: Added new regression test in `test\unit\schema-builder\mysql.js` to 'test adding case-insensitive text types'.

