### PR TITLE
fix(pg,cockroachdb): convert every segment of a nested json path

### DIFF
--- a/lib/dialects/cockroachdb/index.js
+++ b/lib/dialects/cockroachdb/index.js
@@ -67,7 +67,7 @@ class Client_CockroachDB extends Client_PostgreSQL {
   toArrayPathFromJsonPath(jsonPath, builder, bindingsHolder) {
     return jsonPath
       .replace(/^(\$\.)/, '') // remove the first dollar
-      .replace(/\[([0-9]+)]/, '.$1')
+      .replace(/\[([0-9]+)]/g, '.$1')
       .split('.')
       .map(
         function (v) {

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -337,8 +337,8 @@ class Client_PG extends Client {
       '{' +
       jsonPath
         .replace(/^(\$\.)/, '') // remove the first dollar
-        .replace('.', ',')
-        .replace(/\[([0-9]+)]/, ',$1') + // transform [number] to ,number
+        .replace(/\./g, ',')
+        .replace(/\[([0-9]+)]/g, ',$1') + // transform [number] to ,number
       '}'
     );
   }

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -11693,6 +11693,18 @@ describe('QueryBuilder', () => {
         });
       });
 
+      it('should extract json value with multiple array indexes', () => {
+        testsql(
+          qb().jsonExtract('name', '$.names[0].aliases[1]').from('users'),
+          {
+            cockroachdb: {
+              sql: 'select json_extract_path("name", ?, ?, ?, ?) from "users"',
+              bindings: ['names', '0', 'aliases', '1'],
+            },
+          }
+        );
+      });
+
       it('should extract json value with alias', () => {
         testsql(qb().jsonExtract('json_col', '$.name', 'name').from('users'), {
           pg: {

--- a/test/unit/query/builder.js
+++ b/test/unit/query/builder.js
@@ -11851,6 +11851,24 @@ describe('QueryBuilder', () => {
         );
       });
 
+      it('should set json value with a deeply nested path', () => {
+        testsql(
+          qb()
+            .jsonSet('address', '$.street.numbers[2].codes[1]', '5')
+            .from('users'),
+          {
+            pg: {
+              sql: 'select jsonb_set("address", ?, ?) from "users"',
+              bindings: ['{street,numbers,2,codes,1}', '5'],
+            },
+            cockroachdb: {
+              sql: 'select jsonb_set("address", ?, ?) from "users"',
+              bindings: ['{street,numbers,2,codes,1}', '5'],
+            },
+          }
+        );
+      });
+
       it('should set json value with pg path syntax', async function () {
         testsql(
           qb().jsonSet('address', '{street,numbers,2}', '5').from('users'),


### PR DESCRIPTION
Fixes #6522

`toPathForJson()` in the Postgres dialect used `String.prototype.replace` with a string pattern, which only replaces the first match. A path like `$.a.b.c.d` compiled to `{a,b.c.d}` instead of `{a,b,c,d}`, so `jsonSet()` wrote a literal `"b.c.d"` key rather than descending into the nested object. The same applied to the second replace for array indexes, so only the first `[n]` was converted.

CockroachDB has its own `toArrayPathFromJsonPath()` with the same non-global replace on array indexes, so `$.a[0].b[1]` leaked `b[1]` as a literal key. That one feeds `jsonExtract` and `whereJsonPath`, so it is a separate path from the one the issue reports but the same mistake.

Both replaces are now global. Added unit tests covering a deep Postgres path and a CockroachDB path with two array indexes.
