### PR TITLE
fix(types): #6528 - accept readonly column lists in with

### DIFF
--- a/test-tsd/types.test-d.ts
+++ b/test-tsd/types.test-d.ts
@@ -183,21 +183,25 @@ knexInstance.with(
   'sql with positional bindings',
   [1]
 );
-
-// the column list is only read, so readonly arrays and tuples are accepted too
-const readonlyColumnList = ['id', 'parent_id'] as const;
-knexInstance.withRecursive(
-  'readonly columnList+callback',
-  readonlyColumnList,
-  (qb) => qb.select('id').from('table')
+// the column list is never mutated, so a readonly one works everywhere too
+knexInstance.with(
+  'readonlyColumnList+qb',
+  ['columnName'] as const,
+  knexInstance.select('column').from('table')
 );
-knexInstance.withRecursive(
-  'readonly columnList+qb',
-  readonlyColumnList,
-  knexInstance.select('id').from('table')
+knexInstance.with(
+  'readonlyColumnList+callback',
+  ['columnName'] as const,
+  (qb) => qb.select('column').from('table')
 );
-knexInstance.withRecursive(
-  'readonly columnList+sql',
-  readonlyColumnList,
-  'just sql'
+knexInstance.with(
+  'readonlyColumnList+raw',
+  ['columnName'] as const,
+  knexInstance.raw('raw')
+);
+knexInstance.with(
+  'readonlyColumnList+sql+bindingsArr',
+  ['columnName'] as const,
+  'sql with positional bindings',
+  [1]
 );

--- a/test-tsd/types.test-d.ts
+++ b/test-tsd/types.test-d.ts
@@ -183,3 +183,21 @@ knexInstance.with(
   'sql with positional bindings',
   [1]
 );
+
+// the column list is only read, so readonly arrays and tuples are accepted too
+const readonlyColumnList = ['id', 'parent_id'] as const;
+knexInstance.withRecursive(
+  'readonly columnList+callback',
+  readonlyColumnList,
+  (qb) => qb.select('id').from('table')
+);
+knexInstance.withRecursive(
+  'readonly columnList+qb',
+  readonlyColumnList,
+  knexInstance.select('id').from('table')
+);
+knexInstance.withRecursive(
+  'readonly columnList+sql',
+  readonlyColumnList,
+  'just sql'
+);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1663,12 +1663,12 @@ declare namespace Knex {
     ): QueryBuilder<TRecord, TResult>;
     (
       alias: string,
-      columnList: string[],
+      columnList: readonly string[],
       raw: Raw | QueryBuilder
     ): QueryBuilder<TRecord, TResult>;
     (
       alias: string,
-      columnList: string[],
+      columnList: readonly string[],
       sql: string,
       bindings?: readonly Value[] | Record<string, Value>
     ): QueryBuilder<TRecord, TResult>;
@@ -1686,12 +1686,12 @@ declare namespace Knex {
     ): QueryBuilder<TRecord, TResult>;
     (
       alias: string,
-      columnList: string[],
+      columnList: readonly string[],
       queryBuilder: QueryBuilder
     ): QueryBuilder<TRecord, TResult>;
     (
       alias: string,
-      columnList: string[],
+      columnList: readonly string[],
       callback: (queryBuilder: QueryBuilder) => any
     ): QueryBuilder<TRecord, TResult>;
   }


### PR DESCRIPTION
The column list passed to `with`, `withRecursive` and friends was typed as `string[]`, so a `readonly` array or a tuple declared `as const` couldn't be passed without a cast or a copy. Nothing in the query compiler mutates that array, it only gets columnized, so the parameter is now `readonly string[]` on both `WithRaw` and `WithWrapped`.

Fixes #6528