### PR TITLE
fix(oracledb): #6519, don't drop connections that aren't from a session pool

### DIFF
--- a/lib/dialects/oracledb/index.js
+++ b/lib/dialects/oracledb/index.js
@@ -170,7 +170,7 @@ class Client_Oracledb extends Client_Oracle {
    * @param {import('oracledb').Connection} connection
    */
   destroyRawConnection(connection) {
-    return connection.release({ drop: true });
+    return connection.release();
   }
 
   // Wraps a native oracledb pool with the interface knex expects from this.pool.

--- a/test/unit/client/connection-pool.js
+++ b/test/unit/client/connection-pool.js
@@ -404,4 +404,68 @@ describe('connectionPool config option', () => {
       expect(connection).to.equal(mockConnection);
     });
   });
+
+  // ── Oracledb adapter ──────────────────────────────────────────────
+
+  describe('Oracledb wrapNativePool', () => {
+    let OracledbClient;
+
+    before(() => {
+      try {
+        OracledbClient = require('../../../lib/dialects/oracledb/index');
+      } catch (_e) {
+        // oracledb driver may not be installed in test env
+      }
+    });
+
+    it('acquire calls nativePool.getConnection and assigns __knexUid', async function () {
+      if (!OracledbClient) this.skip();
+
+      const mockConnection = {};
+      const mockPool = { getConnection: sinon.stub().resolves(mockConnection) };
+
+      const client = Object.create(OracledbClient.prototype);
+      const adapter = client.wrapNativePool(mockPool);
+
+      const connection = await adapter.acquire().promise;
+
+      expect(mockPool.getConnection.calledOnce).to.be.true;
+      expect(connection.__knexUid).to.be.a('string');
+      expect(connection).to.equal(mockConnection);
+    });
+
+    it('release closes healthy connections back into the pool', function () {
+      if (!OracledbClient) this.skip();
+
+      const conn = { close: sinon.stub().callsFake((opts, cb) => cb(null)) };
+      const client = Object.create(OracledbClient.prototype);
+      const adapter = client.wrapNativePool({});
+
+      expect(adapter.release(conn)).to.be.true;
+      expect(conn.close.firstCall.args[0]).to.deep.equal({});
+    });
+
+    it('release drops disposed connections from the pool', function () {
+      if (!OracledbClient) this.skip();
+
+      const conn = {
+        close: sinon.stub().callsFake((opts, cb) => cb(null)),
+        __knex__disposed: 'err',
+      };
+      const client = Object.create(OracledbClient.prototype);
+      const adapter = client.wrapNativePool({});
+
+      expect(adapter.release(conn)).to.be.true;
+      expect(conn.close.firstCall.args[0]).to.deep.equal({ drop: true });
+    });
+
+    it('release returns false when connection has no close method', function () {
+      if (!OracledbClient) this.skip();
+
+      const client = Object.create(OracledbClient.prototype);
+      const adapter = client.wrapNativePool({});
+
+      expect(adapter.release({})).to.be.false;
+    });
+  });
 });

--- a/test/unit/dialects/oracledb.js
+++ b/test/unit/dialects/oracledb.js
@@ -72,6 +72,22 @@ describe('OracleDB Unit Tests', () => {
         }
       });
     });
+
+    describe('Connection Destruction', () => {
+      it('should not drop connections that were not acquired from a session pool', async () => {
+        const client = new Oracle_Client({ client: 'oracledb' });
+        const releaseOptions = [];
+        const connection = {
+          release: async function (options) {
+            releaseOptions.push(options);
+          },
+        };
+
+        await client.destroyRawConnection(connection);
+
+        expect(releaseOptions).to.deep.equal([undefined]);
+      });
+    });
   });
 
   describe('Name Generation', () => {

--- a/test/unit/dialects/oracledb.js
+++ b/test/unit/dialects/oracledb.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
 const Oracle_Client = require('../../../lib/dialects/oracledb');
 const { NameHelper } = require('../../../lib/dialects/oracle/utils');
 
@@ -76,16 +77,11 @@ describe('OracleDB Unit Tests', () => {
     describe('Connection Destruction', () => {
       it('should not drop connections that were not acquired from a session pool', async () => {
         const client = new Oracle_Client({ client: 'oracledb' });
-        const releaseOptions = [];
-        const connection = {
-          release: async function (options) {
-            releaseOptions.push(options);
-          },
-        };
+        const release = sinon.spy(async () => {});
 
-        await client.destroyRawConnection(connection);
+        await client.destroyRawConnection({ release });
 
-        expect(releaseOptions).to.deep.equal([undefined]);
+        sinon.assert.calledOnceWithExactly(release);
       });
     });
   });


### PR DESCRIPTION
Fixes #6519

The default pool creates connections with `oracledb.getConnection()`, so they are standalone. Passing `{ drop: true }` to `release()` on one of those fails with `DPI-1011: connection was not acquired from a session pool` in thick mode, and the connection stays open. The drop flag only makes sense for connections taken from a native session pool, which is already handled separately in `wrapNativePool`.
