### PR TITLE
fix(types): #6513 - infer type of aliased raw in keyed select

### DIFF
--- a/test-tsd/select.test-d.ts
+++ b/test-tsd/select.test-d.ts
@@ -46,6 +46,12 @@ const main = async () => {
     await knex('users_composite').select([knex.ref('name'), knex.ref('id')])
   );
 
+  expectType<{ identifier: string }[]>(
+    await knex<User>('users').select({
+      identifier: knex.raw<string>('id::text'),
+    })
+  );
+
   expectType<Pick<User, 'id'> | undefined>(
     await knex.first('id').from<User>('users')
   );

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -90,6 +90,10 @@ type PartialOrAny<TBase, TKeys> = Boxed<TKeys> extends Boxed<never>
 type MappedAliasType<TBase, TAliasMapping> = {} & {
   [K in keyof TAliasMapping]: TAliasMapping[K] extends keyof TBase
     ? TBase[TAliasMapping[K]]
+    : TAliasMapping[K] extends Knex.Ref<any, any>
+    ? any
+    : TAliasMapping[K] extends Knex.Raw<infer TValue>
+    ? TValue
     : any;
 };
 


### PR DESCRIPTION
`select({ alias: knex.raw<string>('foo::text') })` typed the alias as `any`, because `MappedAliasType` only resolved alias values that are column names of the base record. It now falls back to the raw's own result type, so a typed raw keeps that type through the alias. `knex.ref()` in the same position still resolves to `any`, as before.

Fixes #6513
